### PR TITLE
V0.0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ compile_for_windows.sh
 cpuprofile
 dist/
 jarvis
+output.json

--- a/cmd/apps/kyber_fpr/fpr.go
+++ b/cmd/apps/kyber_fpr/fpr.go
@@ -65,7 +65,27 @@ var KyberFPRCmd = &cobra.Command{
 		err = reserve.DisplayStepFunctionData(Token)
 		if err != nil {
 			fmt.Printf("Displaying step functions failed: %s\n", err)
+			return
 		}
+		isListed, isEnabled, err := reserve.GetBasicInfo(Token)
+		if err != nil {
+			fmt.Printf("Displaying token basic info failed: %s\n", err)
+			return
+		}
+		fmt.Printf("\n")
+		fmt.Printf(" Listed: %t\n", isListed)
+		fmt.Printf("Enabled: %t\n", isEnabled)
+
+		minimalRecordResolution, maxBlockImb, maxTotalImb, err := reserve.GetTokenControlInfo(Token)
+		if err != nil {
+			fmt.Printf("Displaying token control info failed: %s\n", err)
+			return
+		}
+
+		fmt.Printf("\n")
+		fmt.Printf("Min Resolution: %s\n", util.ReadableNumber(minimalRecordResolution.Text(10)))
+		fmt.Printf("Max Block Imp: %s\n", util.ReadableNumber(maxBlockImb.Text(10)))
+		fmt.Printf("Max Total Imp: %s\n", util.ReadableNumber(maxTotalImb.Text(10)))
 	},
 }
 

--- a/cmd/apps/kyber_fpr/fpr_reserve_contract.go
+++ b/cmd/apps/kyber_fpr/fpr_reserve_contract.go
@@ -87,6 +87,30 @@ func (self *FPRReserveContract) QueryQtyStepFunc(token common.Address) (numSellS
 	return numSellSteps, sellXs, sellYs, numBuySteps, buyXs, buyYs, nil
 }
 
+func (self *FPRReserveContract) GetTokenControlInfo(token string) (*big.Int, *big.Int, *big.Int, error) {
+	result := [3]*big.Int{nil, nil, nil}
+	err := self.reader.ReadHistoryContract(
+		config.AtBlock,
+		&result,
+		self.ConversionRateContract.Hex(),
+		"getTokenControlInfo",
+		ethutils.HexToAddress(token),
+	)
+	return result[0], result[1], result[2], err
+}
+
+func (self *FPRReserveContract) GetBasicInfo(token string) (bool, bool, error) {
+	result := [2]bool{false, false}
+	err := self.reader.ReadHistoryContract(
+		config.AtBlock,
+		&result,
+		self.ConversionRateContract.Hex(),
+		"getTokenBasicData",
+		ethutils.HexToAddress(token),
+	)
+	return result[0], result[1], err
+}
+
 func (self *FPRReserveContract) QueryImbalanceStepFunc(token common.Address) (numSellSteps int, sellXs []float64, sellYs []float64, numBuySteps int, buyXs []float64, buyYs []float64, err error) {
 	type imbFunc struct {
 		NumBuyRateImbalanceSteps  *big.Int

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	VERSION string = "0.0.13"
+	VERSION string = "0.0.14"
 )
 
 var versionCmd = &cobra.Command{

--- a/config/config.go
+++ b/config/config.go
@@ -32,4 +32,5 @@ var (
 	DontBroadcast     bool
 	DontWaitToBeMined bool
 	ForceERC20ABI     bool
+	JSONOutputFile    string
 )

--- a/util/util.go
+++ b/util/util.go
@@ -275,7 +275,7 @@ func IsERC20(addr string, network string) (bool, error) {
 	return isERC20, nil
 }
 
-func readableNumber(value string) string {
+func ReadableNumber(value string) string {
 	digits := []string{}
 	for i, _ := range value {
 		digits = append([]string{string(value[len(value)-1-i])}, digits...)
@@ -317,7 +317,7 @@ func verboseValue(value string, network string) string {
 			return value
 		}
 		// otherwise, it is a number then return it in a readable format
-		return readableNumber(value)
+		return ReadableNumber(value)
 	}
 	return VerboseAddress(common.BigToAddress(valueBig).Hex(), network)
 }


### PR DESCRIPTION
- Add `contract write` as the alias for `contract tx`
- Add json output file option for `contract read`, the output file is in json with the following schema:
```
{
  "result": [return_value_1, return_value2,...],
  "error": "string that describes the error"
}
```
where `return_value_x` is with the following schema:
```
{
  "name": "name of the return variable, will be empty if the variable has no name",
  "values": ["value 1", "value 2", ...],
  "human_values": ["value 1 in human readable format", "value 2 in human readable format", ...]
}
```