### PR TITLE
Fix contract read hanging on Safe proxy method selection

### DIFF
--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -280,6 +280,9 @@ func PromptMethod(u ui.UI, a *abi.ABI, methodIndex uint64, mode string) (*abi.Me
 		}
 	}
 	sort.Sort(orderedMethods(methods))
+	if len(methods) == 0 {
+		return nil, "", fmt.Errorf("the contract has no %s methods", mode)
+	}
 	if methodIndex == 0 {
 		u.Info("%s functions:", mode)
 		for i, m := range methods {

--- a/cmd/util/prompt_util_test.go
+++ b/cmd/util/prompt_util_test.go
@@ -1,0 +1,81 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+
+	"github.com/tranvictor/jarvis/ui"
+)
+
+// SafeProxy verified ABI: constructor + fallback only. This is what
+// `jarvis contract read` used to turn into "Please choose method index [1, 0]".
+const safeProxyABIJSON = `[{"inputs":[{"internalType":"address","name":"_singleton","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"stateMutability":"payable","type":"fallback"}]`
+
+const mixedABIJSON = `[
+	{"inputs":[],"name":"getOwners","outputs":[{"internalType":"address[]","name":"","type":"address[]"}],"stateMutability":"view","type":"function"},
+	{"inputs":[],"name":"VERSION","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"pure","type":"function"},
+	{"inputs":[{"internalType":"address","name":"owner","type":"address"}],"name":"addOwner","outputs":[],"stateMutability":"nonpayable","type":"function"}
+]`
+
+func mustABI(t *testing.T, jsonStr string) *abi.ABI {
+	t.Helper()
+	parsed, err := abi.JSON(strings.NewReader(jsonStr))
+	if err != nil {
+		t.Fatalf("parse ABI: %v", err)
+	}
+	return &parsed
+}
+
+func TestPromptMethodEmptyReadMethods(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	_, _, err := PromptMethod(rec, mustABI(t, safeProxyABIJSON), 0, "read")
+	if err == nil {
+		t.Fatal("expected error for a methodless proxy ABI, got nil")
+	}
+	if !strings.Contains(err.Error(), "no read methods") {
+		t.Fatalf("error %q should mention that there are no read methods", err)
+	}
+	if rec.HasMessage("Please choose method index") {
+		t.Fatal("must not prompt for a method index when the list is empty")
+	}
+}
+
+func TestPromptMethodEmptyWriteMethods(t *testing.T) {
+	const viewOnly = `[{"inputs":[],"name":"name","outputs":[{"type":"string","name":""}],"stateMutability":"view","type":"function"}]`
+	rec := ui.NewRecordingUI()
+	_, _, err := PromptMethod(rec, mustABI(t, viewOnly), 0, "write")
+	if err == nil {
+		t.Fatal("expected error when the ABI has no write methods")
+	}
+	if !strings.Contains(err.Error(), "no write methods") {
+		t.Fatalf("error %q should mention that there are no write methods", err)
+	}
+}
+
+func TestPromptMethodSelectsReadByIndex(t *testing.T) {
+	rec := ui.NewRecordingUI("1")
+	method, name, err := PromptMethod(rec, mustABI(t, mixedABIJSON), 0, "read")
+	if err != nil {
+		t.Fatalf("PromptMethod: %v", err)
+	}
+	// Read methods are sorted by name: VERSION, getOwners
+	if name != "VERSION" || method == nil || method.Name != "VERSION" {
+		t.Fatalf("got method %q, want VERSION", name)
+	}
+	if !rec.HasMessage("Please choose method index [1, 2]") {
+		t.Fatalf("prompt should show a valid [1, 2] range, entries=%v", rec.InfoMessages())
+	}
+}
+
+func TestPromptMethodPrefillIndex(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	method, name, err := PromptMethod(rec, mustABI(t, mixedABIJSON), 2, "read")
+	if err != nil {
+		t.Fatalf("PromptMethod: %v", err)
+	}
+	if name != "getOwners" || method.Name != "getOwners" {
+		t.Fatalf("got method %q, want getOwners", name)
+	}
+}

--- a/util/proxy_abi_test.go
+++ b/util/proxy_abi_test.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+const safeProxyABIJSON = `[{"inputs":[{"internalType":"address","name":"_singleton","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"stateMutability":"payable","type":"fallback"}]`
+
+const uupsProxyABIJSON = `[
+	{"inputs":[],"name":"implementation","outputs":[{"type":"address","name":""}],"stateMutability":"view","type":"function"},
+	{"inputs":[{"name":"newImplementation","type":"address"}],"name":"upgradeTo","outputs":[],"stateMutability":"nonpayable","type":"function"},
+	{"inputs":[{"name":"newImplementation","type":"address"},{"name":"data","type":"bytes"}],"name":"upgradeToAndCall","outputs":[],"stateMutability":"payable","type":"function"}
+]`
+
+func mustParseABI(t *testing.T, jsonStr string) *abi.ABI {
+	t.Helper()
+	parsed, err := abi.JSON(strings.NewReader(jsonStr))
+	if err != nil {
+		t.Fatalf("parse ABI: %v", err)
+	}
+	return &parsed
+}
+
+func TestIsMethodlessABISafeProxy(t *testing.T) {
+	a := mustParseABI(t, safeProxyABIJSON)
+	if !isMethodlessABI(a) {
+		t.Fatal("SafeProxy ABI (constructor + fallback) must be treated as methodless")
+	}
+	if IsProxyABI(a) {
+		t.Fatal("SafeProxy ABI does not expose upgradeTo/implementation and is not a classic proxy ABI")
+	}
+}
+
+func TestIsMethodlessABINil(t *testing.T) {
+	if !isMethodlessABI(nil) {
+		t.Fatal("nil ABI should be methodless")
+	}
+}
+
+func TestIsProxyABIUpgradeable(t *testing.T) {
+	a := mustParseABI(t, uupsProxyABIJSON)
+	if isMethodlessABI(a) {
+		t.Fatal("UUPS proxy ABI has methods")
+	}
+	if !IsProxyABI(a) {
+		t.Fatal("UUPS proxy ABI should match IsProxyABI")
+	}
+}
+
+func TestFollowProxyImplementationSkipsNormalABI(t *testing.T) {
+	erc20 := mustParseABI(t, `[
+		{"inputs":[],"name":"name","outputs":[{"type":"string","name":""}],"stateMutability":"view","type":"function"},
+		{"inputs":[{"name":"to","type":"address"},{"name":"value","type":"uint256"}],"name":"transfer","outputs":[{"type":"bool","name":""}],"stateMutability":"nonpayable","type":"function"}
+	]`)
+	impl, followed, err := followProxyImplementation("0x41675c099f32341bf84bfc5382af534df5c7461a", erc20, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if followed || impl != nil {
+		t.Fatal("non-proxy ABIs must not trigger implementation lookup")
+	}
+}

--- a/util/reader/reader.go
+++ b/util/reader/reader.go
@@ -512,6 +512,17 @@ func (er *EthReader) ImplementationOf(atBlock int64, caddr string) (common.Addre
 		return common.Address{}, err
 	}
 
+	addr = common.BytesToAddress(addrByte)
+	if addr.Big().Cmp(big.NewInt(0)) != 0 {
+		return addr, nil
+	}
+
+	// Gnosis Safe / SafeProxy stores the singleton at slot 0 so
+	// DELEGATECALL targets stay aligned with the implementation layout.
+	addrByte, err = er.StorageAt(atBlock, caddr, common.BigToHash(big.NewInt(0)).Hex())
+	if err != nil {
+		return common.Address{}, err
+	}
 	return common.BytesToAddress(addrByte), nil
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -756,25 +756,97 @@ func ConfigToABI(
 		return a, err
 	}
 
-	if IsProxyABI(a) {
-		r, err := EthReader(network)
-		if err != nil {
-			return nil, err
-		}
+	implABI, followed, err := followProxyImplementation(address, a, network)
+	if followed {
+		return implABI, err
+	}
+	return a, nil
+}
 
-		impl, err := r.ImplementationOf(-1, address)
-		if err != nil {
-			fmt.Printf("getting implementation of %s failed: %s\n", address, err)
-			return nil, err
-		}
-		a, err := GetABI(impl.Hex(), network)
-		if err != nil {
-			fmt.Printf("getting abi for implementation %s of %s failed: %s\n", impl.Hex(), address, err)
-		}
-		return a, err
+// isMethodlessABI reports whether a has no callable functions. Gnosis Safe
+// proxies (and many other minimal proxies) verify on explorers as just a
+// constructor + fallback, so their parsed ABI has an empty Methods map.
+func isMethodlessABI(a *abi.ABI) bool {
+	return a == nil || len(a.Methods) == 0
+}
+
+// explorerImplementation returns the implementation address reported by the
+// block explorer when it flags the contract as a proxy. Empty string means
+// the explorer did not provide a usable address.
+func explorerImplementation(r *reader.EthReader, address string) string {
+	info, err := r.GetContractInfo(address)
+	if err != nil || !info.IsProxy {
+		return ""
+	}
+	impl := strings.TrimSpace(info.Implementation)
+	if impl == "" {
+		return ""
+	}
+	if !strings.HasPrefix(impl, "0x") && !strings.HasPrefix(impl, "0X") {
+		impl = "0x" + impl
+	}
+	if !common.IsHexAddress(impl) || common.HexToAddress(impl) == (common.Address{}) {
+		return ""
+	}
+	return impl
+}
+
+// followProxyImplementation resolves the underlying implementation ABI for
+// proxy contracts. It follows explorer-reported implementations first (this
+// is what Etherscan already knows for SafeProxy / EIP-1967), then on-chain
+// storage slots (EIP-1967, ZeppelinOS, Polygon, Safe slot 0).
+//
+// followed is true only when an implementation ABI was obtained or a
+// classic upgradeable-proxy lookup failed hard (preserving historical
+// ConfigToABI error behavior). Methodless ABIs that cannot be resolved
+// return followed=false so the caller keeps the original ABI.
+func followProxyImplementation(
+	address string,
+	a *abi.ABI,
+	network networks.Network,
+) (*abi.ABI, bool, error) {
+	classicProxy := IsProxyABI(a)
+	methodless := isMethodlessABI(a)
+	if !classicProxy && !methodless {
+		return nil, false, nil
 	}
 
-	return a, nil
+	r, err := EthReader(network)
+	if err != nil {
+		if classicProxy {
+			return nil, true, err
+		}
+		return nil, false, nil
+	}
+
+	if impl := explorerImplementation(r, address); impl != "" {
+		implABI, err := GetABI(impl, network)
+		if err == nil && !isMethodlessABI(implABI) {
+			return implABI, true, nil
+		}
+	}
+
+	impl, err := r.ImplementationOf(-1, address)
+	if err != nil {
+		if classicProxy {
+			fmt.Printf("getting implementation of %s failed: %s\n", address, err)
+			return nil, true, err
+		}
+		return nil, false, nil
+	}
+	if impl == (common.Address{}) {
+		return nil, false, nil
+	}
+
+	implABI, err := GetABI(impl.Hex(), network)
+	if err != nil || isMethodlessABI(implABI) {
+		if classicProxy {
+			fmt.Printf("getting abi for implementation %s of %s failed: %s\n", impl.Hex(), address, err)
+			return implABI, true, err
+		}
+		return nil, false, nil
+	}
+	return implABI, true, nil
 }
 
 func GetGnosisMsigDeployByteCode(ctorBytes []byte) ([]byte, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`jarvis contract read 0xa230dFDE6FADf03FefF9Cc95B73CdebA5EeC8375` (a freshly deployed Safe 1.4.1 proxy) printed:

```
read functions:
Please choose method index [1, 0]
> 0
please enter a number between 1 and 0
> 1
please enter a number between 1 and 0
```

The explorer ABI for `SafeProxy` is constructor + fallback only, so `PromptMethod` built an empty list and asked for an index in the impossible range `[1, 0]`.

## Fix

1. **Follow proxy implementations in `ConfigToABI`.** Methodless ABIs (SafeProxy and other minimal proxies) now resolve via:
   - explorer `Proxy`/`Implementation` metadata (Etherscan already reports this Safe as a proxy of `0x41675c099f32341bf84bfc5382af534df5c7461a`)
   - on-chain slots, including Safe's singleton at slot 0
2. **`PromptMethod` errors** when there are no matching methods instead of looping forever on `[1, 0]`.
3. **`ImplementationOf`** also checks storage slot 0 after EIP-1967 / Zeppelin / Polygon slots miss.

Classic UUPS/transparent proxy detection (`implementation` + `upgradeTo` + `upgradeToAndCall`) is unchanged.

## Tests

- `PromptMethod` empty read/write lists no longer prompt
- `PromptMethod` 1-based selection still works
- SafeProxy ABI is treated as methodless and not as a classic upgradeable proxy ABI

## Live verification

Against `0xa230dFDE6FADf03FefF9Cc95B73CdebA5EeC8375` on mainnet after the fix:

- Prompt is now `[1, 16]` with Safe view methods (`VERSION`, `getOwners`, `nonce`, …)
- `0` is rejected (`between 1 and 16`); `1` reads `VERSION` → `1.4.1`
- `9` reads `getOwners` (5 owners)

<pre>
Please choose method index [1, 16]
Method: VERSION
(string) 1.4.1
</pre>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04e70-44cc-7292-bbdb-7b9647377970?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04e70-44cc-7292-bbdb-7b9647377970&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

