### PR TITLE
Share ScanForTxs and Classic Submission topic

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -24,7 +24,7 @@ var txCmd = &cobra.Command{
 		tc, _ := cmdutil.TxContextFrom(cmd)
 
 		para := strings.Join(args, " ")
-		txs := util.ScanForTxs(para)
+		txs := util.ScanForTxHashes(para)
 		if len(txs) == 0 {
 			appUI.Error("Couldn't find any tx hash in the params")
 			return

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -726,15 +726,8 @@ with --json-output, the same data is also written as JSON.`,
 				results = append(results, r)
 				continue
 			}
-			var txid *big.Int
 			msigHex := txinfo.Tx.To().Hex()
-			for _, l := range txinfo.Receipt.Logs {
-				if strings.EqualFold(l.Address.Hex(), msigHex) &&
-					strings.EqualFold(l.Topics[0].Hex(), "0xc0ba8fe4b176c1714197d43b9cc6bcf797a4a7461c5fe8d0ef6e184ae7601e51") {
-					txid = l.Topics[1].Big()
-					break
-				}
-			}
+			txid := util.GnosisMsigTxIDFromLogs(txinfo.Receipt.Logs, msigHex)
 			if txid == nil {
 				appUI.Warn("This tx is not a gnosis classic multisig init tx. Skip.")
 				r.status = "skipped"

--- a/cmd/util/pre_process.go
+++ b/cmd/util/pre_process.go
@@ -106,6 +106,17 @@ func CommonFunctionCallPreprocess(u ui.UI, cmd *cobra.Command, args []string) (e
 // contract address, making it suitable for commands that operate on arbitrary
 // tx hashes or other non-address arguments (e.g. the "info" command).
 func CommonNetworkPreprocess(u ui.UI, cmd *cobra.Command, args []string) error {
+	// Peek at args for a network-prefixed tx hash (e.g. "mainnet:0x...").
+	// The network must be resolved BEFORE the reader/analyzer are built,
+	// otherwise we bind to the default network and fetch the wrong chain.
+	// An explicit -N/--network flag still wins if the user passed it.
+	if len(args) > 0 && !cmd.Flags().Changed("network") {
+		para := strings.Join(args, " ")
+		if nwks, txs := ScanForTxs(para); len(txs) > 0 && nwks[0] != "" {
+			config.NetworkString = nwks[0]
+		}
+	}
+
 	if err := config.SetNetwork(config.NetworkString); err != nil {
 		return err
 	}

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -160,19 +159,7 @@ type PostProcessFunc func(fc *jarviscommon.FunctionCall) error
 
 // ScanForTxs scans para for network-prefixed or bare transaction hashes.
 func ScanForTxs(para string) (nwks []string, addresses []string) {
-	networkNames := jarvisnetworks.GetSupportedNetworkNames()
-	regexStr := strings.Join(networkNames, "|")
-	regexStr = fmt.Sprintf(
-		"(?i)(?:(?P<network>%s)(?:.{0,}?))?(?P<address>(?:0x)?(?:[0-9a-fA-F]{64}))",
-		regexStr,
-	)
-
-	re := regexp.MustCompile(regexStr)
-	for _, match := range re.FindAllStringSubmatch(para, -1) {
-		nwks = append(nwks, strings.ToLower(match[1]))
-		addresses = append(addresses, match[2])
-	}
-	return
+	return util.ScanForTxs(para)
 }
 
 // HandleApproveOrRevokeOrExecuteMsig handles the confirm / revoke / execute
@@ -233,13 +220,7 @@ func HandleApproveOrRevokeOrExecuteMsig(
 			u.Error("Can't get receipt of the init tx. That tx might still be pending.")
 			return
 		}
-		for _, l := range txInfo.Receipt.Logs {
-			if strings.EqualFold(l.Address.Hex(), tc.To) &&
-				l.Topics[0].Hex() == "0xc0ba8fe4b176c1714197d43b9cc6bcf797a4a7461c5fe8d0ef6e184ae7601e51" {
-				txid = l.Topics[1].Big()
-				break
-			}
-		}
+		txid = util.GnosisMsigTxIDFromLogs(txInfo.Receipt.Logs, tc.To)
 		if txid == nil {
 			u.Error("The provided tx hash is not a gnosis multisig init tx or with a different multisig.")
 			return

--- a/util/gnosis_msig_test.go
+++ b/util/gnosis_msig_test.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const knownSubmissionTopic = "0xc0ba8fe4b176c1714197d43b9cc6bcf797a4a7461c5fe8d0ef6e184ae7601e51"
+
+func TestGnosisMsigSubmissionTopicMatchesABI(t *testing.T) {
+	ev, ok := GetGnosisMsigABI().Events["Submission"]
+	if !ok {
+		t.Fatal("built-in Classic ABI is missing the Submission event")
+	}
+	if ev.ID != GnosisMsigSubmissionTopic() {
+		t.Fatalf("helper %s != ABI event ID %s", GnosisMsigSubmissionTopic().Hex(), ev.ID.Hex())
+	}
+	want := common.HexToHash(knownSubmissionTopic)
+	if ev.ID != want {
+		t.Fatalf("Submission topic = %s, want %s (on-chain Classic event)", ev.ID.Hex(), want.Hex())
+	}
+}
+
+func TestGnosisMsigTxIDFromLogs(t *testing.T) {
+	msig := "0x1111111111111111111111111111111111111111"
+	other := "0x2222222222222222222222222222222222222222"
+	txid := common.BigToHash(big.NewInt(7))
+
+	logs := []*types.Log{
+		{Address: common.HexToAddress(other), Topics: []common.Hash{GnosisMsigSubmissionTopic(), txid}},
+		{Address: common.HexToAddress(msig), Topics: []common.Hash{common.HexToHash("0x01"), txid}},
+		{Address: common.HexToAddress(msig), Topics: []common.Hash{GnosisMsigSubmissionTopic(), txid}},
+	}
+
+	got := GnosisMsigTxIDFromLogs(logs, msig)
+	if got == nil || got.Cmp(big.NewInt(7)) != 0 {
+		t.Fatalf("got %v, want 7", got)
+	}
+	if GnosisMsigTxIDFromLogs(logs[:2], msig) != nil {
+		t.Fatal("expected nil when no matching Submission log")
+	}
+}

--- a/util/scan_txs_test.go
+++ b/util/scan_txs_test.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"testing"
+)
+
+const sampleTxHash = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const sampleTxHashBare = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func TestScanForTxsBareHash(t *testing.T) {
+	nwks, hashes := ScanForTxs(sampleTxHash)
+	if len(hashes) != 1 || hashes[0] != sampleTxHash {
+		t.Fatalf("hashes = %v, want [%s]", hashes, sampleTxHash)
+	}
+	if nwks[0] != "" {
+		t.Fatalf("network = %q, want empty", nwks[0])
+	}
+}
+
+func TestScanForTxsNetworkPrefix(t *testing.T) {
+	nwks, hashes := ScanForTxs("mainnet:" + sampleTxHash)
+	if len(hashes) != 1 || hashes[0] != sampleTxHash {
+		t.Fatalf("hashes = %v, want [%s]", hashes, sampleTxHash)
+	}
+	if nwks[0] != "mainnet" {
+		t.Fatalf("network = %q, want mainnet", nwks[0])
+	}
+}
+
+func TestScanForTxsNetworkPrefixCaseInsensitive(t *testing.T) {
+	nwks, hashes := ScanForTxs("MainNet:" + sampleTxHashBare)
+	if len(hashes) != 1 || hashes[0] != sampleTxHashBare {
+		t.Fatalf("hashes = %v, want [%s]", hashes, sampleTxHashBare)
+	}
+	if nwks[0] != "mainnet" {
+		t.Fatalf("network = %q, want mainnet", nwks[0])
+	}
+}
+
+func TestScanForTxsMultiple(t *testing.T) {
+	other := "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	nwks, hashes := ScanForTxs("mainnet:" + sampleTxHash + " " + other)
+	if len(hashes) != 2 {
+		t.Fatalf("got %d hashes, want 2", len(hashes))
+	}
+	if hashes[0] != sampleTxHash || hashes[1] != other {
+		t.Fatalf("hashes = %v", hashes)
+	}
+	if nwks[0] != "mainnet" || nwks[1] != "" {
+		t.Fatalf("nwks = %v", nwks)
+	}
+}
+
+func TestScanForTxsNone(t *testing.T) {
+	nwks, hashes := ScanForTxs("not a hash")
+	if len(nwks) != 0 || len(hashes) != 0 {
+		t.Fatalf("got nwks=%v hashes=%v, want empty", nwks, hashes)
+	}
+}
+
+func TestScanForTxHashes(t *testing.T) {
+	got := ScanForTxHashes("mainnet:" + sampleTxHash)
+	if len(got) != 1 || got[0] != sampleTxHash {
+		t.Fatalf("ScanForTxHashes = %v, want [%s]", got, sampleTxHash)
+	}
+	if empty := ScanForTxHashes(""); len(empty) != 0 {
+		t.Fatalf("empty input = %v, want []", empty)
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -219,13 +219,31 @@ func ValueToAmountAndCurrency(value string) (string, string, error) {
 	return amountStr, currency, nil
 }
 
-func ScanForTxs(para string) []string {
-	re := regexp.MustCompile("(0x)?[0-9a-fA-F]{64}")
-	result := re.FindAllString(para, -1)
-	if result == nil {
+// ScanForTxs finds network-prefixed or bare 32-byte transaction hashes.
+// nwks[i] is the lowercase network name when a prefix was present, else "".
+func ScanForTxs(para string) (nwks []string, hashes []string) {
+	networkNames := networks.GetSupportedNetworkNames()
+	regexStr := strings.Join(networkNames, "|")
+	regexStr = fmt.Sprintf(
+		"(?i)(?:(?P<network>%s)(?:.{0,}?))?(?P<address>(?:0x)?(?:[0-9a-fA-F]{64}))",
+		regexStr,
+	)
+
+	re := regexp.MustCompile(regexStr)
+	for _, match := range re.FindAllStringSubmatch(para, -1) {
+		nwks = append(nwks, strings.ToLower(match[1]))
+		hashes = append(hashes, match[2])
+	}
+	return
+}
+
+// ScanForTxHashes is ScanForTxs dropping the optional network prefixes.
+func ScanForTxHashes(para string) []string {
+	_, hashes := ScanForTxs(para)
+	if hashes == nil {
 		return []string{}
 	}
-	return result
+	return hashes
 }
 
 func ScanForAddresses(para string) []string {
@@ -864,6 +882,31 @@ func GetGnosisMsigABI() *abi.ABI {
 		panic(err)
 	}
 	return &result
+}
+
+// GnosisMsigSubmissionTopic is the Classic Gnosis multisig Submission event topic
+// (keccak of Submission(uint256)), taken from the built-in ABI.
+func GnosisMsigSubmissionTopic() common.Hash {
+	ev, ok := GetGnosisMsigABI().Events["Submission"]
+	if !ok {
+		panic("gnosis msig ABI missing Submission event")
+	}
+	return ev.ID
+}
+
+// GnosisMsigTxIDFromLogs returns the transactionId from the first Submission
+// log emitted by msigAddr, or nil if none is present.
+func GnosisMsigTxIDFromLogs(logs []*types.Log, msigAddr string) *big.Int {
+	topic := GnosisMsigSubmissionTopic()
+	for _, l := range logs {
+		if len(l.Topics) < 2 {
+			continue
+		}
+		if strings.EqualFold(l.Address.Hex(), msigAddr) && l.Topics[0] == topic {
+			return l.Topics[1].Big()
+		}
+	}
+	return nil
 }
 
 func GetABI(addr string, network networks.Network) (*abi.ABI, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
First wave of the remaining refactor plan: two isolated consistency fixes, no Classic/Safe merge.

**ScanForTxs**
- One network-aware scanner now lives in `util.ScanForTxs` (optional `mainnet:0x…` prefix + bare hash).
- `cmd/util.ScanForTxs` wraps it so msig/preprocess callers stay the same.
- `jarvis info` uses `ScanForTxHashes` and `CommonNetworkPreprocess` now peeks at a prefix before building the reader, matching function-call preprocess. An explicit `-N/--network` still wins.

**Classic Submission topic**
- `GnosisMsigSubmissionTopic` / `GnosisMsigTxIDFromLogs` read `Events["Submission"].ID` from the built-in ABI.
- `HandleApproveOrRevokeOrExecuteMsig` and `bapprove` use that helper instead of the hardcoded `0xc0ba8fe4…` hash.

**Behavior change (intentional):** `jarvis info mainnet:0x…` binds the reader to that network.

Tests: scanner prefixes, Submission topic == ABI event ID, log walk ignores non-matching address/topic.

This is PR 1 of the sequenced plan (amount-wei → pending loader → approve core → propose tail → mixed bapprove JSON → inject reader → split `safe.go`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0528c-a970-7072-8275-03dc95ef0b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0528c-a970-7072-8275-03dc95ef0b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

