### PR TITLE
Share send amount-to-wei helper across EOA, Classic, and Safe

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -154,6 +154,65 @@ func sendTransferUserErrorEOA(err error, to string) string {
 	return sendTransferUserError(err, to)
 }
 
+func sendAmountUserErrorClassic(err error, tokenAddr string) string {
+	cause := cmdutil.AmountWeiCause(err)
+	switch {
+	case errors.Is(err, cmdutil.ErrSendNativeBalance):
+		return fmt.Sprintf("Couldn't get balance of the multisig: %s", cause)
+	case errors.Is(err, cmdutil.ErrSendTokenBalance):
+		return fmt.Sprintf("Couldn't read balance of the multisig: %s", cause)
+	case errors.Is(err, cmdutil.ErrSendTokenDecimal):
+		return fmt.Sprintf("Couldn't get token decimal: %s", cause)
+	case errors.Is(err, cmdutil.ErrSendAmountParse):
+		if tokenAddr == util.ETH_ADDR {
+			return fmt.Sprintf("Couldn't calculate the amount: %s", cause)
+		}
+		return fmt.Sprintf("Couldn't calculate amount in wei: %s", cause)
+	default:
+		return err.Error()
+	}
+}
+
+func sendAmountUserErrorSafe(err error, tokenAddr string) string {
+	cause := cmdutil.AmountWeiCause(err)
+	switch {
+	case errors.Is(err, cmdutil.ErrSendNativeBalance):
+		return fmt.Sprintf("Couldn't get balance of the safe: %s", cause)
+	case errors.Is(err, cmdutil.ErrSendTokenBalance):
+		return fmt.Sprintf("Couldn't read token balance of the safe: %s", cause)
+	case errors.Is(err, cmdutil.ErrSendTokenDecimal):
+		return fmt.Sprintf("Couldn't get token decimal: %s", cause)
+	case errors.Is(err, cmdutil.ErrSendAmountParse):
+		if tokenAddr == util.ETH_ADDR {
+			return fmt.Sprintf("Couldn't calculate the amount: %s", cause)
+		}
+		return fmt.Sprintf("Couldn't calculate amount in wei: %s", cause)
+	default:
+		return err.Error()
+	}
+}
+
+func sendAmountUserErrorEOA(err error, tokenAddr string) string {
+	cause := cmdutil.AmountWeiCause(err)
+	switch {
+	case errors.Is(err, cmdutil.ErrSendInsufficientGas):
+		return "Wallet doesn't have enough token to cover gas. Aborted."
+	case errors.Is(err, cmdutil.ErrSendNativeBalance):
+		return fmt.Sprintf("Couldn't get %s balance: %s", config.Network().GetNativeTokenSymbol(), cause)
+	case errors.Is(err, cmdutil.ErrSendTokenBalance):
+		return fmt.Sprintf("Couldn't get token balance: %s", cause)
+	case errors.Is(err, cmdutil.ErrSendTokenDecimal):
+		return fmt.Sprintf("Couldn't get token decimal: %s", cause)
+	case errors.Is(err, cmdutil.ErrSendAmountParse):
+		if tokenAddr == util.ETH_ADDR {
+			return fmt.Sprintf("Couldn't calculate send amount: %s", cause)
+		}
+		return fmt.Sprintf("Couldn't calculate token amount in wei: %s", cause)
+	default:
+		return err.Error()
+	}
+}
+
 func sendFromMsig(reader utilreader.Reader, analyzer util.TxAnalyzer, resolver cmdutil.ABIResolver, bc cmdutil.TxBroadcaster) {
 	msigAddress, err := getMsigContractFromParams([]string{config.From}, resolver)
 	if err != nil {
@@ -209,41 +268,15 @@ func sendFromMsig(reader utilreader.Reader, analyzer util.TxAnalyzer, resolver c
 	}
 
 	// Resolve amountWei — must happen regardless of whether the user supplied a gas limit.
-	var amountWei *big.Int
-	if tokenAddrLocal == util.ETH_ADDR {
-		if amountStr == "ALL" {
-			ethBalance, err := reader.GetBalance(msigContractAddr)
-			if err != nil {
-				appUI.Error("Couldn't get balance of the multisig: %s", err)
-				return
-			}
-			amountWei = ethBalance
-		} else {
-			amountWei, err = jarviscommon.FloatStringToBig(amountStr, config.Network().GetNativeTokenDecimal())
-			if err != nil {
-				appUI.Error("Couldn't calculate the amount: %s", err)
-				return
-			}
-		}
-	} else {
-		if amountStr == "ALL" {
-			amountWei, err = reader.ERC20Balance(tokenAddrLocal, msigContractAddr)
-			if err != nil {
-				appUI.Error("Couldn't read balance of the multisig: %s", err)
-				return
-			}
-		} else {
-			decimals, err := reader.ERC20Decimal(tokenAddrLocal)
-			if err != nil {
-				appUI.Error("Couldn't get token decimal: %s", err)
-				return
-			}
-			amountWei, err = jarviscommon.FloatStringToBig(amountStr, decimals)
-			if err != nil {
-				appUI.Error("Couldn't calculate amount in wei: %s", err)
-				return
-			}
-		}
+	amountWei, err := cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
+		TokenAddr:      tokenAddrLocal,
+		AmountStr:      amountStr,
+		Holder:         msigContractAddr,
+		NativeDecimals: config.Network().GetNativeTokenDecimal(),
+	})
+	if err != nil {
+		appUI.Error("%s", sendAmountUserErrorClassic(err, tokenAddrLocal))
+		return
 	}
 
 	// Pack txdata — also must happen regardless of gas limit.
@@ -424,24 +457,30 @@ exact addresses start with 0x.`,
 					}
 					extraGasLimit = 0 // exact gas for ALL; no extra needed
 
-					ethBalance, err := reader.GetBalance(fromAddr)
-					if err != nil {
-						appUI.Error("Couldn't get %s balance: %s", config.Network().GetNativeTokenSymbol(), err)
-						return
-					}
 					gasCost := big.NewInt(0).Mul(
 						big.NewInt(int64(gasLimit)),
 						jarviscommon.FloatToBigInt(gasPrice+config.ExtraGasPrice, 9),
 					)
-					if ethBalance.Cmp(gasCost) == -1 {
-						appUI.Error("Wallet doesn't have enough token to cover gas. Aborted.")
+					amountWei, err = cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
+						TokenAddr:      tokenAddrLocal,
+						AmountStr:      amountStr,
+						Holder:         fromAddr,
+						NativeDecimals: config.Network().GetNativeTokenDecimal(),
+						SubtractGas:    gasCost,
+					})
+					if err != nil {
+						appUI.Error("%s", sendAmountUserErrorEOA(err, tokenAddrLocal))
 						return
 					}
-					amountWei = big.NewInt(0).Sub(ethBalance, gasCost)
 				} else {
-					amountWei, err = jarviscommon.FloatStringToBig(amountStr, config.Network().GetNativeTokenDecimal())
+					amountWei, err = cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
+						TokenAddr:      tokenAddrLocal,
+						AmountStr:      amountStr,
+						Holder:         fromAddr,
+						NativeDecimals: config.Network().GetNativeTokenDecimal(),
+					})
 					if err != nil {
-						appUI.Error("Couldn't calculate send amount: %s", err)
+						appUI.Error("%s", sendAmountUserErrorEOA(err, tokenAddrLocal))
 						return
 					}
 					gasLimit, err = reader.EstimateExactGas(fromAddr, toAddr, 0, amountWei, cmdutil.StringParamToBytes(data))
@@ -451,34 +490,20 @@ exact addresses start with 0x.`,
 					}
 				}
 			} else {
-				var innerData []byte
-				if amountStr == "ALL" {
-					amountWei, err = reader.ERC20Balance(tokenAddrLocal, fromAddr)
-					if err != nil {
-						appUI.Error("Couldn't get token balance: %s", err)
-						return
-					}
-					innerData, err = jarviscommon.PackERC20Data("transfer", jarviscommon.HexToAddress(toAddr), amountWei)
-					if err != nil {
-						appUI.Error("Couldn't pack data: %s", err)
-						return
-					}
-				} else {
-					decimals, err := reader.ERC20Decimal(tokenAddrLocal)
-					if err != nil {
-						appUI.Error("Couldn't get token decimal: %s", err)
-						return
-					}
-					amountWei, err = jarviscommon.FloatStringToBig(amountStr, decimals)
-					if err != nil {
-						appUI.Error("Couldn't calculate token amount in wei: %s", err)
-						return
-					}
-					innerData, err = jarviscommon.PackERC20Data("transfer", jarviscommon.HexToAddress(toAddr), amountWei)
-					if err != nil {
-						appUI.Error("Couldn't pack data: %s", err)
-						return
-					}
+				amountWei, err = cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
+					TokenAddr:      tokenAddrLocal,
+					AmountStr:      amountStr,
+					Holder:         fromAddr,
+					NativeDecimals: config.Network().GetNativeTokenDecimal(),
+				})
+				if err != nil {
+					appUI.Error("%s", sendAmountUserErrorEOA(err, tokenAddrLocal))
+					return
+				}
+				innerData, err := jarviscommon.PackERC20Data("transfer", jarviscommon.HexToAddress(toAddr), amountWei)
+				if err != nil {
+					appUI.Error("Couldn't pack data: %s", err)
+					return
 				}
 				gasLimit, err = reader.EstimateGas(fromAddr, tokenAddrLocal, gasPrice+config.ExtraGasPrice, 0, innerData)
 				if err != nil {
@@ -602,41 +627,15 @@ func sendFromSafe(
 
 	// Compute the wei amount the Safe should move. ALL refers to the
 	// Safe's balance, NOT the EOA's, mirroring sendFromMsig semantics.
-	var amountWei *big.Int
-	if tokenAddrLocal == util.ETH_ADDR {
-		if amountStr == "ALL" {
-			ethBalance, err := reader.GetBalance(safeContract.Address)
-			if err != nil {
-				appUI.Error("Couldn't get balance of the safe: %s", err)
-				return
-			}
-			amountWei = ethBalance
-		} else {
-			amountWei, err = jarviscommon.FloatStringToBig(amountStr, config.Network().GetNativeTokenDecimal())
-			if err != nil {
-				appUI.Error("Couldn't calculate the amount: %s", err)
-				return
-			}
-		}
-	} else {
-		if amountStr == "ALL" {
-			amountWei, err = reader.ERC20Balance(tokenAddrLocal, safeContract.Address)
-			if err != nil {
-				appUI.Error("Couldn't read token balance of the safe: %s", err)
-				return
-			}
-		} else {
-			decimals, err := reader.ERC20Decimal(tokenAddrLocal)
-			if err != nil {
-				appUI.Error("Couldn't get token decimal: %s", err)
-				return
-			}
-			amountWei, err = jarviscommon.FloatStringToBig(amountStr, decimals)
-			if err != nil {
-				appUI.Error("Couldn't calculate amount in wei: %s", err)
-				return
-			}
-		}
+	amountWei, err := cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
+		TokenAddr:      tokenAddrLocal,
+		AmountStr:      amountStr,
+		Holder:         safeContract.Address,
+		NativeDecimals: config.Network().GetNativeTokenDecimal(),
+	})
+	if err != nil {
+		appUI.Error("%s", sendAmountUserErrorSafe(err, tokenAddrLocal))
+		return
 	}
 
 	// Inner SafeTx call: native send carries (to, value, --data); ERC20

--- a/cmd/send_amount_error_test.go
+++ b/cmd/send_amount_error_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	cmdutil "github.com/tranvictor/jarvis/cmd/util"
+	"github.com/tranvictor/jarvis/config"
+	"github.com/tranvictor/jarvis/util"
+)
+
+func TestSendAmountUserErrorPreservesMessages(t *testing.T) {
+	rpc := errors.New("rpc failed")
+	nativeBal := fmt.Errorf("%w: %w", cmdutil.ErrSendNativeBalance, rpc)
+	tokenBal := fmt.Errorf("%w: %w", cmdutil.ErrSendTokenBalance, rpc)
+	decimals := fmt.Errorf("%w: %w", cmdutil.ErrSendTokenDecimal, rpc)
+	parse := fmt.Errorf("%w: %w", cmdutil.ErrSendAmountParse, rpc)
+
+	if got := sendAmountUserErrorClassic(nativeBal, util.ETH_ADDR); got != "Couldn't get balance of the multisig: rpc failed" {
+		t.Fatalf("classic native ALL: %q", got)
+	}
+	if got := sendAmountUserErrorClassic(parse, util.ETH_ADDR); got != "Couldn't calculate the amount: rpc failed" {
+		t.Fatalf("classic native parse: %q", got)
+	}
+	if got := sendAmountUserErrorClassic(tokenBal, "0x1"); got != "Couldn't read balance of the multisig: rpc failed" {
+		t.Fatalf("classic token ALL: %q", got)
+	}
+	if got := sendAmountUserErrorClassic(decimals, "0x1"); got != "Couldn't get token decimal: rpc failed" {
+		t.Fatalf("classic decimals: %q", got)
+	}
+	if got := sendAmountUserErrorClassic(parse, "0x1"); got != "Couldn't calculate amount in wei: rpc failed" {
+		t.Fatalf("classic token parse: %q", got)
+	}
+
+	if got := sendAmountUserErrorSafe(nativeBal, util.ETH_ADDR); got != "Couldn't get balance of the safe: rpc failed" {
+		t.Fatalf("safe native ALL: %q", got)
+	}
+	if got := sendAmountUserErrorSafe(tokenBal, "0x1"); got != "Couldn't read token balance of the safe: rpc failed" {
+		t.Fatalf("safe token ALL: %q", got)
+	}
+	if got := sendAmountUserErrorSafe(parse, util.ETH_ADDR); got != "Couldn't calculate the amount: rpc failed" {
+		t.Fatalf("safe native parse: %q", got)
+	}
+	if got := sendAmountUserErrorSafe(parse, "0x1"); got != "Couldn't calculate amount in wei: rpc failed" {
+		t.Fatalf("safe token parse: %q", got)
+	}
+
+	if err := config.SetNetwork("mainnet"); err != nil {
+		t.Fatal(err)
+	}
+	if got := sendAmountUserErrorEOA(cmdutil.ErrSendInsufficientGas, util.ETH_ADDR); got != "Wallet doesn't have enough token to cover gas. Aborted." {
+		t.Fatalf("eoa gas: %q", got)
+	}
+	if got := sendAmountUserErrorEOA(nativeBal, util.ETH_ADDR); got != "Couldn't get ETH balance: rpc failed" {
+		t.Fatalf("eoa native ALL: %q", got)
+	}
+	if got := sendAmountUserErrorEOA(parse, util.ETH_ADDR); got != "Couldn't calculate send amount: rpc failed" {
+		t.Fatalf("eoa native parse: %q", got)
+	}
+	if got := sendAmountUserErrorEOA(tokenBal, "0x1"); got != "Couldn't get token balance: rpc failed" {
+		t.Fatalf("eoa token ALL: %q", got)
+	}
+	if got := sendAmountUserErrorEOA(parse, "0x1"); got != "Couldn't calculate token amount in wei: rpc failed" {
+		t.Fatalf("eoa token parse: %q", got)
+	}
+}

--- a/cmd/util/send_amount.go
+++ b/cmd/util/send_amount.go
@@ -1,0 +1,101 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	jarvisutil "github.com/tranvictor/jarvis/util"
+)
+
+var (
+	ErrSendNativeBalance   = errors.New("couldn't get native balance")
+	ErrSendTokenBalance    = errors.New("couldn't get token balance")
+	ErrSendTokenDecimal    = errors.New("couldn't get token decimal")
+	ErrSendAmountParse     = errors.New("couldn't calculate amount")
+	ErrSendInsufficientGas = errors.New("insufficient balance to cover gas")
+)
+
+// BalanceReader is the subset of util/reader.Reader used to turn an
+// amount string into wei.
+type BalanceReader interface {
+	GetBalance(address string) (*big.Int, error)
+	ERC20Balance(caddr string, user string) (*big.Int, error)
+	ERC20Decimal(caddr string) (uint64, error)
+}
+
+// AmountWeiOpts controls ResolveSendAmountWei.
+// Holder is the address ALL reads (EOA, Classic msig, or Safe).
+// SubtractGas, when non-nil, is subtracted from a native ALL balance
+// (EOA send); Classic/Safe leave it nil so ALL is the full holder balance.
+type AmountWeiOpts struct {
+	TokenAddr      string
+	AmountStr      string
+	Holder         string
+	NativeDecimals uint64
+	SubtractGas    *big.Int
+}
+
+// ResolveSendAmountWei converts AmountStr (`ALL` or a decimal float) to wei.
+func ResolveSendAmountWei(r BalanceReader, opts AmountWeiOpts) (*big.Int, error) {
+	if opts.TokenAddr == jarvisutil.ETH_ADDR {
+		if opts.AmountStr == "ALL" {
+			bal, err := r.GetBalance(opts.Holder)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrSendNativeBalance, err)
+			}
+			if opts.SubtractGas != nil {
+				if bal.Cmp(opts.SubtractGas) < 0 {
+					return nil, ErrSendInsufficientGas
+				}
+				return new(big.Int).Sub(bal, opts.SubtractGas), nil
+			}
+			return bal, nil
+		}
+		amount, err := jarviscommon.FloatStringToBig(opts.AmountStr, opts.NativeDecimals)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrSendAmountParse, err)
+		}
+		return amount, nil
+	}
+
+	if opts.AmountStr == "ALL" {
+		bal, err := r.ERC20Balance(opts.TokenAddr, opts.Holder)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrSendTokenBalance, err)
+		}
+		return bal, nil
+	}
+	decimals, err := r.ERC20Decimal(opts.TokenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrSendTokenDecimal, err)
+	}
+	amount, err := jarviscommon.FloatStringToBig(opts.AmountStr, decimals)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrSendAmountParse, err)
+	}
+	return amount, nil
+}
+
+// AmountWeiCause returns the wrapped reader/parse error text so callers
+// can keep their original "Couldn't …: %s" strings.
+func AmountWeiCause(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	for _, s := range []error{
+		ErrSendNativeBalance,
+		ErrSendTokenBalance,
+		ErrSendTokenDecimal,
+		ErrSendAmountParse,
+	} {
+		prefix := s.Error() + ": "
+		if strings.HasPrefix(msg, prefix) {
+			return strings.TrimPrefix(msg, prefix)
+		}
+	}
+	return msg
+}

--- a/cmd/util/send_amount_test.go
+++ b/cmd/util/send_amount_test.go
@@ -1,0 +1,207 @@
+package util
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	jarvisutil "github.com/tranvictor/jarvis/util"
+)
+
+type stubBalanceReader struct {
+	native        *big.Int
+	token         *big.Int
+	decimals      uint64
+	errNative     error
+	errToken      error
+	errDecimals   error
+	lastHolder    string
+	lastToken     string
+	lastTokenUser string
+}
+
+func (s *stubBalanceReader) GetBalance(address string) (*big.Int, error) {
+	s.lastHolder = address
+	if s.errNative != nil {
+		return nil, s.errNative
+	}
+	if s.native == nil {
+		return big.NewInt(0), nil
+	}
+	return new(big.Int).Set(s.native), nil
+}
+
+func (s *stubBalanceReader) ERC20Balance(caddr, user string) (*big.Int, error) {
+	s.lastToken = caddr
+	s.lastTokenUser = user
+	if s.errToken != nil {
+		return nil, s.errToken
+	}
+	if s.token == nil {
+		return big.NewInt(0), nil
+	}
+	return new(big.Int).Set(s.token), nil
+}
+
+func (s *stubBalanceReader) ERC20Decimal(string) (uint64, error) {
+	if s.errDecimals != nil {
+		return 0, s.errDecimals
+	}
+	if s.decimals == 0 {
+		return 18, nil
+	}
+	return s.decimals, nil
+}
+
+const (
+	testHolder = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testToken  = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func TestResolveSendAmountWeiNativeFixed(t *testing.T) {
+	got, err := ResolveSendAmountWei(&stubBalanceReader{}, AmountWeiOpts{
+		TokenAddr:      jarvisutil.ETH_ADDR,
+		AmountStr:      "1.5",
+		Holder:         testHolder,
+		NativeDecimals: 18,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := new(big.Int).Mul(big.NewInt(15), new(big.Int).Exp(big.NewInt(10), big.NewInt(17), nil))
+	if got.Cmp(want) != 0 {
+		t.Fatalf("got %s want %s", got, want)
+	}
+}
+
+func TestResolveSendAmountWeiNativeALLHolder(t *testing.T) {
+	r := &stubBalanceReader{native: big.NewInt(1000)}
+	got, err := ResolveSendAmountWei(r, AmountWeiOpts{
+		TokenAddr:      jarvisutil.ETH_ADDR,
+		AmountStr:      "ALL",
+		Holder:         testHolder,
+		NativeDecimals: 18,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.lastHolder != testHolder {
+		t.Fatalf("holder %s", r.lastHolder)
+	}
+	if got.Cmp(big.NewInt(1000)) != 0 {
+		t.Fatalf("got %s", got)
+	}
+}
+
+func TestResolveSendAmountWeiNativeALLSubtractsGas(t *testing.T) {
+	r := &stubBalanceReader{native: big.NewInt(1000)}
+	got, err := ResolveSendAmountWei(r, AmountWeiOpts{
+		TokenAddr:      jarvisutil.ETH_ADDR,
+		AmountStr:      "ALL",
+		Holder:         testHolder,
+		NativeDecimals: 18,
+		SubtractGas:    big.NewInt(21),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cmp(big.NewInt(979)) != 0 {
+		t.Fatalf("got %s want 979", got)
+	}
+}
+
+func TestResolveSendAmountWeiNativeALLInsufficientGas(t *testing.T) {
+	r := &stubBalanceReader{native: big.NewInt(100)}
+	_, err := ResolveSendAmountWei(r, AmountWeiOpts{
+		TokenAddr:      jarvisutil.ETH_ADDR,
+		AmountStr:      "ALL",
+		Holder:         testHolder,
+		NativeDecimals: 18,
+		SubtractGas:    big.NewInt(21000),
+	})
+	if !errors.Is(err, ErrSendInsufficientGas) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestResolveSendAmountWeiERC20ALL(t *testing.T) {
+	r := &stubBalanceReader{token: big.NewInt(42)}
+	got, err := ResolveSendAmountWei(r, AmountWeiOpts{
+		TokenAddr:      testToken,
+		AmountStr:      "ALL",
+		Holder:         testHolder,
+		NativeDecimals: 18,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.lastToken != testToken || r.lastTokenUser != testHolder {
+		t.Fatalf("token=%s user=%s", r.lastToken, r.lastTokenUser)
+	}
+	if got.Cmp(big.NewInt(42)) != 0 {
+		t.Fatalf("got %s", got)
+	}
+}
+
+func TestResolveSendAmountWeiERC20Fixed(t *testing.T) {
+	r := &stubBalanceReader{decimals: 6}
+	got, err := ResolveSendAmountWei(r, AmountWeiOpts{
+		TokenAddr:      testToken,
+		AmountStr:      "1.5",
+		Holder:         testHolder,
+		NativeDecimals: 18,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cmp(big.NewInt(1500000)) != 0 {
+		t.Fatalf("got %s want 1500000", got)
+	}
+}
+
+func TestResolveSendAmountWeiErrors(t *testing.T) {
+	_, err := ResolveSendAmountWei(&stubBalanceReader{errNative: errors.New("rpc")}, AmountWeiOpts{
+		TokenAddr: jarvisutil.ETH_ADDR, AmountStr: "ALL", Holder: testHolder, NativeDecimals: 18,
+	})
+	if !errors.Is(err, ErrSendNativeBalance) {
+		t.Fatalf("native: %v", err)
+	}
+
+	_, err = ResolveSendAmountWei(&stubBalanceReader{errToken: errors.New("rpc")}, AmountWeiOpts{
+		TokenAddr: testToken, AmountStr: "ALL", Holder: testHolder, NativeDecimals: 18,
+	})
+	if !errors.Is(err, ErrSendTokenBalance) {
+		t.Fatalf("token bal: %v", err)
+	}
+
+	_, err = ResolveSendAmountWei(&stubBalanceReader{errDecimals: errors.New("rpc")}, AmountWeiOpts{
+		TokenAddr: testToken, AmountStr: "1", Holder: testHolder, NativeDecimals: 18,
+	})
+	if !errors.Is(err, ErrSendTokenDecimal) {
+		t.Fatalf("decimals: %v", err)
+	}
+
+	_, err = ResolveSendAmountWei(&stubBalanceReader{}, AmountWeiOpts{
+		TokenAddr: jarvisutil.ETH_ADDR, AmountStr: "nope", Holder: testHolder, NativeDecimals: 18,
+	})
+	if !errors.Is(err, ErrSendAmountParse) {
+		t.Fatalf("parse: %v", err)
+	}
+}
+
+func TestAmountWeiCause(t *testing.T) {
+	err := fmtWrapNative()
+	if AmountWeiCause(err) != "rpc down" {
+		t.Fatalf("cause = %q", AmountWeiCause(err))
+	}
+	if AmountWeiCause(ErrSendInsufficientGas) != ErrSendInsufficientGas.Error() {
+		t.Fatalf("bare sentinel: %q", AmountWeiCause(ErrSendInsufficientGas))
+	}
+}
+
+func fmtWrapNative() error {
+	_, err := ResolveSendAmountWei(&stubBalanceReader{errNative: errors.New("rpc down")}, AmountWeiOpts{
+		TokenAddr: jarvisutil.ETH_ADDR, AmountStr: "ALL", Holder: testHolder, NativeDecimals: 18,
+	})
+	return err
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Second wave of the remaining refactor plan. Independent of #93.

`ResolveSendAmountWei` owns native/ERC-20 × fixed/`ALL` conversion. Callers pass a holder and an optional gas cost:

- Classic / Safe: `ALL` is the holder (msig/safe) balance.
- EOA native `ALL`: still estimates gas first, then subtracts that cost. Insufficient gas is still `Wallet doesn't have enough token to cover gas. Aborted.`

Per-path error strings are unchanged (`sendAmountUserErrorClassic` / `Safe` / `EOA`), same sentinel pattern as `ResolveSendTransfer`.

Gas estimation, packing, and confirm/display stay in each caller.

Tests: native/ERC-20 × fixed/`ALL`, gas subtract, insufficient gas, reader/parse sentinels, and CLI message mapping.

Next in the sequence: pending Safe tx loader (#4), then approve core, then propose tail. This PR does not depend on #93 and can merge in either order.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0528c-a970-7072-8275-03dc95ef0b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0528c-a970-7072-8275-03dc95ef0b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

