### PR TITLE
Fix brew upgrade staying on 0.1.0 after a GitHub release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,6 +58,10 @@ brews:
         url "https://github.com/tranvictor/jarvis.git"
         depends_on "go"
       end
+    caveats: |
+      After a new GitHub release, refresh the tap before upgrading:
+        brew update
+        brew upgrade tranvictor/jarvis/jarvis
     install: |
       system "make", "jarvis" if build.head?
       bin.install "bin/jarvis"

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Both Ethereum and BSC :)
 brew install tranvictor/jarvis/jarvis
 ```
 
-or to upgrade jarvis to the latest version
+To upgrade to the latest version, refresh the tap first. `brew upgrade jarvis` alone uses the locally cached formula, so after a new GitHub release it can report:
+
+`Warning: tranvictor/jarvis/jarvis 0.1.0 already installed`
 
 ```bash
-brew upgrade jarvis
+brew update
+brew upgrade tranvictor/jarvis/jarvis
 ```
 
 ## Build from source


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
v0.2.0 is already on GitHub and the Homebrew tap formula is already `version "0.2.0"` (`tranvictor/homebrew-tranvictor` commit `689a35a`). `brew upgrade jarvis` still reports 0.1.0 because Homebrew does not refresh third-party taps unless the formula is given with its tap prefix, or `brew update` runs first.

That matches [Homebrew#21885](https://github.com/Homebrew/brew/issues/21885): `brew upgrade jarvis` uses the cached tap formula, while `brew upgrade tranvictor/jarvis/jarvis` auto-updates the tap.

Users can upgrade to 0.2.0 today with:

```bash
brew update
brew upgrade tranvictor/jarvis/jarvis
```

This PR updates the README (which previously documented the command that misses the new version) and adds the same hint as `brew` caveats on the next GoReleaser-generated formula.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04e89-6fc1-7040-b27e-44863e7d5d58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04e89-6fc1-7040-b27e-44863e7d5d58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

