### PR TITLE
V0.0.11

### DIFF
--- a/cmd/apps/kyber_dao/stake.go
+++ b/cmd/apps/kyber_dao/stake.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/spf13/cobra"
+	"github.com/tranvictor/jarvis/accounts"
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/util"
 )
@@ -18,9 +19,13 @@ var stakeCmd = &cobra.Command{
 	Short:            "Stake your KNC to Kyber DAO to vote and get rewards",
 	TraverseChildren: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-		config.From, _, err = util.GetAddressFromString(config.From)
+		// process from to get address
+		acc, err := accounts.GetAccount(config.From)
 		if err != nil {
 			return fmt.Errorf("Couldn't interpret addresss. Please double check your -f flag. %w\n", err)
+		} else {
+			config.FromAcc = acc
+			config.From = acc.Address
 		}
 
 		return Preprocess(cmd, args)

--- a/cmd/apps/kyber_dao/util.go
+++ b/cmd/apps/kyber_dao/util.go
@@ -108,7 +108,7 @@ func PrintStakeInformation(cmd *cobra.Command, info *StakeRelatedInfo) {
 		return
 	}
 
-	cmd.Printf("Staker: %s\n", util.VerboseAddress(info.Staker))
+	cmd.Printf("Staker: %s\n", util.VerboseAddress(info.Staker, config.Network))
 	stakef := ethutils.BigToFloat(info.Stake, 18)
 	cmd.Printf("Your stake: %f KNC (%s)\n", stakef, info.Stake)
 
@@ -121,7 +121,7 @@ func PrintStakeInformation(cmd *cobra.Command, info *StakeRelatedInfo) {
 	if strings.ToLower(info.Staker) == strings.ToLower(info.Representative) {
 		cmd.Printf("Your representative: None\n")
 	} else {
-		cmd.Printf("Your representative: %s (Contact him to get your reward if you have some)\n", util.VerboseAddress(info.Representative))
+		cmd.Printf("Your representative: %s (Contact him to get your reward if you have some)\n", util.VerboseAddress(info.Representative, config.Network))
 	}
 	cmd.Printf("Stake other people delegated to you: %f KNC\n", ethutils.BigToFloat(info.DelegatedStake, 18))
 }

--- a/cmd/apps/kyber_dao/vote.go
+++ b/cmd/apps/kyber_dao/vote.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
+	"github.com/tranvictor/jarvis/accounts"
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/util"
 )
@@ -15,9 +16,13 @@ var voteCmd = &cobra.Command{
 	Short:            "Vote on a KyberDAO voting campaign",
 	TraverseChildren: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-		config.From, _, err = util.GetAddressFromString(config.From)
+		// process from to get address
+		acc, err := accounts.GetAccount(config.From)
 		if err != nil {
 			return fmt.Errorf("Couldn't interpret addresss. Please double check your -f flag. %w\n", err)
+		} else {
+			config.FromAcc = acc
+			config.From = acc.Address
 		}
 
 		return Preprocess(cmd, args)

--- a/cmd/apps/kyber_dao/withdraw.go
+++ b/cmd/apps/kyber_dao/withdraw.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/spf13/cobra"
+	"github.com/tranvictor/jarvis/accounts"
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/util"
 )
@@ -14,9 +15,13 @@ var withdrawCmd = &cobra.Command{
 	Short:            "Withdraw your KNC from KyberDAO",
 	TraverseChildren: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-		config.From, _, err = util.GetAddressFromString(config.From)
+		// process from to get address
+		acc, err := accounts.GetAccount(config.From)
 		if err != nil {
 			return fmt.Errorf("Couldn't interpret addresss. Please double check your -f flag. %w\n", err)
+		} else {
+			config.FromAcc = acc
+			config.From = acc.Address
 		}
 
 		return Preprocess(cmd, args)

--- a/cmd/apps/kyber_fpr/fpr.go
+++ b/cmd/apps/kyber_fpr/fpr.go
@@ -52,7 +52,7 @@ var KyberFPRCmd = &cobra.Command{
 			}
 			fmt.Printf("\nListed tokens:\n")
 			for i, token := range tokens {
-				fmt.Printf("%d. %s\n", i, util.VerboseAddress(token.Hex()))
+				fmt.Printf("%d. %s\n", i, util.VerboseAddress(token.Hex(), config.Network))
 			}
 			fmt.Printf("\n")
 
@@ -61,7 +61,7 @@ var KyberFPRCmd = &cobra.Command{
 			Token = tokens[index].Hex()
 		}
 		fmt.Printf("\n")
-		fmt.Printf("Checking on token: %s\n", util.VerboseAddress(Token))
+		fmt.Printf("Checking on token: %s\n", util.VerboseAddress(Token, config.Network))
 		err = reserve.DisplayStepFunctionData(Token)
 		if err != nil {
 			fmt.Printf("Displaying step functions failed: %s\n", err)

--- a/cmd/pre_process.go
+++ b/cmd/pre_process.go
@@ -47,7 +47,7 @@ func CommonFunctionCallPreprocess(cmd *cobra.Command, args []string) (err error)
 		}
 	}
 
-	fmt.Printf("Interpreted to address: %s\n", util.VerboseAddress(config.To))
+	fmt.Printf("To address: %s\n", util.VerboseAddress(config.To, config.Network))
 	return nil
 }
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,13 +2,25 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 )
 
-func indent(nospace int, str string) string {
+func indent(nospace int, strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+
+	if len(strs) == 1 {
+		return strs[0]
+	}
+
 	indentation := ""
 	for i := 0; i < nospace; i++ {
 		indentation += " "
 	}
-	return strings.ReplaceAll(str, "\n", fmt.Sprintf("\n%s", indentation))
+	result := ""
+	for i, str := range strs {
+		result += fmt.Sprintf("\n%s%d. %s", indentation, i, str)
+	}
+	result += "\n"
+	return result
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	VERSION string = "0.0.10"
+	VERSION string = "0.0.11"
 )
 
 var versionCmd = &cobra.Command{

--- a/config/config.go
+++ b/config/config.go
@@ -31,4 +31,5 @@ var (
 
 	DontBroadcast     bool
 	DontWaitToBeMined bool
+	ForceERC20ABI     bool
 )

--- a/db/fuzzy_source.go
+++ b/db/fuzzy_source.go
@@ -3,11 +3,20 @@ package db
 import (
 	"fmt"
 	"strings"
+	"sync"
+)
+
+var (
+	onceSource      sync.Once
+	source          FuzzySource
+	onceTokenSource sync.Once
+	tokenSource     FuzzySource
 )
 
 type AddressDesc struct {
-	Address string
-	Desc    string
+	Address      string
+	Desc         string
+	SearchString string
 }
 
 type FuzzySource []AddressDesc
@@ -17,29 +26,35 @@ func (self FuzzySource) Len() int {
 }
 
 func (self FuzzySource) String(i int) string {
-	return fmt.Sprintf("%s_%s", strings.Replace(self[i].Desc, " ", "_", -1), self[i].Address)
+	return self[i].SearchString
 }
 
 func NewFuzzySource() FuzzySource {
-	addrs := AllAddresses()
-	result := FuzzySource{}
-	for addr, desc := range addrs {
-		result = append(result, AddressDesc{
-			Address: addr,
-			Desc:    desc,
-		})
-	}
-	return result
+	onceSource.Do(func() {
+		addrs := AllAddresses()
+		source = FuzzySource{}
+		for addr, desc := range addrs {
+			source = append(source, AddressDesc{
+				Address:      addr,
+				Desc:         desc,
+				SearchString: fmt.Sprintf("%s_%s", strings.Replace(desc, " ", "_", -1), addr),
+			})
+		}
+	})
+	return source
 }
 
 func NewTokenFuzzySource() FuzzySource {
-	addrs := AllTokenAddresses()
-	result := FuzzySource{}
-	for addr, desc := range addrs {
-		result = append(result, AddressDesc{
-			Address: addr,
-			Desc:    desc,
-		})
-	}
-	return result
+	onceTokenSource.Do(func() {
+		addrs := AllTokenAddresses()
+		tokenSource = FuzzySource{}
+		for addr, desc := range addrs {
+			tokenSource = append(tokenSource, AddressDesc{
+				Address:      addr,
+				Desc:         desc,
+				SearchString: fmt.Sprintf("%s_%s", strings.Replace(desc, " ", "_", -1), addr),
+			})
+		}
+	})
+	return tokenSource
 }

--- a/main.go
+++ b/main.go
@@ -20,8 +20,20 @@
 
 package main
 
-import "github.com/tranvictor/jarvis/cmd"
+import (
+	"github.com/tranvictor/jarvis/cmd"
+)
 
 func main() {
+	// f, err := os.Create("cpuprofile")
+	// if err != nil {
+	// 	log.Fatal("could not create CPU profile: ", err)
+	// }
+	// defer f.Close() // error handling omitted for example
+	// if err := pprof.StartCPUProfile(f); err != nil {
+	// 	log.Fatal("could not start CPU profile: ", err)
+	// }
+	// defer pprof.StopCPUProfile()
+
 	cmd.Execute()
 }

--- a/txanalyzer/result.go
+++ b/txanalyzer/result.go
@@ -1,24 +1,14 @@
 package txanalyzer
 
-import (
-	"fmt"
-	"io"
-)
-
-type AddressResult struct {
-	Address string
-	Name    string
-}
-
 type ParamResult struct {
 	Name  string
 	Type  string
-	Value string
+	Value []string
 }
 
 type TopicResult struct {
 	Name  string
-	Value string
+	Value []string
 }
 
 type LogResult struct {
@@ -28,7 +18,8 @@ type LogResult struct {
 }
 
 type GnosisResult struct {
-	Contract AddressResult
+	Contract string
+	Network  string
 	Method   string
 	Params   []ParamResult
 	Error    string
@@ -36,16 +27,17 @@ type GnosisResult struct {
 
 type TxResult struct {
 	Hash     string
+	Network  string
 	Status   string
-	From     AddressResult
+	From     string
 	Value    string
-	To       AddressResult
+	To       string
 	Nonce    string
 	GasPrice string
 	GasLimit string
 	TxType   string
 
-	Contract AddressResult
+	Contract string
 	Method   string
 	Params   []ParamResult
 	Logs     []LogResult
@@ -59,15 +51,16 @@ type TxResult struct {
 func NewTxResult() *TxResult {
 	return &TxResult{
 		Hash:       "",
+		Network:    "mainnet",
 		Status:     "",
-		From:       AddressResult{},
+		From:       "",
 		Value:      "",
-		To:         AddressResult{},
+		To:         "",
 		Nonce:      "",
 		GasPrice:   "",
 		GasLimit:   "",
 		TxType:     "",
-		Contract:   AddressResult{},
+		Contract:   "",
 		Method:     "",
 		Params:     []ParamResult{},
 		Logs:       []LogResult{},
@@ -75,63 +68,4 @@ func NewTxResult() *TxResult {
 		Completed:  false,
 		Error:      "",
 	}
-}
-
-func (self *TxResult) Print(writer io.Writer) {
-	fmt.Fprintf(writer, "Tx hash: %s\n", self.Hash)
-	fmt.Fprintf(writer, "Mining status: %s\n", self.Status)
-	fmt.Fprintf(writer, "From: %s - (%s)\n", self.From.Address, self.From.Name)
-	fmt.Fprintf(writer, "Value: %s ETH\n", self.Value)
-	fmt.Fprintf(writer, "To: %s - (%s)\n", self.To.Address, self.To.Name)
-	fmt.Fprintf(writer, "Nonce: %s\n", self.Nonce)
-	fmt.Fprintf(writer, "Gas price: %s gwei\n", self.GasPrice)
-	fmt.Fprintf(writer, "Gas limit: %s\n", self.GasLimit)
-
-	if self.TxType == "" {
-		fmt.Fprintf(writer, "Checking tx type failed: %s\n", self.Error)
-		return
-	}
-
-	fmt.Fprintf(writer, "Tx type: %s\n", self.TxType)
-	if self.TxType == "normal" {
-		return
-	}
-
-	if self.Method == "" {
-		fmt.Fprintf(writer, "Getting ABI and function name failed: %s\n", self.Error)
-		return
-	}
-	fmt.Fprintf(writer, "Contract: %s - (%s)\n", self.Contract.Address, self.Contract.Name)
-	fmt.Fprintf(writer, "Method: %s\n", self.Method)
-	fmt.Fprintf(writer, "Params:\n")
-	for _, param := range self.Params {
-		fmt.Fprintf(writer, "    %s (%s): %s\n", param.Name, param.Type, param.Value)
-	}
-	fmt.Fprintf(writer, "Event logs:\n")
-	for i, l := range self.Logs {
-		fmt.Fprintf(writer, "Log %d: %s\n", i+1, l.Name)
-		for j, topic := range l.Topics {
-			fmt.Fprintf(writer, "    Topic %d - %s: %s\n", j+1, topic.Name, topic.Value)
-		}
-		fmt.Fprintf(writer, "    Data:\n")
-		for _, param := range l.Data {
-			fmt.Fprintf(writer, "    %s (%s): %s\n", param.Name, param.Type, param.Value)
-		}
-	}
-	if self.GnosisInit != nil {
-		fmt.Fprintf(writer, "Gnosis multisig init data:\n")
-		if self.GnosisInit.Method == "" {
-			fmt.Fprintf(writer, "Getting ABI and function name failed: %s\n", self.Error)
-			return
-		}
-		fmt.Fprintf(writer, "Contract: %s - %s\n", self.GnosisInit.Contract.Address, self.GnosisInit.Contract.Name)
-		fmt.Fprintf(writer, "Method: %s\n", self.GnosisInit.Method)
-		fmt.Fprintf(writer, "Params:\n")
-		for _, param := range self.GnosisInit.Params {
-			fmt.Fprintf(writer, "    %s (%s): %s\n", param.Name, param.Type, param.Value)
-		}
-	}
-	// if self.Error != "" {
-	// 	fmt.Fprintf(writer, "Error during tx analysis: %s\n", self.Error)
-	// }
 }

--- a/util/analyzer.go
+++ b/util/analyzer.go
@@ -19,7 +19,7 @@ func AnalyzeMethodCallAndPrint(analyzer *txanalyzer.TxAnalyzer, abi *abi.ABI, da
 	fmt.Printf("  Method: %s\n", methodName)
 	fmt.Printf("  Params:\n")
 	for _, param := range params {
-		fmt.Printf("    %s (%s): %s\n", param.Name, param.Type, param.Value)
+		fmt.Printf("    %s (%s): %s\n", param.Name, param.Type, DisplayValues(param.Value, analyzer.Network))
 	}
 	if gnosisResult != nil {
 		PrintGnosis(gnosisResult)
@@ -45,16 +45,17 @@ func PrintGnosis(result *txanalyzer.GnosisResult) {
 
 func printGnosisToWriter(result *txanalyzer.GnosisResult, writer io.Writer) {
 	if result != nil {
-		fmt.Fprintf(writer, "Gnosis multisig init data:\n")
+		fmt.Fprintf(writer, "\n     __________________________")
+		fmt.Fprintf(writer, "\n     Gnosis multisig init data: ")
 		if result.Method == "" {
 			fmt.Fprintf(writer, "Couldn't decode gnosis call method\n")
 			return
 		}
-		fmt.Fprintf(writer, "Contract: %s - %s\n", result.Contract.Address, nameWithColor(result.Contract.Name))
-		fmt.Fprintf(writer, "Method: %s\n", result.Method)
-		fmt.Fprintf(writer, "Params:\n")
+		fmt.Fprintf(writer, "\n     Contract: %s\n", VerboseAddress(result.Contract, result.Network))
+		fmt.Fprintf(writer, "     Method: %s\n", result.Method)
+		fmt.Fprintf(writer, "     Params:\n")
 		for _, param := range result.Params {
-			fmt.Fprintf(writer, "    %s (%s): %s\n", param.Name, param.Type, param.Value)
+			fmt.Fprintf(writer, "       %s (%s): %s\n", param.Name, param.Type, DisplayValues(param.Value, result.Network))
 		}
 	}
 }
@@ -66,9 +67,9 @@ func printToStdout(result *txanalyzer.TxResult, writer io.Writer) {
 	} else {
 		fmt.Fprintf(writer, "Mining status: %s\n", Bold(Red(result.Status)))
 	}
-	fmt.Fprintf(writer, "From: %s - (%s)\n", result.From.Address, nameWithColor(result.From.Name))
+	fmt.Fprintf(writer, "From: %s\n", VerboseAddress(result.From, result.Network))
 	fmt.Fprintf(writer, "Value: %s ETH\n", result.Value)
-	fmt.Fprintf(writer, "To: %s - (%s)\n", result.To.Address, nameWithColor(result.To.Name))
+	fmt.Fprintf(writer, "To: %s\n", VerboseAddress(result.To, result.Network))
 	fmt.Fprintf(writer, "Nonce: %s\n", result.Nonce)
 	fmt.Fprintf(writer, "Gas price: %s gwei\n", result.GasPrice)
 	fmt.Fprintf(writer, "Gas limit: %s\n", result.GasLimit)
@@ -87,22 +88,22 @@ func printToStdout(result *txanalyzer.TxResult, writer io.Writer) {
 		fmt.Fprintf(writer, "Getting ABI and function name failed: %s\n", result.Error)
 		return
 	}
-	fmt.Fprintf(writer, "Contract: %s - (%s)\n", result.Contract.Address, nameWithColor(result.Contract.Name))
+	fmt.Fprintf(writer, "\nContract: %s\n", VerboseAddress(result.Contract, result.Network))
 	fmt.Fprintf(writer, "Method: %s\n", result.Method)
 	fmt.Fprintf(writer, "Params:\n")
 	for _, param := range result.Params {
-		fmt.Fprintf(writer, "    %s (%s): %s\n", param.Name, param.Type, param.Value)
+		fmt.Fprintf(writer, "    %s (%s): %s\n", param.Name, param.Type, DisplayValues(param.Value, result.Network))
 	}
-	fmt.Fprintf(writer, "Event logs:\n")
+	printGnosisToWriter(result.GnosisInit, writer)
+	fmt.Fprintf(writer, "\nEvent logs:\n")
 	for i, l := range result.Logs {
 		fmt.Fprintf(writer, "Log %d: %s\n", i+1, l.Name)
 		for j, topic := range l.Topics {
-			fmt.Fprintf(writer, "    Topic %d - %s: %s\n", j+1, topic.Name, topic.Value)
+			fmt.Fprintf(writer, "    Topic %d - %s: %s\n", j+1, topic.Name, DisplayValues(topic.Value, result.Network))
 		}
 		fmt.Fprintf(writer, "    Data:\n")
 		for _, param := range l.Data {
-			fmt.Fprintf(writer, "    %s (%s): %s\n", param.Name, param.Type, param.Value)
+			fmt.Fprintf(writer, "    %s (%s): %s\n", param.Name, param.Type, DisplayValues(param.Value, result.Network))
 		}
 	}
-	printGnosisToWriter(result.GnosisInit, writer)
 }

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -2,10 +2,12 @@ package cache
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -54,6 +56,42 @@ func loadSimpleCache() *simpleCache {
 		return cache
 	}
 	return cache
+}
+
+func GetBoolCache(key string) (bool, bool) {
+	value, found := GetCache(key)
+	if !found {
+		return false, false
+	}
+
+	result, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, false
+	}
+
+	return result, true
+}
+
+func SetBoolCache(key string, value bool) error {
+	return SetCache(key, fmt.Sprintf("%t", value))
+}
+
+func GetInt64Cache(key string) (int64, bool) {
+	value, found := GetCache(key)
+	if !found {
+		return 0, false
+	}
+
+	result, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return result, true
+}
+
+func SetInt64Cache(key string, value int64) error {
+	return SetCache(key, fmt.Sprintf("%d", value))
 }
 
 func GetCache(key string) (string, bool) {

--- a/util/convert_util.go
+++ b/util/convert_util.go
@@ -119,7 +119,8 @@ func ConvertParamStrToType(name string, t abi.Type, str string, network string) 
 	case abi.BoolTy:
 		return ConvertToBool(str)
 	case abi.AddressTy:
-		if strings.ToLower(name) == "token" || strings.ToLower(name) == "asset" {
+		lcName := strings.ToLower(name)
+		if lcName == "token" || lcName == "tokens" || lcName == "asset" {
 			return ConvertToAddress(fmt.Sprintf("%s token", str))
 		}
 		return ConvertToAddress(str)


### PR DESCRIPTION
# Added support for proxy contracts, improved kyber-dao, and improved display format
## Features
1. Automatically try erc20 abi if there is no compatible abi because of proxy patterns
2. Added --erc20-abi to force msig and contract subcommands to use erc20 abi instead of getting the abi from etherscan
3. Allowed msig to init sending eth to non-contract addresses

## Improvements
1. Display address names whenever possible, even in topics
2. Display long number with separators to easily count its digits (the group of 3 and 9 are supported)
3. Display decimal number along with erc20 token names when possible
4. Cache decimal and erc20 check to save blockchain interaction
5. Improved data display format to spot information more easily
6. Improved address lookup performance significantly

## Fixes
1. Fixed kyber-dao app to interpret address correctly