### PR TITLE
Let jarvis msig new deploy a Gnosis Safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,38 @@ of multisig you're talking to.
 | `jarvis msig gov`      | yes | yes | Show owners / threshold / version / nonce. |
 | `jarvis msig bapprove` | yes | yes | Batch-approve many pending txs in one shot. Safe refs may be Safe-app URLs, `multisig_<safe>_<hash>` tokens, or `<chain>:<safe>:<hash>` triples. |
 | `jarvis msig revoke`   | yes | **no** | Classic-only; errors with a clear message on Safe addresses. |
-| `jarvis msig new`      | yes | **no** | Classic-only (deploys a new Classic wallet). |
+| `jarvis msig new`      | yes | yes | Deploy a new wallet. `--type safe` uses SafeProxyFactory (CREATE2); `--type classic` deploys the original MultiSigWallet. Omitted `--type` prompts, or stays Classic when `--prefills` is set. |
 
 `jarvis send --from <multisig>` also auto-detects and routes through
 `msig init` automatically for both flavors, so you rarely need to reach
 for `init` directly.
+
+### Deploying a new Safe (`jarvis msig new`)
+
+```bash
+# Prompt for Safe vs Classic, then owners / threshold / salt
+jarvis msig new --from 0xALICE --network eth
+
+# Deploy a Safe without the flavor prompt
+jarvis msig new --from 0xALICE --type safe --network eth
+
+# Non-interactive: owners | threshold | salt nonce
+jarvis msig new --from 0xALICE --type safe -I "0xA,0xB,0xC|2|0" -y --network eth
+
+# Custom factory / singleton on a chain without the canonical set
+jarvis msig new --from 0xALICE --type safe \
+    --factory 0xFACTORY --singleton 0xSAFE --fallback-handler 0xHANDLER
+```
+
+Jarvis probes the canonical Safe 1.4.1 deployments first, then 1.3.0
+(canonical and eip155). L2 chains get SafeL2 so indexers see the extra
+events; Ethereum mainnet and its L1 testnets get the L1 Safe singleton.
+The predicted CREATE2 address is shown before you sign. After the
+deploy confirms:
+
+```bash
+jarvis msig gov 0xNEWSAFE --network eth
+```
 
 ### Identifying a pending Safe transaction
 

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -912,78 +912,142 @@ with --json-output, the same data is also written as JSON.`,
 }
 
 var newMsigCmd = &cobra.Command{
-	Use:              "new",
-	Short:            "deploy a new gnosis classic multisig",
-	Long:             ` `,
+	Use:   "new",
+	Short: "Deploy a new Gnosis Safe or Gnosis Classic multisig",
+	Long: `Deploys a brand-new multisig wallet from --from.
+
+Pass --type safe or --type classic to skip the flavor prompt. Safe is
+the modern Gnosis wallet (proxy via SafeProxyFactory, CREATE2 address).
+Classic is the original on-chain MultiSigWallet.
+
+When --type is omitted:
+  - interactive runs prompt for Safe vs Classic
+  - --prefills / -I runs stay Classic, so existing scripts keep working
+
+Safe deploy prompts for owners, threshold and a CREATE2 salt nonce.
+Factory / singleton / fallback-handler are probed on-chain from the
+canonical Safe deployments (1.4.1, then 1.3.0). Override them with
+--factory, --singleton and --fallback-handler on chains that use a
+custom set.`,
 	TraverseChildren: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return cmdutil.CommonTxPreprocess(appUI, cmd, args)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		tc, _ := cmdutil.TxContextFrom(cmd)
-
-		reader := tc.Reader
-		if reader == nil {
-			appUI.Error("Couldn't connect to blockchain.")
-			return
-		}
-
-		msigABI := util.GetGnosisMsigABI()
-
-		cAddr := crypto.CreateAddress(jarviscommon.HexToAddress(tc.From), tc.Nonce).Hex()
-
-		data, err := cmdutil.PromptTxData(
-			appUI,
-			tc.Analyzer,
-			cAddr,
-			cmdutil.CONSTRUCTOR_METHOD_INDEX,
-			tc.PrefillParams,
-			tc.PrefillMode,
-			msigABI,
-			nil,
-			config.Network(),
-		)
+		typ, err := resolveNewMsigType()
 		if err != nil {
-			appUI.Error("Couldn't pack constructor data: %s", err)
+			appUI.Error("%s", err)
 			return
 		}
-
-		bytecode, err := util.GetGnosisMsigDeployByteCode(data)
-		if err != nil {
-			appUI.Error("Couldn't pack deployment data: %s", err)
+		if typ == cmdutil.MultisigSafe {
+			runNewSafe(cmd, args)
 			return
 		}
-
-		customABIs := map[string]*abi.ABI{
-			strings.ToLower(cAddr): msigABI,
-		}
-
-		gasLimit := config.GasLimit
-		if gasLimit == 0 {
-			gasLimit, err = reader.EstimateExactGas(tc.From, "", 0, tc.Value, bytecode)
-			if err != nil {
-				appUI.Error("Couldn't estimate gas limit: %s", err)
-				return
-			}
-		}
-		tx := jarviscommon.BuildContractCreationTx(
-			tc.TxType,
-			tc.Nonce,
-			tc.Value,
-			gasLimit+config.ExtraGasLimit,
-			tc.GasPrice+config.ExtraGasPrice,
-			tc.TipGas+config.ExtraTipGas,
-			bytecode,
-			config.Network().GetChainID(),
-		)
-
-		if broadcasted, err := cmdutil.SignAndBroadcast(
-			appUI, tc.FromAcc, tx, customABIs,
-			reader, tc.Analyzer, nil, tc.Broadcaster,
-		); err != nil && !broadcasted {
-			appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
-		}
+		runNewClassic(cmd, args)
 	},
+}
+
+func resolveNewMsigType() (cmdutil.MultisigType, error) {
+	typ, err := parseNewMsigType(msigNewType)
+	if err != nil {
+		return cmdutil.MultisigUnknown, err
+	}
+	if typ != cmdutil.MultisigUnknown {
+		return typ, nil
+	}
+	if config.PrefillStr != "" {
+		return cmdutil.MultisigClassic, nil
+	}
+	appUI.Info("Which multisig to deploy?")
+	appUI.Info("1. Gnosis Safe (recommended)")
+	appUI.Info("2. Gnosis Classic")
+	switch cmdutil.PromptIndex(appUI, "Please choose [1, 2]", 1, 2) {
+	case 1:
+		return cmdutil.MultisigSafe, nil
+	case 2:
+		return cmdutil.MultisigClassic, nil
+	default:
+		return cmdutil.MultisigUnknown, fmt.Errorf("no multisig type selected")
+	}
+}
+
+func parseNewMsigType(raw string) (cmdutil.MultisigType, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "safe", "gnosis-safe", "gnosissafe":
+		return cmdutil.MultisigSafe, nil
+	case "classic", "gnosis", "gnosis-classic", "msig":
+		return cmdutil.MultisigClassic, nil
+	case "":
+		return cmdutil.MultisigUnknown, nil
+	default:
+		return cmdutil.MultisigUnknown, fmt.Errorf("--type must be 'safe' or 'classic', got %q", raw)
+	}
+}
+
+func runNewClassic(cmd *cobra.Command, args []string) {
+	tc, _ := cmdutil.TxContextFrom(cmd)
+
+	reader := tc.Reader
+	if reader == nil {
+		appUI.Error("Couldn't connect to blockchain.")
+		return
+	}
+
+	msigABI := util.GetGnosisMsigABI()
+
+	cAddr := crypto.CreateAddress(jarviscommon.HexToAddress(tc.From), tc.Nonce).Hex()
+
+	data, err := cmdutil.PromptTxData(
+		appUI,
+		tc.Analyzer,
+		cAddr,
+		cmdutil.CONSTRUCTOR_METHOD_INDEX,
+		tc.PrefillParams,
+		tc.PrefillMode,
+		msigABI,
+		nil,
+		config.Network(),
+	)
+	if err != nil {
+		appUI.Error("Couldn't pack constructor data: %s", err)
+		return
+	}
+
+	bytecode, err := util.GetGnosisMsigDeployByteCode(data)
+	if err != nil {
+		appUI.Error("Couldn't pack deployment data: %s", err)
+		return
+	}
+
+	customABIs := map[string]*abi.ABI{
+		strings.ToLower(cAddr): msigABI,
+	}
+
+	gasLimit := config.GasLimit
+	if gasLimit == 0 {
+		gasLimit, err = reader.EstimateExactGas(tc.From, "", 0, tc.Value, bytecode)
+		if err != nil {
+			appUI.Error("Couldn't estimate gas limit: %s", err)
+			return
+		}
+	}
+	tx := jarviscommon.BuildContractCreationTx(
+		tc.TxType,
+		tc.Nonce,
+		tc.Value,
+		gasLimit+config.ExtraGasLimit,
+		tc.GasPrice+config.ExtraGasPrice,
+		tc.TipGas+config.ExtraTipGas,
+		bytecode,
+		config.Network().GetChainID(),
+	)
+
+	if broadcasted, err := cmdutil.SignAndBroadcast(
+		appUI, tc.FromAcc, tx, customABIs,
+		reader, tc.Analyzer, nil, tc.Broadcaster,
+	); err != nil && !broadcasted {
+		appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
+	}
 }
 
 var initMsigCmd = &cobra.Command{
@@ -1191,7 +1255,11 @@ func init() {
 	}
 
 	AddCommonFlagsToTransactionalCmds(newMsigCmd)
-	newMsigCmd.PersistentFlags().StringVarP(&config.PrefillStr, "prefills", "I", "", "Prefill params string. Each param is separated by | char. If the param is \"?\", user input will be prompted.")
+	newMsigCmd.PersistentFlags().StringVarP(&config.PrefillStr, "prefills", "I", "", "Prefill params string. Each param is separated by | char. If the param is \"?\", user input will be prompted. Safe: owners|threshold|saltNonce. Classic: owners|required|dailyLimit.")
+	newMsigCmd.Flags().StringVar(&msigNewType, "type", "", "Multisig flavor to deploy: safe or classic. Omitted: prompt (or classic when --prefills is set).")
+	newMsigCmd.Flags().StringVar(&msigNewFactory, "factory", "", "Safe-only: SafeProxyFactory address. Default: probe canonical 1.4.1 / 1.3.0 deployments on this chain.")
+	newMsigCmd.Flags().StringVar(&msigNewSingleton, "singleton", "", "Safe-only: Safe / SafeL2 singleton address. Default: probe canonical deployments (SafeL2 on L2s).")
+	newMsigCmd.Flags().StringVar(&msigNewFallbackHandler, "fallback-handler", "", "Safe-only: CompatibilityFallbackHandler address. Default: probe canonical deployments.")
 	newMsigCmd.MarkFlagRequired("from")
 
 	batchApproveMsigCmd.PersistentFlags().StringVarP(&config.PrefillStr, "prefills", "I", "", "Prefill params string. Each param is separated by | char. If the param is \"?\", user input will be prompted.")

--- a/cmd/msig_new_test.go
+++ b/cmd/msig_new_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"math/big"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	cmdutil "github.com/tranvictor/jarvis/cmd/util"
+)
+
+func TestParseNewMsigType(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    cmdutil.MultisigType
+		wantErr bool
+	}{
+		{"safe", cmdutil.MultisigSafe, false},
+		{" SAFE ", cmdutil.MultisigSafe, false},
+		{"gnosis-safe", cmdutil.MultisigSafe, false},
+		{"classic", cmdutil.MultisigClassic, false},
+		{"gnosis-classic", cmdutil.MultisigClassic, false},
+		{"", cmdutil.MultisigUnknown, false},
+		{"ledger", cmdutil.MultisigUnknown, true},
+	}
+	for _, tc := range cases {
+		got, err := parseNewMsigType(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%q: expected error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%q: %s", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%q: got %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseSafeDeployParams(t *testing.T) {
+	a := ethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
+	b := ethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+	owners, threshold, salt, err := parseSafeDeployParams([]any{
+		[]ethcommon.Address{a, b},
+		big.NewInt(2),
+		uint64(9),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owners) != 2 || owners[0] != a || owners[1] != b {
+		t.Errorf("owners = %v", owners)
+	}
+	if threshold.Cmp(big.NewInt(2)) != 0 {
+		t.Errorf("threshold = %s", threshold)
+	}
+	if salt.Cmp(big.NewInt(9)) != 0 {
+		t.Errorf("salt = %s", salt)
+	}
+
+	if _, _, _, err := parseSafeDeployParams([]any{a}); err == nil {
+		t.Error("expected error for wrong arity")
+	}
+	if _, _, _, err := parseSafeDeployParams([]any{"nope", big.NewInt(1), big.NewInt(0)}); err == nil {
+		t.Error("expected error for bad owners")
+	}
+}

--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -69,6 +69,18 @@ var txBuilderJSON string
 // jarvis probes the canonical MultiSendCallOnly deployments on-chain.
 var multiSendAddressOverride string
 
+// msigNewType is --type on `jarvis msig new`: "safe", "classic", or empty
+// (prompt interactively; prefill mode defaults to classic for compatibility).
+var msigNewType string
+
+// Safe-deploy contract overrides for `jarvis msig new --type safe`. Empty
+// means "probe the canonical Safe deployments on this chain".
+var (
+	msigNewFactory         string
+	msigNewSingleton       string
+	msigNewFallbackHandler string
+)
+
 // txBuilderBatch holds the parsed batch from --tx-builder-file or
 // --tx-builder-json. It is populated by
 // initMsigCmd's PersistentPreRunE (which has to parse the file before the
@@ -1119,6 +1131,209 @@ var govSafeCmd = &cobra.Command{
 		appUI.Section("Safe governance")
 		showSafeInfo(tc.Safe)
 	},
+}
+
+// safeDeployPromptABI is the interactive shape of `jarvis msig new --type safe`.
+// Factory / singleton / fallback-handler are resolved on-chain (or via
+// overrides); the operator only supplies owners, threshold and CREATE2 salt.
+const safeDeployPromptABI = `[
+  {
+    "name": "create",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {"name": "_owners", "type": "address[]"},
+      {"name": "_threshold", "type": "uint256"},
+      {"name": "_saltNonce", "type": "uint256"}
+    ]
+  }
+]`
+
+// runNewSafe is the Safe path of `jarvis msig new`. It prompts for owners /
+// threshold / salt, deploys a proxy via SafeProxyFactory.createProxyWithNonce,
+// and prints the predicted CREATE2 address before the user signs.
+func runNewSafe(cmd *cobra.Command, args []string) {
+	tc, _ := cmdutil.TxContextFrom(cmd)
+	if tc.Reader == nil {
+		appUI.Error("Couldn't connect to blockchain.")
+		return
+	}
+
+	dep, err := safe.ResolveSafeDeployment(config.Network(), safe.DeployOverrides{
+		Factory:         msigNewFactory,
+		Singleton:       msigNewSingleton,
+		FallbackHandler: msigNewFallbackHandler,
+	})
+	if err != nil {
+		appUI.Error("%s", err)
+		return
+	}
+
+	promptABI, err := abi.JSON(strings.NewReader(safeDeployPromptABI))
+	if err != nil {
+		appUI.Error("Couldn't parse Safe deploy prompt ABI: %s", err)
+		return
+	}
+
+	appUI.Section("New Gnosis Safe")
+	appUI.Info("Factory          : %s (%s)", dep.Factory.Hex(), dep.FactoryLabel)
+	appUI.Info("Singleton        : %s (%s)", dep.Singleton.Hex(), dep.SingletonLabel)
+	appUI.Info("Fallback handler : %s (%s)", dep.FallbackHandler.Hex(), dep.FallbackLabel)
+	appUI.Info("Salt nonce is any unused uint; the same owners + threshold + salt")
+	appUI.Info("always produce the same Safe address (CREATE2). Use 0 unless you")
+	appUI.Info("need a specific address or are retrying after a collision.")
+
+	method, params, err := cmdutil.PromptFunctionCallData(
+		appUI,
+		tc.Analyzer,
+		dep.Factory.Hex(),
+		1,
+		tc.PrefillParams,
+		tc.PrefillMode,
+		"write",
+		&promptABI,
+		nil,
+		config.Network(),
+	)
+	if err != nil {
+		appUI.Error("Couldn't read Safe deploy params: %s", err)
+		return
+	}
+	_ = method
+
+	owners, threshold, saltNonce, err := parseSafeDeployParams(params)
+	if err != nil {
+		appUI.Error("%s", err)
+		return
+	}
+	if err := safe.ValidateNewSafeParams(owners, threshold); err != nil {
+		appUI.Error("%s", err)
+		return
+	}
+
+	initializer, err := safe.EncodeSetup(owners, threshold, dep.FallbackHandler)
+	if err != nil {
+		appUI.Error("Couldn't pack Safe.setup: %s", err)
+		return
+	}
+	txData, err := safe.EncodeCreateProxyWithNonce(dep.Singleton, initializer, saltNonce)
+	if err != nil {
+		appUI.Error("Couldn't pack createProxyWithNonce: %s", err)
+		return
+	}
+
+	var predicted ethcommon.Address
+	var predictedOK bool
+	if creation, err := safe.FactoryProxyCreationCode(dep.Factory, config.Network()); err != nil {
+		appUI.Warn("Couldn't read factory.proxyCreationCode(); predicted address will be omitted: %s", err)
+	} else if addr, err := safe.PredictProxyAddress(dep.Factory, dep.Singleton, creation, initializer, saltNonce); err != nil {
+		appUI.Warn("Couldn't predict Safe address: %s", err)
+	} else {
+		predicted = addr
+		predictedOK = true
+		if occupied, err := util.IsContract(addr.Hex(), config.Network()); err == nil && occupied {
+			appUI.Error(
+				"Predicted Safe %s already has code. Pick a different salt nonce.",
+				addr.Hex(),
+			)
+			return
+		}
+	}
+
+	appUI.Section("Safe to be created")
+	if predictedOK {
+		appUI.Critical("Predicted address : %s", predicted.Hex())
+	}
+	appUI.Critical("Threshold         : %s / %d", threshold.String(), len(owners))
+	appUI.Critical("Salt nonce        : %s", saltNonce.String())
+	appUI.Info("Owners (%d):", len(owners))
+	for i, o := range owners {
+		jarvisAddr := util.GetJarvisAddress(o.Hex(), config.Network())
+		appUI.Info("  %d. %s", i+1, appUI.Style(util.StyledAddress(jarvisAddr)))
+	}
+
+	gasLimit := config.GasLimit
+	if gasLimit == 0 {
+		gasLimit, err = tc.Reader.EstimateExactGas(tc.From, dep.Factory.Hex(), 0, tc.Value, txData)
+		if err != nil {
+			appUI.Error("Couldn't estimate gas limit for createProxyWithNonce: %s", err)
+			return
+		}
+	}
+
+	tx := jarviscommon.BuildExactTx(
+		tc.TxType,
+		tc.Nonce,
+		dep.Factory.Hex(),
+		tc.Value,
+		gasLimit+config.ExtraGasLimit,
+		tc.GasPrice+config.ExtraGasPrice,
+		tc.TipGas+config.ExtraTipGas,
+		txData,
+		config.Network().GetChainID(),
+	)
+
+	customABIs := map[string]*abi.ABI{
+		strings.ToLower(dep.Factory.Hex()): safe.GetProxyFactoryABI(),
+	}
+
+	if broadcasted, err := cmdutil.SignAndBroadcast(
+		appUI, tc.FromAcc, tx, customABIs,
+		tc.Reader, tc.Analyzer, safe.GetProxyFactoryABI(), tc.Broadcaster,
+	); err != nil && !broadcasted {
+		appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
+		return
+	}
+
+	if predictedOK {
+		appUI.Info("")
+		appUI.Info("Next (after the deploy tx confirms):")
+		appUI.Info("  jarvis msig gov %s%s", predicted.Hex(), networkFlag())
+		appUI.Info("  jarvis msig init %s --msig-to <target>%s", predicted.Hex(), networkFlag())
+	}
+}
+
+func parseSafeDeployParams(params []any) (owners []ethcommon.Address, threshold, saltNonce *big.Int, err error) {
+	if len(params) != 3 {
+		return nil, nil, nil, fmt.Errorf("expected 3 deploy params (owners, threshold, salt nonce), got %d", len(params))
+	}
+	owners, err = asAddressSlice(params[0])
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("owners: %w", err)
+	}
+	threshold, err = asBigInt(params[1])
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("threshold: %w", err)
+	}
+	saltNonce, err = asBigInt(params[2])
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("salt nonce: %w", err)
+	}
+	return owners, threshold, saltNonce, nil
+}
+
+func asAddressSlice(v any) ([]ethcommon.Address, error) {
+	if t, ok := v.([]ethcommon.Address); ok {
+		return t, nil
+	}
+	return nil, fmt.Errorf("got %T, want []address", v)
+}
+
+func asBigInt(v any) (*big.Int, error) {
+	switch t := v.(type) {
+	case *big.Int:
+		return t, nil
+	case big.Int:
+		n := t
+		return &n, nil
+	case uint64:
+		return new(big.Int).SetUint64(t), nil
+	case int64:
+		return big.NewInt(t), nil
+	case int:
+		return big.NewInt(int64(t)), nil
+	}
+	return nil, fmt.Errorf("got %T, want integer", v)
 }
 
 // safeBatchResult is the per-ref outcome of `jarvis msig bapprove`.

--- a/safe/deploy.go
+++ b/safe/deploy.go
@@ -1,0 +1,407 @@
+package safe
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/util"
+)
+
+// Official Safe singleton / factory / fallback-handler deployments.
+// Addresses are CREATE2-deterministic, so the same hex is used on every
+// chain that Safe deployed to. Two variants exist per 1.3.0 contract
+// (canonical vs eip155); 1.4.1 ships a single canonical set.
+//
+// Source: https://github.com/safe-global/safe-deployments
+type deployCandidate struct {
+	Address string
+	Label   string
+}
+
+type safeRelease struct {
+	Version   string
+	Factories []deployCandidate
+	Safe      []deployCandidate // L1 singleton (no extra events)
+	SafeL2    []deployCandidate // L2 singleton (emits extra events for indexers)
+	Fallback  []deployCandidate
+}
+
+var (
+	safeRelease141 = safeRelease{
+		Version: "1.4.1",
+		Factories: []deployCandidate{
+			{"0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", "SafeProxyFactory 1.4.1 (canonical)"},
+		},
+		Safe: []deployCandidate{
+			{"0x41675C099F32341bf84BFc5382aF534df5C7461a", "Safe 1.4.1 (canonical)"},
+		},
+		SafeL2: []deployCandidate{
+			{"0x29fcB43b46531BcA003ddC8FCB67FFE9194148C4", "SafeL2 1.4.1 (canonical)"},
+		},
+		Fallback: []deployCandidate{
+			{"0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99", "CompatibilityFallbackHandler 1.4.1 (canonical)"},
+		},
+	}
+	safeRelease130 = safeRelease{
+		Version: "1.3.0",
+		Factories: []deployCandidate{
+			{"0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", "GnosisSafeProxyFactory 1.3.0 (canonical)"},
+			{"0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", "GnosisSafeProxyFactory 1.3.0 (eip155)"},
+		},
+		Safe: []deployCandidate{
+			{"0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", "GnosisSafe 1.3.0 (canonical)"},
+			{"0x69f4D1788e39c87893C980c06EdF4b7f686e2938", "GnosisSafe 1.3.0 (eip155)"},
+		},
+		SafeL2: []deployCandidate{
+			{"0x3E5c63644E683549055b9Be8653de26E0B4CD36E", "GnosisSafeL2 1.3.0 (canonical)"},
+			{"0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", "GnosisSafeL2 1.3.0 (eip155)"},
+		},
+		Fallback: []deployCandidate{
+			{"0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4", "CompatibilityFallbackHandler 1.3.0 (canonical)"},
+			{"0x017062a1dE2FE6b99BE3d9d37841FeD19F573804", "CompatibilityFallbackHandler 1.3.0 (eip155)"},
+		},
+	}
+)
+
+// releasesNewestFirst is the probe order for a new Safe. 1.4.1 is what
+// the Safe{Wallet} UI deploys today; 1.3.0 is the fallback on chains that
+// never received the 1.4.1 set.
+func releasesNewestFirst() []safeRelease {
+	return []safeRelease{safeRelease141, safeRelease130}
+}
+
+// preferL2Singleton reports whether this chain should deploy SafeL2
+// (extra events, needed by indexers that lack a tracing API) rather than
+// the L1 Safe singleton. Ethereum mainnet and its public L1 testnets
+// have tracing, so they use the cheaper L1 singleton — matching the
+// Safe{Wallet} UI.
+func preferL2Singleton(chainID uint64) bool {
+	switch chainID {
+	case 1, 11155111, 17000, 560048: // ethereum, sepolia, holesky, hoodi
+		return false
+	default:
+		return true
+	}
+}
+
+// DeployOverrides lets an operator point jarvis at their own factory /
+// singleton / fallback-handler instead of the canonical Safe deployments.
+// Empty fields are filled by on-chain probing.
+type DeployOverrides struct {
+	Factory         string
+	Singleton       string
+	FallbackHandler string
+}
+
+// Deployment is the fully-resolved set of contracts used to deploy one
+// new Safe, plus human-readable labels for the confirmation screen.
+type Deployment struct {
+	Version         string
+	Factory         common.Address
+	FactoryLabel    string
+	Singleton       common.Address
+	SingletonLabel  string
+	FallbackHandler common.Address
+	FallbackLabel   string
+}
+
+const (
+	proxyFactoryABIJSON = `[
+	  {
+	    "inputs": [
+	      {"internalType": "address", "name": "_singleton", "type": "address"},
+	      {"internalType": "bytes", "name": "initializer", "type": "bytes"},
+	      {"internalType": "uint256", "name": "saltNonce", "type": "uint256"}
+	    ],
+	    "name": "createProxyWithNonce",
+	    "outputs": [{"internalType": "address", "name": "proxy", "type": "address"}],
+	    "stateMutability": "nonpayable",
+	    "type": "function"
+	  },
+	  {
+	    "inputs": [],
+	    "name": "proxyCreationCode",
+	    "outputs": [{"internalType": "bytes", "name": "", "type": "bytes"}],
+	    "stateMutability": "pure",
+	    "type": "function"
+	  }
+	]`
+
+	safeSetupABIJSON = `[
+	  {
+	    "inputs": [
+	      {"internalType": "address[]", "name": "_owners", "type": "address[]"},
+	      {"internalType": "uint256", "name": "_threshold", "type": "uint256"},
+	      {"internalType": "address", "name": "to", "type": "address"},
+	      {"internalType": "bytes", "name": "data", "type": "bytes"},
+	      {"internalType": "address", "name": "fallbackHandler", "type": "address"},
+	      {"internalType": "address", "name": "paymentToken", "type": "address"},
+	      {"internalType": "uint256", "name": "payment", "type": "uint256"},
+	      {"internalType": "address payable", "name": "paymentReceiver", "type": "address"}
+	    ],
+	    "name": "setup",
+	    "outputs": [],
+	    "stateMutability": "nonpayable",
+	    "type": "function"
+	  }
+	]`
+)
+
+// GetProxyFactoryABI returns the parsed SafeProxyFactory subset used for
+// createProxyWithNonce and proxyCreationCode.
+func GetProxyFactoryABI() *abi.ABI {
+	a, err := abi.JSON(strings.NewReader(proxyFactoryABIJSON))
+	if err != nil {
+		panic(err)
+	}
+	return &a
+}
+
+// GetSafeSetupABI returns the parsed Safe.setup ABI used to build the
+// initializer passed to createProxyWithNonce.
+func GetSafeSetupABI() *abi.ABI {
+	a, err := abi.JSON(strings.NewReader(safeSetupABIJSON))
+	if err != nil {
+		panic(err)
+	}
+	return &a
+}
+
+// EncodeSetup packs Safe.setup(...) for a standard new wallet: no
+// post-setup delegatecall, no payment, and the given fallback handler.
+func EncodeSetup(owners []common.Address, threshold *big.Int, fallbackHandler common.Address) ([]byte, error) {
+	if err := ValidateNewSafeParams(owners, threshold); err != nil {
+		return nil, err
+	}
+	if threshold == nil {
+		return nil, fmt.Errorf("threshold is required")
+	}
+	return GetSafeSetupABI().Pack(
+		"setup",
+		owners,
+		threshold,
+		common.Address{},
+		[]byte{},
+		fallbackHandler,
+		common.Address{},
+		big.NewInt(0),
+		common.Address{},
+	)
+}
+
+// EncodeCreateProxyWithNonce packs SafeProxyFactory.createProxyWithNonce.
+func EncodeCreateProxyWithNonce(singleton common.Address, initializer []byte, saltNonce *big.Int) ([]byte, error) {
+	if singleton == (common.Address{}) {
+		return nil, fmt.Errorf("singleton address is required")
+	}
+	if saltNonce == nil {
+		saltNonce = big.NewInt(0)
+	}
+	if saltNonce.Sign() < 0 {
+		return nil, fmt.Errorf("salt nonce must be non-negative")
+	}
+	return GetProxyFactoryABI().Pack("createProxyWithNonce", singleton, initializer, saltNonce)
+}
+
+// PredictProxyAddress is the CREATE2 address SafeProxyFactory uses for
+// createProxyWithNonce: salt = keccak256(keccak256(initializer) || saltNonce),
+// init code = proxyCreationCode || uint256(singleton).
+func PredictProxyAddress(
+	factory, singleton common.Address,
+	proxyCreationCode, initializer []byte,
+	saltNonce *big.Int,
+) (common.Address, error) {
+	if factory == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("factory address is required")
+	}
+	if singleton == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("singleton address is required")
+	}
+	if len(proxyCreationCode) == 0 {
+		return common.Address{}, fmt.Errorf("proxy creation code is empty")
+	}
+	if saltNonce == nil {
+		saltNonce = big.NewInt(0)
+	}
+	if saltNonce.Sign() < 0 {
+		return common.Address{}, fmt.Errorf("salt nonce must be non-negative")
+	}
+
+	initHash := crypto.Keccak256(initializer)
+	salt := crypto.Keccak256Hash(append(initHash, common.LeftPadBytes(saltNonce.Bytes(), 32)...))
+	deploymentData := append(append([]byte{}, proxyCreationCode...), common.LeftPadBytes(singleton.Bytes(), 32)...)
+	return crypto.CreateAddress2(factory, salt, crypto.Keccak256(deploymentData)), nil
+}
+
+// ValidateNewSafeParams mirrors Safe.setup's owner / threshold checks so
+// we fail before the user signs a reverting factory call.
+func ValidateNewSafeParams(owners []common.Address, threshold *big.Int) error {
+	if len(owners) == 0 {
+		return fmt.Errorf("need at least one owner")
+	}
+	if threshold == nil || threshold.Sign() <= 0 {
+		return fmt.Errorf("threshold must be at least 1")
+	}
+	if threshold.Cmp(big.NewInt(int64(len(owners)))) > 0 {
+		return fmt.Errorf("threshold %s is greater than owner count %d", threshold, len(owners))
+	}
+	seen := make(map[common.Address]struct{}, len(owners))
+	for i, o := range owners {
+		if o == (common.Address{}) {
+			return fmt.Errorf("owner %d is the zero address", i+1)
+		}
+		if _, ok := seen[o]; ok {
+			return fmt.Errorf("duplicate owner %s", o.Hex())
+		}
+		seen[o] = struct{}{}
+	}
+	return nil
+}
+
+// hasCodeFunc is the on-chain probe used by ResolveSafeDeployment. Tests
+// inject a fake; production uses util.IsContract.
+type hasCodeFunc func(address string) (bool, error)
+
+// ResolveSafeDeployment picks factory / singleton / fallback-handler for
+// a new Safe on network. Canonical 1.4.1 is preferred when those
+// contracts have code; 1.3.0 (canonical then eip155) is the fallback.
+// L2 chains get SafeL2 so indexers see the extra events.
+func ResolveSafeDeployment(network networks.Network, overrides DeployOverrides) (*Deployment, error) {
+	return resolveSafeDeployment(network.GetChainID(), func(addr string) (bool, error) {
+		return util.IsContract(addr, network)
+	}, overrides)
+}
+
+func resolveSafeDeployment(chainID uint64, hasCode hasCodeFunc, overrides DeployOverrides) (*Deployment, error) {
+	factoryOverride, err := parseOptionalAddress(overrides.Factory, "--factory")
+	if err != nil {
+		return nil, err
+	}
+	singletonOverride, err := parseOptionalAddress(overrides.Singleton, "--singleton")
+	if err != nil {
+		return nil, err
+	}
+	fallbackOverride, err := parseOptionalAddress(overrides.FallbackHandler, "--fallback-handler")
+	if err != nil {
+		return nil, err
+	}
+
+	if factoryOverride != nil && singletonOverride != nil && fallbackOverride != nil {
+		return &Deployment{
+			Version:         "custom",
+			Factory:         *factoryOverride,
+			FactoryLabel:    "user-supplied via --factory",
+			Singleton:       *singletonOverride,
+			SingletonLabel:  "user-supplied via --singleton",
+			FallbackHandler: *fallbackOverride,
+			FallbackLabel:   "user-supplied via --fallback-handler",
+		}, nil
+	}
+
+	wantL2 := preferL2Singleton(chainID)
+	var lastErr error
+	for _, rel := range releasesNewestFirst() {
+		d := Deployment{Version: rel.Version}
+
+		if factoryOverride != nil {
+			d.Factory = *factoryOverride
+			d.FactoryLabel = "user-supplied via --factory"
+		} else if addr, label, err := firstWithCode(hasCode, rel.Factories); err == nil {
+			d.Factory = addr
+			d.FactoryLabel = label + ", verified on-chain"
+		} else {
+			lastErr = err
+			continue
+		}
+
+		// The other flavour is appended so a chain that only deployed one
+		// still succeeds; the preferred flavour is just tried first.
+		var singletons []deployCandidate
+		if wantL2 {
+			singletons = append(append([]deployCandidate{}, rel.SafeL2...), rel.Safe...)
+		} else {
+			singletons = append(append([]deployCandidate{}, rel.Safe...), rel.SafeL2...)
+		}
+
+		if singletonOverride != nil {
+			d.Singleton = *singletonOverride
+			d.SingletonLabel = "user-supplied via --singleton"
+		} else if addr, label, err := firstWithCode(hasCode, singletons); err == nil {
+			d.Singleton = addr
+			d.SingletonLabel = label + ", verified on-chain"
+		} else {
+			lastErr = err
+			continue
+		}
+
+		if fallbackOverride != nil {
+			d.FallbackHandler = *fallbackOverride
+			d.FallbackLabel = "user-supplied via --fallback-handler"
+		} else if addr, label, err := firstWithCode(hasCode, rel.Fallback); err == nil {
+			d.FallbackHandler = addr
+			d.FallbackLabel = label + ", verified on-chain"
+		} else {
+			lastErr = err
+			continue
+		}
+
+		return &d, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no candidate had code")
+	}
+	return nil, fmt.Errorf(
+		"couldn't locate Safe factory/singleton/fallback-handler on chain %d: %w; "+
+			"pass --factory / --singleton / --fallback-handler explicitly",
+		chainID, lastErr,
+	)
+}
+
+func firstWithCode(hasCode hasCodeFunc, candidates []deployCandidate) (common.Address, string, error) {
+	tried := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		tried = append(tried, c.Address)
+		ok, err := hasCode(c.Address)
+		if err != nil || !ok {
+			continue
+		}
+		return common.HexToAddress(c.Address), c.Label, nil
+	}
+	return common.Address{}, "", fmt.Errorf("none of %s have code", strings.Join(tried, ", "))
+}
+
+func parseOptionalAddress(raw, flag string) (*common.Address, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	if !common.IsHexAddress(raw) {
+		return nil, fmt.Errorf("%s %q is not a valid address", flag, raw)
+	}
+	addr := common.HexToAddress(raw)
+	return &addr, nil
+}
+
+// FactoryProxyCreationCode reads factory.proxyCreationCode() so the
+// CREATE2 address can be predicted before the user signs.
+func FactoryProxyCreationCode(factory common.Address, network networks.Network) ([]byte, error) {
+	r, err := util.EthReader(network)
+	if err != nil {
+		return nil, err
+	}
+	var code []byte
+	if err := r.ReadContractWithABI(&code, factory.Hex(), GetProxyFactoryABI(), "proxyCreationCode"); err != nil {
+		return nil, err
+	}
+	if len(code) == 0 {
+		return nil, fmt.Errorf("factory %s returned empty proxyCreationCode", factory.Hex())
+	}
+	return code, nil
+}

--- a/safe/deploy_test.go
+++ b/safe/deploy_test.go
@@ -1,0 +1,316 @@
+package safe
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestPreferL2Singleton(t *testing.T) {
+	l1 := []uint64{1, 11155111, 17000, 560048}
+	for _, id := range l1 {
+		if preferL2Singleton(id) {
+			t.Errorf("chain %d should use the L1 Safe singleton", id)
+		}
+	}
+	for _, id := range []uint64{10, 56, 137, 8453, 42161} {
+		if !preferL2Singleton(id) {
+			t.Errorf("chain %d should use SafeL2", id)
+		}
+	}
+}
+
+func TestValidateNewSafeParams(t *testing.T) {
+	a := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	b := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	cases := []struct {
+		name      string
+		owners    []common.Address
+		threshold *big.Int
+		wantErr   string
+	}{
+		{"ok 1-of-1", []common.Address{a}, big.NewInt(1), ""},
+		{"ok 2-of-2", []common.Address{a, b}, big.NewInt(2), ""},
+		{"no owners", nil, big.NewInt(1), "at least one owner"},
+		{"threshold 0", []common.Address{a}, big.NewInt(0), "at least 1"},
+		{"threshold nil", []common.Address{a}, nil, "at least 1"},
+		{"threshold too high", []common.Address{a}, big.NewInt(2), "greater than owner count"},
+		{"zero owner", []common.Address{{}}, big.NewInt(1), "zero address"},
+		{"duplicate", []common.Address{a, a}, big.NewInt(1), "duplicate owner"},
+	}
+	for _, tc := range cases {
+		err := ValidateNewSafeParams(tc.owners, tc.threshold)
+		if tc.wantErr == "" {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %s", tc.name, err)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+			t.Errorf("%s: got %v, want substring %q", tc.name, err, tc.wantErr)
+		}
+	}
+}
+
+func TestEncodeSetupSelectorAndRoundTrip(t *testing.T) {
+	owners := []common.Address{
+		common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		common.HexToAddress("0x2222222222222222222222222222222222222222"),
+	}
+	fallback := common.HexToAddress("0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99")
+	got, err := EncodeSetup(owners, big.NewInt(2), fallback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got[:4]) != "b63e800d" {
+		t.Fatalf("setup selector = %s, want b63e800d", hex.EncodeToString(got[:4]))
+	}
+
+	unpacked, err := GetSafeSetupABI().Methods["setup"].Inputs.Unpack(got[4:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotOwners := unpacked[0].([]common.Address)
+	if len(gotOwners) != 2 || gotOwners[0] != owners[0] || gotOwners[1] != owners[1] {
+		t.Errorf("owners = %v", gotOwners)
+	}
+	if unpacked[1].(*big.Int).Cmp(big.NewInt(2)) != 0 {
+		t.Errorf("threshold = %v", unpacked[1])
+	}
+	if unpacked[4].(common.Address) != fallback {
+		t.Errorf("fallback = %s", unpacked[4].(common.Address).Hex())
+	}
+	if unpacked[2].(common.Address) != (common.Address{}) {
+		t.Error("to should be zero")
+	}
+	if len(unpacked[3].([]byte)) != 0 {
+		t.Error("data should be empty")
+	}
+}
+
+func TestEncodeSetupRejectsBadParams(t *testing.T) {
+	if _, err := EncodeSetup(nil, big.NewInt(1), common.Address{}); err == nil {
+		t.Fatal("expected error for empty owners")
+	}
+}
+
+func TestEncodeCreateProxyWithNonceSelector(t *testing.T) {
+	singleton := common.HexToAddress("0x41675C099F32341bf84BFc5382aF534df5C7461a")
+	got, err := EncodeCreateProxyWithNonce(singleton, []byte{0xab}, big.NewInt(7))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got[:4]) != "1688f0b9" {
+		t.Fatalf("createProxyWithNonce selector = %s, want 1688f0b9", hex.EncodeToString(got[:4]))
+	}
+
+	unpacked, err := GetProxyFactoryABI().Methods["createProxyWithNonce"].Inputs.Unpack(got[4:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unpacked[0].(common.Address) != singleton {
+		t.Errorf("singleton = %s", unpacked[0].(common.Address).Hex())
+	}
+	if string(unpacked[1].([]byte)) != string([]byte{0xab}) {
+		t.Errorf("initializer = %x", unpacked[1].([]byte))
+	}
+	if unpacked[2].(*big.Int).Cmp(big.NewInt(7)) != 0 {
+		t.Errorf("salt = %v", unpacked[2])
+	}
+
+	if _, err := EncodeCreateProxyWithNonce(common.Address{}, nil, big.NewInt(0)); err == nil {
+		t.Error("expected error for zero singleton")
+	}
+	if _, err := EncodeCreateProxyWithNonce(singleton, nil, big.NewInt(-1)); err == nil {
+		t.Error("expected error for negative salt")
+	}
+}
+
+func TestPredictProxyAddressMatchesCreate2Formula(t *testing.T) {
+	factory := common.HexToAddress("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67")
+	singleton := common.HexToAddress("0x41675C099F32341bf84BFc5382aF534df5C7461a")
+	// Minimal stand-in for proxy creation code: only the hash matters.
+	creation := []byte{0x60, 0x80, 0x60, 0x40}
+	initializer := []byte{0xb6, 0x3e, 0x80, 0x0d}
+	saltNonce := big.NewInt(42)
+
+	got, err := PredictProxyAddress(factory, singleton, creation, initializer, saltNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	initHash := crypto.Keccak256(initializer)
+	salt := crypto.Keccak256Hash(append(initHash, common.LeftPadBytes(saltNonce.Bytes(), 32)...))
+	deployment := append(append([]byte{}, creation...), common.LeftPadBytes(singleton.Bytes(), 32)...)
+	want := crypto.CreateAddress2(factory, salt, crypto.Keccak256(deployment))
+	if got != want {
+		t.Fatalf("predicted %s, want %s", got.Hex(), want.Hex())
+	}
+	// Pin the hex so a formula regression fails even if both sides drift together.
+	if got.Hex() != "0x83a395F3485eaff1E5491730aCDFFdD69c0a5886" {
+		t.Fatalf("CREATE2 address drifted: %s", got.Hex())
+	}
+
+	if _, err := PredictProxyAddress(common.Address{}, singleton, creation, initializer, saltNonce); err == nil {
+		t.Error("expected error for zero factory")
+	}
+	if _, err := PredictProxyAddress(factory, singleton, nil, initializer, saltNonce); err == nil {
+		t.Error("expected error for empty creation code")
+	}
+}
+
+func TestPredictProxyAddressNilSaltIsZero(t *testing.T) {
+	factory := common.HexToAddress("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67")
+	singleton := common.HexToAddress("0x29fcB43b46531BcA003ddC8FCB67FFE9194148C4")
+	creation := []byte{0x01}
+	withZero, err := PredictProxyAddress(factory, singleton, creation, nil, big.NewInt(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	withNil, err := PredictProxyAddress(factory, singleton, creation, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withZero != withNil {
+		t.Fatalf("nil salt %s != zero salt %s", withNil.Hex(), withZero.Hex())
+	}
+}
+
+func TestResolveSafeDeploymentAllOverrides(t *testing.T) {
+	factory := "0x0000000000000000000000000000000000000001"
+	singleton := "0x0000000000000000000000000000000000000002"
+	fallback := "0x0000000000000000000000000000000000000003"
+	d, err := resolveSafeDeployment(1, func(string) (bool, error) {
+		t.Fatal("should not probe when every address is overridden")
+		return false, nil
+	}, DeployOverrides{Factory: factory, Singleton: singleton, FallbackHandler: fallback})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Factory.Hex() != common.HexToAddress(factory).Hex() {
+		t.Errorf("factory = %s", d.Factory.Hex())
+	}
+	if d.Singleton.Hex() != common.HexToAddress(singleton).Hex() {
+		t.Errorf("singleton = %s", d.Singleton.Hex())
+	}
+	if d.FallbackHandler.Hex() != common.HexToAddress(fallback).Hex() {
+		t.Errorf("fallback = %s", d.FallbackHandler.Hex())
+	}
+	if d.Version != "custom" {
+		t.Errorf("version = %s", d.Version)
+	}
+}
+
+func TestResolveSafeDeploymentBadOverride(t *testing.T) {
+	_, err := resolveSafeDeployment(1, func(string) (bool, error) { return true, nil }, DeployOverrides{Factory: "nope"})
+	if err == nil || !strings.Contains(err.Error(), "--factory") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestResolveSafeDeploymentProbes141ThenL1OnEthereum(t *testing.T) {
+	wantFactory := strings.ToLower(safeRelease141.Factories[0].Address)
+	wantSafe := strings.ToLower(safeRelease141.Safe[0].Address)
+	wantFallback := strings.ToLower(safeRelease141.Fallback[0].Address)
+
+	d, err := resolveSafeDeployment(1, func(addr string) (bool, error) {
+		switch strings.ToLower(addr) {
+		case wantFactory, wantSafe, wantFallback:
+			return true, nil
+		default:
+			return false, nil
+		}
+	}, DeployOverrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Version != "1.4.1" {
+		t.Errorf("version = %s", d.Version)
+	}
+	if !strings.EqualFold(d.Factory.Hex(), wantFactory) {
+		t.Errorf("factory = %s", d.Factory.Hex())
+	}
+	if !strings.EqualFold(d.Singleton.Hex(), wantSafe) {
+		t.Errorf("singleton = %s, want L1 Safe", d.Singleton.Hex())
+	}
+	if !strings.Contains(d.SingletonLabel, "Safe 1.4.1") {
+		t.Errorf("singleton label = %s", d.SingletonLabel)
+	}
+}
+
+func TestResolveSafeDeploymentPrefersL2OnBSC(t *testing.T) {
+	wantL2 := strings.ToLower(safeRelease141.SafeL2[0].Address)
+	d, err := resolveSafeDeployment(56, func(addr string) (bool, error) {
+		return true, nil
+	}, DeployOverrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.EqualFold(d.Singleton.Hex(), wantL2) {
+		t.Errorf("singleton = %s, want SafeL2 %s", d.Singleton.Hex(), wantL2)
+	}
+}
+
+func TestResolveSafeDeploymentFallsBackTo130(t *testing.T) {
+	wantFactory := strings.ToLower(safeRelease130.Factories[0].Address)
+	wantL2 := strings.ToLower(safeRelease130.SafeL2[0].Address)
+	wantFallback := strings.ToLower(safeRelease130.Fallback[0].Address)
+
+	d, err := resolveSafeDeployment(137, func(addr string) (bool, error) {
+		switch strings.ToLower(addr) {
+		case wantFactory, wantL2, wantFallback:
+			return true, nil
+		default:
+			return false, nil
+		}
+	}, DeployOverrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Version != "1.3.0" {
+		t.Errorf("version = %s", d.Version)
+	}
+	if !strings.EqualFold(d.Singleton.Hex(), wantL2) {
+		t.Errorf("singleton = %s", d.Singleton.Hex())
+	}
+}
+
+func TestResolveSafeDeploymentPartialOverride(t *testing.T) {
+	customFactory := "0x00000000000000000000000000000000000000fA"
+	d, err := resolveSafeDeployment(1, func(addr string) (bool, error) {
+		return !strings.EqualFold(addr, customFactory), nil
+	}, DeployOverrides{Factory: customFactory})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.EqualFold(d.Factory.Hex(), customFactory) {
+		t.Errorf("factory = %s", d.Factory.Hex())
+	}
+	if !strings.Contains(d.FactoryLabel, "--factory") {
+		t.Errorf("factory label = %s", d.FactoryLabel)
+	}
+	if d.Singleton == (common.Address{}) || d.FallbackHandler == (common.Address{}) {
+		t.Error("expected probed singleton and fallback")
+	}
+}
+
+func TestResolveSafeDeploymentNothingOnChain(t *testing.T) {
+	_, err := resolveSafeDeployment(999, func(string) (bool, error) { return false, nil }, DeployOverrides{})
+	if err == nil || !strings.Contains(err.Error(), "--factory") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestReleasesNewestFirstDoesNotAlias(t *testing.T) {
+	before141 := len(safeRelease141.Factories)
+	before130 := len(safeRelease130.Factories)
+	_ = releasesNewestFirst()
+	if len(safeRelease141.Factories) != before141 || len(safeRelease130.Factories) != before130 {
+		t.Fatal("release tables were mutated")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`jarvis msig new` can now deploy a Gnosis Safe as well as a Classic MultiSigWallet. `jarvis msig gov` already routed to Safe; that path is unchanged and was re-verified against live mainnet Safes.

## `jarvis msig new`

```bash
jarvis msig new --from 0xALICE --type safe --network eth
jarvis msig new --from 0xALICE --type safe -I "0xA,0xB,0xC|2|0" -y
jarvis msig new --from 0xALICE --type classic
```

- `--type safe|classic` skips the flavor prompt.
- Omitted `--type` prompts interactively. `--prefills` / `-I` without `--type` stays **Classic**, so existing scripts keep working.
- Safe path calls `SafeProxyFactory.createProxyWithNonce` with a standard `setup(owners, threshold, …)` initializer.
- Factory / singleton / fallback-handler are probed on-chain from the canonical 1.4.1 set, then 1.3.0 (canonical + eip155). L2 chains try SafeL2 first; Ethereum mainnet and its L1 testnets use the L1 Safe singleton. Override with `--factory`, `--singleton`, `--fallback-handler`.
- The CREATE2 address is predicted from `proxyCreationCode()` and shown before signing. A salt that collides with an existing contract is rejected.

## `jarvis msig gov`

Already dispatched to the Safe backend via `DetectMultisigType`. Confirmed against the GnosisDAO Safe on mainnet (`0x0DA0C3e52C977Ed3cBc641fF02DD271c3ED55aFe`): owners, 3/5 threshold, version 1.3.0, nonce.

## Tests

- Unit tests for setup / `createProxyWithNonce` encoding, CREATE2 formula, owner validation, and deployment probe order (1.4.1 vs 1.3.0, L1 vs L2, overrides).
- Live mainnet resolve: factory `0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67`, Safe 1.4.1 singleton, fallback handler, 486-byte proxy creation code.
- Live BSC resolve falls back to the 1.4.1 L1 Safe singleton because SafeL2 1.4.1 has no code there.

Walkthrough:

[msig gov on a mainnet Safe](https://cursor.com/agents/bc-01a04eb3-8bd2-7fae-a90a-e81680fc098b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmsig_gov_safe_mainnet.txt)
[msig new help](https://cursor.com/agents/bc-01a04eb3-8bd2-7fae-a90a-e81680fc098b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmsig_new_help.txt)
[live Safe deploy resolution on mainnet](https://cursor.com/agents/bc-01a04eb3-8bd2-7fae-a90a-e81680fc098b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmsig_new_safe_mainnet_resolve.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04eb3-8bd2-7fae-a90a-e81680fc098b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04eb3-8bd2-7fae-a90a-e81680fc098b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

