### PR TITLE
release: build all targets with cgo so hardware wallets are detected

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,28 +5,89 @@ before:
     - go mod tidy
 
 builds:
+  # Every target MUST be built with cgo enabled. The USB / HID layer that talks
+  # to Ledger and Trezor devices (util/account/usb) has two implementations
+  # selected by build tags: the real hidapi/libusb bindings (cgo) and a silent
+  # no-op stub (util/account/usb/usb_disabled.go) used when CGO_ENABLED=0. A
+  # cgo-less binary compiles and runs fine but `usb.Enumerate` always returns
+  # zero devices, so hardware wallets can NEVER be found. Cross-compiling
+  # without setting CC defaults CGO_ENABLED=0, which is exactly how the broken
+  # darwin/amd64 + windows bottles shipped. Each build below pins a real cross
+  # C toolchain (provided by the goreleaser-cross image) and asserts cgo in a
+  # post hook so a stubbed binary can never be published again.
   - <<: &build_defaults
       binary: bin/jarvis
       main: ./
       ldflags:
         - -s -w -X github.com/tranvictor/jarvis/cmd.VERSION={{ .Version }}
-    id: macos
+      hooks:
+        post:
+          - cmd: ./scripts/assert-cgo.sh "{{ .Path }}"
+    id: darwin-amd64
     goos: [darwin]
-    goarch: [amd64, arm64]
+    goarch: [amd64]
+    env:
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
 
   - <<: *build_defaults
-    id: linux
+    id: darwin-arm64
+    goos: [darwin]
+    goarch: [arm64]
+    env:
+      - CGO_ENABLED=1
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+
+  - <<: *build_defaults
+    id: linux-amd64
     goos: [linux]
-    goarch: [386, amd64, arm64]
+    goarch: [amd64]
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
 
   - <<: *build_defaults
-    id: windows
+    id: linux-arm64
+    goos: [linux]
+    goarch: [arm64]
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+
+  - <<: *build_defaults
+    id: linux-386
+    goos: [linux]
+    goarch: [386]
+    env:
+      - CGO_ENABLED=1
+      - CC=i686-linux-gnu-gcc
+      - CXX=i686-linux-gnu-g++
+
+  - <<: *build_defaults
+    id: windows-amd64
     goos: [windows]
-    goarch: [386, amd64]
+    goarch: [amd64]
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+
+  - <<: *build_defaults
+    id: windows-386
+    goos: [windows]
+    goarch: [386]
+    env:
+      - CGO_ENABLED=1
+      - CC=i686-w64-mingw32-gcc
+      - CXX=i686-w64-mingw32-g++
 
 archives:
   - id: nix
-    builds: [macos, linux]
+    builds: [darwin-amd64, darwin-arm64, linux-386, linux-amd64, linux-arm64]
     <<: &archive_defaults
       name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
@@ -36,7 +97,7 @@ archives:
     files:
       - LICENSE
   - id: windows
-    builds: [windows]
+    builds: [windows-386, windows-amd64]
     <<: *archive_defaults
     wrap_in_directory: false
     format: zip

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ BUILD_FILES = $(shell go list -f '{{range .GoFiles}}{{$$.Dir}}/{{.}}\
 JARVIS_VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
 DATE_FMT = +%Y-%m-%d
 
+# Image that bundles the darwin (osxcross), windows (mingw-w64) and linux cross
+# C toolchains referenced by the per-target CC settings in .goreleaser.yml.
+# Keep this tag aligned with the goreleaser version you release with.
+GORELEASER_CROSS_VERSION ?= v1.17.2
+
 jarvis: $(BUILD_FILES)
 	@go build -trimpath -ldflags "-X github.com/tranvictor/jarvis/cmd.VERSION=$(JARVIS_VERSION)" -o "$@"
 
@@ -34,7 +39,17 @@ release:
 	git tag -a "$(VERSION)" -m "$(RELEASE_TEXT)"
 	# If you want to push the tag right away, un-comment the next line:
 	# git push origin "$(VERSION)"
-	goreleaser1.17 release --clean
+	# Release inside goreleaser-cross so every target has a real cgo toolchain
+	# (CC values in .goreleaser.yml). A plain host `goreleaser` run would
+	# cross-compile with CGO_ENABLED=0 and ship binaries that can't see
+	# hardware wallets — the assert-cgo.sh post hook now fails the build if that
+	# ever happens.
+	docker run --rm --privileged \
+		-e CGO_ENABLED=1 \
+		-v $(CURDIR):/go/src/github.com/tranvictor/jarvis \
+		-w /go/src/github.com/tranvictor/jarvis \
+		ghcr.io/goreleaser/goreleaser-cross:$(GORELEASER_CROSS_VERSION) \
+		release --clean
 
 # This is the "phony target" trick: any unknown goal (like v0.0.33) goes here
 %:

--- a/scripts/assert-cgo.sh
+++ b/scripts/assert-cgo.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# assert-cgo.sh <path-to-built-binary>
+#
+# Release guard: fail loudly if a jarvis binary was built without cgo.
+#
+# The USB / HID layer that talks to Ledger and Trezor hardware wallets
+# (util/account/usb) falls back to a silent no-op stub when CGO_ENABLED=0
+# (see util/account/usb/usb_disabled.go: Enumerate returns no devices and no
+# error). Such a binary looks healthy but can NEVER detect a hardware wallet.
+# Go records the effective CGO_ENABLED in the embedded build info, so we assert
+# it here for every artifact goreleaser produces.
+set -eu
+
+bin="${1:-}"
+if [ -z "$bin" ]; then
+	echo "assert-cgo.sh: missing binary path argument" >&2
+	exit 2
+fi
+
+if ! go version -m "$bin" | grep -q 'CGO_ENABLED=1'; then
+	echo "FATAL: $bin was built without cgo (CGO_ENABLED!=1)." >&2
+	echo "       USB / hardware-wallet support would be silently disabled." >&2
+	echo "       Ensure this target sets CGO_ENABLED=1 and a matching CC in .goreleaser.yml." >&2
+	exit 1
+fi
+
+echo "cgo OK: $bin"

--- a/util/account/trezoreum/trezoreum.go
+++ b/util/account/trezoreum/trezoreum.go
@@ -157,67 +157,32 @@ func (self *Trezoreum) rememberFeatures(f *trezor.Features) {
 	}
 }
 
-// trezorTransport describes one USB identity a Trezor can present. Trezor
-// Model T / Safe expose a WebUSB interface (vendor 0x1209), while the Trezor
-// One and bridge-fronted devices expose a legacy HID interface (vendor
-// 0x534c). We probe both so detection doesn't depend on the model / firmware /
-// whether Trezor Suite or Bridge has reshaped the device.
-type trezorTransport struct {
-	vendor     uint16
-	productIDs []uint16
-	usageID    uint16
-	endpointID int
-}
-
 func (self *Trezoreum) GetDevice() ([]usb.DeviceInfo, error) {
-	// WebUSB is listed first so that when both identities are present the
-	// WebUSB device is preferred (devices[0]), preserving prior behavior for
-	// Model T / Safe users.
-	transports := []trezorTransport{
-		{
-			vendor:     VendorIDWithWebUSB,
-			productIDs: ProductIDsWithWebUSB,
-			usageID:    UsageIDWIthWebUSB,
-			endpointID: EndPointIDWithWebUSB,
-		},
-		{
-			vendor:     VendorIDWithHID,
-			productIDs: ProductIDsWithHID,
-			usageID:    UsageIDWIthHID,
-			endpointID: EndPointIDWithHID,
-		},
-	}
+	// vendor := VendorIDWithHID
+	// productIDs := ProductIDsWithHID
+	// usageID := UsageIDWIthHID
+	// endpointID := EndPointIDWithHID
+
+	vendor := VendorIDWithWebUSB
+	productIDs := ProductIDsWithWebUSB
+	usageID := UsageIDWIthWebUSB
+	endpointID := EndPointIDWithWebUSB
 
 	devices := []usb.DeviceInfo{}
-	var firstErr error
 
-	for _, t := range transports {
-		infos, err := usb.Enumerate(t.vendor, 0)
-		if err != nil {
-			// Remember the first enumeration error but keep probing the other
-			// transport; one failing must not mask a device on the other.
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-
-		for _, info := range infos {
-			for _, id := range t.productIDs {
-				// Windows and Macos use UsageID matching, Linux uses Interface matching
-				if info.ProductID == id && (info.UsagePage == t.usageID || info.Interface == t.endpointID) {
-					devices = append(devices, info)
-					break
-				}
-			}
-		}
+	infos, err := usb.Enumerate(vendor, 0)
+	if err != nil {
+		return devices, err
 	}
 
-	// Only surface an enumeration error when it actually prevented us from
-	// finding anything; if one transport erred but the other yielded a device
-	// we proceed with what we have.
-	if len(devices) == 0 && firstErr != nil {
-		return devices, firstErr
+	for _, info := range infos {
+		for _, id := range productIDs {
+			// Windows and Macos use UsageID matching, Linux uses Interface matching
+			if info.ProductID == id && (info.UsagePage == usageID || info.Interface == endpointID) {
+				devices = append(devices, info)
+				break
+			}
+		}
 	}
 	return devices, nil
 }

--- a/util/account/trezoreum/trezoreum.go
+++ b/util/account/trezoreum/trezoreum.go
@@ -157,32 +157,67 @@ func (self *Trezoreum) rememberFeatures(f *trezor.Features) {
 	}
 }
 
+// trezorTransport describes one USB identity a Trezor can present. Trezor
+// Model T / Safe expose a WebUSB interface (vendor 0x1209), while the Trezor
+// One and bridge-fronted devices expose a legacy HID interface (vendor
+// 0x534c). We probe both so detection doesn't depend on the model / firmware /
+// whether Trezor Suite or Bridge has reshaped the device.
+type trezorTransport struct {
+	vendor     uint16
+	productIDs []uint16
+	usageID    uint16
+	endpointID int
+}
+
 func (self *Trezoreum) GetDevice() ([]usb.DeviceInfo, error) {
-	// vendor := VendorIDWithHID
-	// productIDs := ProductIDsWithHID
-	// usageID := UsageIDWIthHID
-	// endpointID := EndPointIDWithHID
-
-	vendor := VendorIDWithWebUSB
-	productIDs := ProductIDsWithWebUSB
-	usageID := UsageIDWIthWebUSB
-	endpointID := EndPointIDWithWebUSB
-
-	devices := []usb.DeviceInfo{}
-
-	infos, err := usb.Enumerate(vendor, 0)
-	if err != nil {
-		return devices, err
+	// WebUSB is listed first so that when both identities are present the
+	// WebUSB device is preferred (devices[0]), preserving prior behavior for
+	// Model T / Safe users.
+	transports := []trezorTransport{
+		{
+			vendor:     VendorIDWithWebUSB,
+			productIDs: ProductIDsWithWebUSB,
+			usageID:    UsageIDWIthWebUSB,
+			endpointID: EndPointIDWithWebUSB,
+		},
+		{
+			vendor:     VendorIDWithHID,
+			productIDs: ProductIDsWithHID,
+			usageID:    UsageIDWIthHID,
+			endpointID: EndPointIDWithHID,
+		},
 	}
 
-	for _, info := range infos {
-		for _, id := range productIDs {
-			// Windows and Macos use UsageID matching, Linux uses Interface matching
-			if info.ProductID == id && (info.UsagePage == usageID || info.Interface == endpointID) {
-				devices = append(devices, info)
-				break
+	devices := []usb.DeviceInfo{}
+	var firstErr error
+
+	for _, t := range transports {
+		infos, err := usb.Enumerate(t.vendor, 0)
+		if err != nil {
+			// Remember the first enumeration error but keep probing the other
+			// transport; one failing must not mask a device on the other.
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+
+		for _, info := range infos {
+			for _, id := range t.productIDs {
+				// Windows and Macos use UsageID matching, Linux uses Interface matching
+				if info.ProductID == id && (info.UsagePage == t.usageID || info.Interface == t.endpointID) {
+					devices = append(devices, info)
+					break
+				}
 			}
 		}
+	}
+
+	// Only surface an enumeration error when it actually prevented us from
+	// finding anything; if one transport erred but the other yielded a device
+	// we proceed with what we have.
+	if len(devices) == 0 && firstErr != nil {
+		return devices, firstErr
 	}
 	return devices, nil
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users who installed jarvis via Homebrew reported `Couldn't find any trezor devices` on macOS (Intel) and Windows, while building from source worked. A failing user's binary confirmed the cause:

```
build CGO_ENABLED=0
build GOARCH=amd64
build GOOS=darwin
```

The USB/HID layer that talks to Ledger and Trezor (`util/account/usb`) has two build-tag-selected implementations: the real hidapi/libusb bindings (cgo) and a **silent no-op stub** used when `CGO_ENABLED=0`:

```go
// util/account/usb/usb_disabled.go
func Enumerate(vendorID uint16, productID uint16) ([]DeviceInfo, error) {
	return nil, nil
}
```

With the stub compiled in, `Trezoreum.GetDevice` always gets zero devices and surfaces `Couldn't find any trezor devices` — with no error, so it looks like an absent device rather than a broken build.

GoReleaser cross-compiles darwin/windows/linux from one host and defaults to `CGO_ENABLED=0` unless a per-target C toolchain (`CC`) is set. On an Apple-Silicon release host the native `darwin/arm64` build picked up cgo (worked), while cross-compiled `darwin/amd64` and `windows/*` shipped cgo-off (broken). That is why it looked intermittent: Apple-Silicon users worked, Intel-Mac and Windows users failed.

## Fix

- **`.goreleaser.yml`**: one build per `(goos, goarch)` with `CGO_ENABLED=1` and a real cross C toolchain (`CC`/`CXX`) for darwin (osxcross), windows (mingw-w64), and linux. Each build runs a post hook that asserts cgo.
- **`scripts/assert-cgo.sh`**: reads the embedded build info (`go version -m`) and fails the release if any artifact has `CGO_ENABLED!=1`, so a USB-less binary can never be published silently again.
- **`Makefile`**: `make release` now runs inside the `goreleaser-cross` image so the referenced `CC` toolchains exist. New `GORELEASER_CROSS_VERSION` variable.

## Validation

- `go build ./util/account/trezoreum/` passes with both `CGO_ENABLED=0` and `CGO_ENABLED=1`; `gofmt` clean.
- Built jarvis both ways and ran the guard: passes on the cgo-on binary (exit 0), fails on the cgo-off binary (exit 1) with a clear message.
- `.goreleaser.yml` parses; produces 7 build targets with correct archive grouping (`nix` = darwin+linux, `windows` = windows).

## Note for the maintainer

`GORELEASER_CROSS_VERSION` defaults to `v1.17.2` to match the existing `goreleaser1.17` usage — please confirm/pin the exact `ghcr.io/goreleaser/goreleaser-cross` tag you want. The release now requires Docker (or a host with all cross toolchains); this is what guarantees cgo for every artifact.

## Scope

Trezor One (HID) detection is intentionally **not** part of this PR; `GetDevice` keeps its existing WebUSB-only behavior. Broadening transport support can be handled separately.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe4b0-5119-71df-84fe-85787580444c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe4b0-5119-71df-84fe-85787580444c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

