### PR TITLE
Share Safe approve hash, sign, and persist helpers

### DIFF
--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -573,16 +573,13 @@ over an off-chain signature store. Other owners' off-chain signatures
 		// corner case above we only have the hash, so there's nothing to
 		// cross-check — the Safe itself will reject a wrong hash at
 		// approveHash / execute time.
-		if pending.SafeTx != nil {
-			expected := pending.SafeTx.SafeTxHash(domainSep)
-			if expected != pending.SafeTxHash {
-				appUI.Error(
-					"declared safeTxHash (0x%s) doesn't match locally recomputed hash (0x%s); refusing to sign",
-					ethcommon.Bytes2Hex(pending.SafeTxHash[:]),
-					ethcommon.Bytes2Hex(expected[:]),
-				)
-				return
-			}
+		if expected, err := verifyPendingSafeTxHash(pending, domainSep); errors.Is(err, errPendingHashMismatch) {
+			appUI.Error(
+				"declared safeTxHash (0x%s) doesn't match locally recomputed hash (0x%s); refusing to sign",
+				ethcommon.Bytes2Hex(pending.SafeTxHash[:]),
+				ethcommon.Bytes2Hex(expected[:]),
+			)
+			return
 		}
 
 		// Merge on-chain approvals into the in-memory Sigs before the
@@ -601,15 +598,13 @@ over an off-chain signature store. Other owners' off-chain signatures
 		showSafeSigners("Existing signatures", pending.Sigs)
 
 		me := ethcommon.HexToAddress(tc.From)
-		for _, s := range pending.Sigs {
-			if s.Owner == me {
-				if safe.IsOnChainApproval(s.Sig) {
-					appUI.Warn("You (%s) have already approved this transaction on-chain (approveHash).", me.Hex())
-				} else {
-					appUI.Warn("You (%s) have already signed this transaction off-chain.", me.Hex())
-				}
-				return
+		if onChain, found := ownerAlreadySigned(pending, me); found {
+			if onChain {
+				appUI.Warn("You (%s) have already approved this transaction on-chain (approveHash).", me.Hex())
+			} else {
+				appUI.Warn("You (%s) have already signed this transaction off-chain.", me.Hex())
 			}
+			return
 		}
 
 		if safeApproveOnChain {
@@ -628,41 +623,30 @@ over an off-chain signature store. Other owners' off-chain signatures
 		}
 
 		appUI.Info("Unlock your wallet and sign the EIP-712 safeTxHash now...")
-		account, err := accounts.UnlockAccount(tc.FromAcc)
-		if err != nil {
-			appUI.Error("Couldn't unlock wallet: %s", err)
+		sig, err := signPendingSafeTx(tc.FromAcc, pending, domainSep)
+		if errors.Is(err, errSignSafeHash) {
+			appUI.Error("Couldn't sign safeTxHash: %s", signCause(err))
 			return
 		}
-
-		structHash := pending.SafeTx.StructHash()
-		sig, err := account.SignSafeHash(domainSep, structHash)
 		if err != nil {
-			appUI.Error("Couldn't sign safeTxHash: %s", err)
+			appUI.Error("Couldn't unlock wallet: %s", err)
 			return
 		}
 
 		// Persist the new signature. In file mode we append to the file
 		// (the collective source of truth); otherwise we POST to the Safe
 		// Transaction Service.
-		if safeTxFile != "" {
-			updatedSigs := append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{
-				Owner: me, Sig: sig,
-			})
-			if err := safe.WriteTxFile(
-				safeTxFile,
-				safeContract.Address,
-				config.Network().GetChainID(),
-				pending.SafeTx, pending.SafeTxHash, updatedSigs,
-			); err != nil {
+		if err := persistApproval(tc, safeContract.Address, pending, me, sig, safeTxFile, config.Network().GetChainID()); err != nil {
+			if safeTxFile != "" {
 				appUI.Error("Couldn't write updated Safe tx file: %s", err)
-				return
+			} else {
+				appUI.Error("Submitting confirmation to Safe Transaction Service failed: %s", err)
 			}
+			return
+		}
+		if safeTxFile != "" {
 			appUI.Success("Signature appended to %s", safeTxFile)
 		} else {
-			if err := tc.Collector.Confirm(pending.SafeTxHash, me, sig); err != nil {
-				appUI.Error("Submitting confirmation to Safe Transaction Service failed: %s", err)
-				return
-			}
 			appUI.Success("Confirmation submitted.")
 		}
 		totalSigs := len(pending.Sigs) + 1
@@ -703,12 +687,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 			return
 		}
 
-		augmented := *pending
-		augmented.Sigs = append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{
-			Owner: me,
-			Sig:   sig,
-		})
-		runSafeExecute(tc, safeContract, &augmented, domainSep)
+		runSafeExecute(tc, safeContract, pendingWithNewSig(pending, me, sig), domainSep)
 	},
 }
 
@@ -1456,7 +1435,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		appUI.Error("%s", res.reason)
 		return res
 	}
-	if expected := pending.SafeTx.SafeTxHash(domainSep); expected != pending.SafeTxHash {
+	if _, err := verifyPendingSafeTxHash(pending, domainSep); errors.Is(err, errPendingHashMismatch) {
 		res.status = "failed"
 		res.reason = "service safeTxHash doesn't match locally recomputed hash"
 		appUI.Error("%s", res.reason)
@@ -1473,17 +1452,15 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 	}
 
 	me := ethcommon.HexToAddress(fromAcc.Address)
-	for _, s := range pending.Sigs {
-		if s.Owner == me {
-			res.status = "skipped"
-			if safe.IsOnChainApproval(s.Sig) {
-				res.reason = fmt.Sprintf("%s already approved on-chain", me.Hex())
-			} else {
-				res.reason = fmt.Sprintf("%s already signed off-chain", me.Hex())
-			}
-			appUI.Warn("%s", res.reason)
-			return res
+	if onChain, found := ownerAlreadySigned(pending, me); found {
+		res.status = "skipped"
+		if onChain {
+			res.reason = fmt.Sprintf("%s already approved on-chain", me.Hex())
+		} else {
+			res.reason = fmt.Sprintf("%s already signed off-chain", me.Hex())
 		}
+		appUI.Warn("%s", res.reason)
+		return res
 	}
 
 	// Build a TxContext rich enough for showSafeTxToConfirm and (for the
@@ -1526,7 +1503,13 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 	}
 
 	appUI.Info("Unlock %s and sign the EIP-712 safeTxHash now...", fromAcc.Address)
-	account, err := accounts.UnlockAccount(fromAcc)
+	sig, err := signPendingSafeTx(fromAcc, pending, domainSep)
+	if errors.Is(err, errSignSafeHash) {
+		res.status = "failed"
+		res.reason = fmt.Sprintf("sign safeTxHash: %s", signCause(err))
+		appUI.Error("%s", res.reason)
+		return res
+	}
 	if err != nil {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("unlock wallet: %s", err)
@@ -1534,16 +1517,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		return res
 	}
 
-	structHash := pending.SafeTx.StructHash()
-	sig, err := account.SignSafeHash(domainSep, structHash)
-	if err != nil {
-		res.status = "failed"
-		res.reason = fmt.Sprintf("sign safeTxHash: %s", err)
-		appUI.Error("%s", res.reason)
-		return res
-	}
-
-	if err := collector.Confirm(pending.SafeTxHash, me, sig); err != nil {
+	if err := persistApproval(tc, safeContract.Address, pending, me, sig, "", network.GetChainID()); err != nil {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("submit confirmation: %s", err)
 		appUI.Error("%s", res.reason)
@@ -1568,11 +1542,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		return res
 	}
 
-	augmented := *pending
-	augmented.Sigs = append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{
-		Owner: me, Sig: sig,
-	})
-	runSafeExecute(tc, safeContract, &augmented, domainSep)
+	runSafeExecute(tc, safeContract, pendingWithNewSig(pending, me, sig), domainSep)
 	res.confirmType = "approve+execute"
 	res.status = "executed"
 	return res
@@ -1994,9 +1964,79 @@ func nextSafeNonce(s *safe.SafeContract, c safe.SignatureCollector) (uint64, err
 }
 
 var (
-	errPendingNoCollector = errors.New("safe transaction service is not available")
-	errPendingNeedHash    = errors.New("on-chain approve without a service requires an explicit safeTxHash")
+	errPendingNoCollector  = errors.New("safe transaction service is not available")
+	errPendingNeedHash     = errors.New("on-chain approve without a service requires an explicit safeTxHash")
+	errPendingHashMismatch = errors.New("safeTxHash mismatch")
+	errSignSafeHash        = errors.New("sign safeTxHash")
 )
+
+// verifyPendingSafeTxHash recomputes the EIP-712 hash when a SafeTx body
+// is present. Hash-only --approve-onchain stubs skip the check (nil error).
+func verifyPendingSafeTxHash(pending *safe.PendingTx, domainSep [32]byte) ([32]byte, error) {
+	var expected [32]byte
+	if pending == nil || pending.SafeTx == nil {
+		return expected, nil
+	}
+	expected = pending.SafeTx.SafeTxHash(domainSep)
+	if expected != pending.SafeTxHash {
+		return expected, errPendingHashMismatch
+	}
+	return expected, nil
+}
+
+func ownerAlreadySigned(pending *safe.PendingTx, me ethcommon.Address) (onChain bool, found bool) {
+	if pending == nil {
+		return false, false
+	}
+	for _, s := range pending.Sigs {
+		if s.Owner == me {
+			return safe.IsOnChainApproval(s.Sig), true
+		}
+	}
+	return false, false
+}
+
+func signPendingSafeTx(fromAcc jtypes.AccDesc, pending *safe.PendingTx, domainSep [32]byte) ([]byte, error) {
+	account, err := accounts.UnlockAccount(fromAcc)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := account.SignSafeHash(domainSep, pending.SafeTx.StructHash())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errSignSafeHash, err)
+	}
+	return sig, nil
+}
+
+func signCause(err error) string {
+	prefix := errSignSafeHash.Error() + ": "
+	if strings.HasPrefix(err.Error(), prefix) {
+		return strings.TrimPrefix(err.Error(), prefix)
+	}
+	return err.Error()
+}
+
+func persistApproval(
+	tc cmdutil.TxContext,
+	safeAddr string,
+	pending *safe.PendingTx,
+	me ethcommon.Address,
+	sig []byte,
+	file string,
+	chainID uint64,
+) error {
+	if file != "" {
+		updated := append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{Owner: me, Sig: sig})
+		return safe.WriteTxFile(file, safeAddr, chainID, pending.SafeTx, pending.SafeTxHash, updated)
+	}
+	return tc.Collector.Confirm(pending.SafeTxHash, me, sig)
+}
+
+func pendingWithNewSig(pending *safe.PendingTx, me ethcommon.Address, sig []byte) *safe.PendingTx {
+	augmented := *pending
+	augmented.Sigs = append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{Owner: me, Sig: sig})
+	return &augmented
+}
 
 // loadPendingTx is the shared pending-tx source selector for approve /
 // execute / info: local file, Safe Transaction Service, or (approve only)

--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -536,61 +536,25 @@ over an off-chain signature store. Other owners' off-chain signatures
 		appUI.Section("Safe info")
 		showSafeInfo(safeContract)
 
-		var pending *safe.PendingTx
-		var err error
-		useFile := safeTxFile != ""
-		if useFile {
-			_, pending, err = loadPendingFromTxFile(tc, safeTxFile)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-		} else {
-			if tc.Collector == nil && !safeApproveOnChain {
-				appUI.Error(
-					"Safe Transaction Service is not available for chain %d.",
-					config.Network().GetChainID(),
-				)
-				appUI.Info("Pass --approve-onchain to approve via Safe.approveHash directly, or")
-				appUI.Info("pass --safe-tx-file <path> to load the pending SafeTx from a local file.")
-				return
-			}
-			if tc.Collector == nil && safeApproveOnChain {
-				// On-chain approval without a Tx Service: we need the
-				// safeTxHash directly (can't list the queue). The caller
-				// must have passed it as an argument or via a Safe-app URL.
-				if tc.SafeAppRef != nil && tc.SafeAppRef.HasTxHash() {
-					var hash [32]byte
-					copy(hash[:], tc.SafeAppRef.SafeTxHash[:])
-					pending = &safe.PendingTx{
-						Safe:       ethcommon.HexToAddress(safeContract.Address),
-						SafeTxHash: hash,
-					}
-				} else if len(args) >= 2 && strings.HasPrefix(strings.ToLower(strings.TrimSpace(args[1])), "0x") && len(strings.TrimSpace(args[1])) == 66 {
-					var hash [32]byte
-					copy(hash[:], ethcommon.FromHex(strings.TrimSpace(args[1])))
-					pending = &safe.PendingTx{
-						Safe:       ethcommon.HexToAddress(safeContract.Address),
-						SafeTxHash: hash,
-					}
-				} else {
-					appUI.Error(
-						"--approve-onchain without a Safe Transaction Service requires an explicit safeTxHash (0x... 32 bytes) or a Safe-app URL that carries one.",
-					)
-					return
-				}
-			} else {
-				identifier, err := pickPendingTxIdentifier(tc, args)
-				if err != nil {
-					appUI.Error("%s", err)
-					return
-				}
-				pending, err = resolvePendingTx(tc, identifier)
-				if err != nil {
-					appUI.Error("%s", err)
-					return
-				}
-			}
+		pending, err := loadPendingTx(tc, args, safeTxFile, safeApproveOnChain)
+		if errors.Is(err, errPendingNoCollector) {
+			appUI.Error(
+				"Safe Transaction Service is not available for chain %d.",
+				config.Network().GetChainID(),
+			)
+			appUI.Info("Pass --approve-onchain to approve via Safe.approveHash directly, or")
+			appUI.Info("pass --safe-tx-file <path> to load the pending SafeTx from a local file.")
+			return
+		}
+		if errors.Is(err, errPendingNeedHash) {
+			appUI.Error(
+				"--approve-onchain without a Safe Transaction Service requires an explicit safeTxHash (0x... 32 bytes) or a Safe-app URL that carries one.",
+			)
+			return
+		}
+		if err != nil {
+			appUI.Error("%s", err)
+			return
 		}
 		if pending.IsExecuted {
 			appUI.Warn("This transaction has already been executed; nothing to approve.")
@@ -680,7 +644,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 		// Persist the new signature. In file mode we append to the file
 		// (the collective source of truth); otherwise we POST to the Safe
 		// Transaction Service.
-		if useFile {
+		if safeTxFile != "" {
 			updatedSigs := append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{
 				Owner: me, Sig: sig,
 			})
@@ -710,7 +674,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 			return
 		}
 		nextCmdHint := fmt.Sprintf("  jarvis msig execute %s 0x%s%s", safeContract.Address, ethcommon.Bytes2Hex(pending.SafeTxHash[:]), networkFlag())
-		if useFile {
+		if safeTxFile != "" {
 			nextCmdHint = fmt.Sprintf("  jarvis msig execute %s --safe-tx-file %s%s", safeContract.Address, safeTxFile, networkFlag())
 		}
 		if uint64(totalSigs) < threshold {
@@ -928,33 +892,18 @@ The pending tx can be identified by:
 		appUI.Section("Safe info")
 		showSafeInfo(safeContract)
 
-		var pending *safe.PendingTx
-		var err error
-		if safeTxFile != "" {
-			_, pending, err = loadPendingFromTxFile(tc, safeTxFile)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-		} else {
-			if tc.Collector == nil {
-				appUI.Error(
-					"Safe Transaction Service is not available for chain %d, and --safe-tx-file was not set.",
-					config.Network().GetChainID(),
-				)
-				appUI.Info("Pass --safe-tx-file <path> to execute from a local file, or configure SAFE_TX_SERVICE_URL_%d.", config.Network().GetChainID())
-				return
-			}
-			identifier, err := pickPendingTxIdentifier(tc, args)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-			pending, err = resolvePendingTx(tc, identifier)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
+		pending, err := loadPendingTx(tc, args, safeTxFile, false)
+		if errors.Is(err, errPendingNoCollector) {
+			appUI.Error(
+				"Safe Transaction Service is not available for chain %d, and --safe-tx-file was not set.",
+				config.Network().GetChainID(),
+			)
+			appUI.Info("Pass --safe-tx-file <path> to execute from a local file, or configure SAFE_TX_SERVICE_URL_%d.", config.Network().GetChainID())
+			return
+		}
+		if err != nil {
+			appUI.Error("%s", err)
+			return
 		}
 		if pending.IsExecuted {
 			appUI.Warn("This transaction has already been executed.")
@@ -1057,33 +1006,18 @@ Equivalent to ` + "`jarvis msig info`" + ` for Gnosis Classic.`,
 		appUI.Section("Safe info")
 		showSafeInfo(safeContract)
 
-		var pending *safe.PendingTx
-		var err error
-		if safeTxFile != "" {
-			_, pending, err = loadPendingFromTxFile(tc, safeTxFile)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-		} else {
-			if tc.Collector == nil {
-				appUI.Error(
-					"Safe Transaction Service is not available for chain %d, and --safe-tx-file was not set.",
-					config.Network().GetChainID(),
-				)
-				appUI.Info("Pass --safe-tx-file <path> to inspect a local Safe tx file, or configure SAFE_TX_SERVICE_URL_%d.", config.Network().GetChainID())
-				return
-			}
-			identifier, err := pickPendingTxIdentifier(tc, args)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-			pending, err = resolvePendingTx(tc, identifier)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
+		pending, err := loadPendingTx(tc, args, safeTxFile, false)
+		if errors.Is(err, errPendingNoCollector) {
+			appUI.Error(
+				"Safe Transaction Service is not available for chain %d, and --safe-tx-file was not set.",
+				config.Network().GetChainID(),
+			)
+			appUI.Info("Pass --safe-tx-file <path> to inspect a local Safe tx file, or configure SAFE_TX_SERVICE_URL_%d.", config.Network().GetChainID())
+			return
+		}
+		if err != nil {
+			appUI.Error("%s", err)
+			return
 		}
 
 		if _, err := safeContract.MergeOnChainApprovals(pending); err != nil {
@@ -2059,6 +1993,65 @@ func nextSafeNonce(s *safe.SafeContract, c safe.SignatureCollector) (uint64, err
 	return safe.NextNonce(s, c)
 }
 
+var (
+	errPendingNoCollector = errors.New("safe transaction service is not available")
+	errPendingNeedHash    = errors.New("on-chain approve without a service requires an explicit safeTxHash")
+)
+
+// loadPendingTx is the shared pending-tx source selector for approve /
+// execute / info: local file, Safe Transaction Service, or (approve only)
+// a hash-only stub when --approve-onchain is used without a service.
+func loadPendingTx(tc cmdutil.TxContext, args []string, file string, allowOnChainHash bool) (*safe.PendingTx, error) {
+	if file != "" {
+		_, pending, err := loadPendingFromTxFile(tc, file)
+		return pending, err
+	}
+	if tc.Collector == nil {
+		if allowOnChainHash {
+			return pendingFromOnChainHash(tc, args)
+		}
+		return nil, errPendingNoCollector
+	}
+	identifier, err := pickPendingTxIdentifier(tc, args)
+	if err != nil {
+		return nil, err
+	}
+	return resolvePendingTx(tc, identifier)
+}
+
+// pendingFromOnChainHash builds a hash-only PendingTx when there is no
+// Transaction Service. The caller must have passed a Safe-app URL with a
+// hash or a 32-byte 0x… positional arg.
+func pendingFromOnChainHash(tc cmdutil.TxContext, args []string) (*safe.PendingTx, error) {
+	if tc.SafeAppRef != nil && tc.SafeAppRef.HasTxHash() {
+		var hash [32]byte
+		copy(hash[:], tc.SafeAppRef.SafeTxHash[:])
+		return &safe.PendingTx{
+			Safe:       ethcommon.HexToAddress(tc.Safe.Address),
+			SafeTxHash: hash,
+		}, nil
+	}
+	if len(args) >= 2 {
+		if hash, ok := parseSafeTxHashArg(args[1]); ok {
+			return &safe.PendingTx{
+				Safe:       ethcommon.HexToAddress(tc.Safe.Address),
+				SafeTxHash: hash,
+			}, nil
+		}
+	}
+	return nil, errPendingNeedHash
+}
+
+func parseSafeTxHashArg(s string) ([32]byte, bool) {
+	s = strings.TrimSpace(s)
+	var hash [32]byte
+	if !strings.HasPrefix(strings.ToLower(s), "0x") || len(s) != 66 {
+		return hash, false
+	}
+	copy(hash[:], ethcommon.FromHex(s))
+	return hash, true
+}
+
 // loadPendingFromTxFile reads safeTxFile, cross-checks that it matches
 // the Safe and chain the user is currently targeting, and returns a
 // PendingTx in the same shape the Safe Transaction Service would. It is
@@ -2147,9 +2140,7 @@ func pickPendingTxIdentifier(tc cmdutil.TxContext, args []string) (string, error
 // or SafeTx nonce (decimal integer).
 func resolvePendingTx(tc cmdutil.TxContext, identifier string) (*safe.PendingTx, error) {
 	identifier = strings.TrimSpace(identifier)
-	if strings.HasPrefix(strings.ToLower(identifier), "0x") && len(identifier) == 66 {
-		var hash [32]byte
-		copy(hash[:], ethcommon.FromHex(identifier))
+	if hash, ok := parseSafeTxHashArg(identifier); ok {
 		pt, err := tc.Collector.Get(hash)
 		if err != nil {
 			return nil, fmt.Errorf("fetching tx 0x%s from service: %w", ethcommon.Bytes2Hex(hash[:]), err)

--- a/cmd/safe_approve_test.go
+++ b/cmd/safe_approve_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	cmdutil "github.com/tranvictor/jarvis/cmd/util"
+	"github.com/tranvictor/jarvis/safe"
+)
+
+func TestVerifyPendingSafeTxHashSkipsNilBody(t *testing.T) {
+	pending := &safe.PendingTx{SafeTxHash: pendingTestHashBytes()}
+	if _, err := verifyPendingSafeTxHash(pending, [32]byte{1}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyPendingSafeTxHashMatchAndMismatch(t *testing.T) {
+	stx := safe.NewSafeTx(ethcommon.HexToAddress("0x1111111111111111111111111111111111111111"), big.NewInt(0), nil, safe.OpCall, 3)
+	var domain [32]byte
+	domain[0] = 0xab
+	hash := stx.SafeTxHash(domain)
+	pending := &safe.PendingTx{SafeTx: stx, SafeTxHash: hash}
+
+	if _, err := verifyPendingSafeTxHash(pending, domain); err != nil {
+		t.Fatal(err)
+	}
+
+	pending.SafeTxHash = pendingTestHashBytes()
+	expected, err := verifyPendingSafeTxHash(pending, domain)
+	if !errors.Is(err, errPendingHashMismatch) {
+		t.Fatalf("got %v", err)
+	}
+	if expected != hash {
+		t.Fatalf("expected %x want %x", expected, hash)
+	}
+}
+
+func TestOwnerAlreadySigned(t *testing.T) {
+	me := ethcommon.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	other := ethcommon.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	pending := &safe.PendingTx{
+		Sigs: []safe.OwnerSig{
+			{Owner: other, Sig: []byte{1}},
+		},
+	}
+	if _, found := ownerAlreadySigned(pending, me); found {
+		t.Fatal("should not find me")
+	}
+
+	pending.Sigs = append(pending.Sigs, safe.OwnerSig{Owner: me, Sig: append(make([]byte, 64), 27)})
+	onChain, found := ownerAlreadySigned(pending, me)
+	if !found || onChain {
+		t.Fatalf("off-chain: onChain=%v found=%v", onChain, found)
+	}
+
+	pending.Sigs[1] = safe.OnChainApprovalSig(me)
+	onChain, found = ownerAlreadySigned(pending, me)
+	if !found || !onChain {
+		t.Fatalf("on-chain: onChain=%v found=%v", onChain, found)
+	}
+}
+
+func TestPendingWithNewSig(t *testing.T) {
+	me := ethcommon.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	pending := &safe.PendingTx{
+		Sigs: []safe.OwnerSig{{Owner: ethcommon.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), Sig: []byte{1}}},
+	}
+	got := pendingWithNewSig(pending, me, []byte{2})
+	if len(pending.Sigs) != 1 {
+		t.Fatal("must not mutate original")
+	}
+	if len(got.Sigs) != 2 || got.Sigs[1].Owner != me {
+		t.Fatalf("got %+v", got.Sigs)
+	}
+}
+
+type confirmCollector struct {
+	stubCollector
+	gotHash [32]byte
+	gotMe   ethcommon.Address
+	gotSig  []byte
+}
+
+func (c *confirmCollector) Confirm(hash [32]byte, owner ethcommon.Address, sig []byte) error {
+	c.gotHash = hash
+	c.gotMe = owner
+	c.gotSig = sig
+	return nil
+}
+
+func TestPersistApprovalUsesCollector(t *testing.T) {
+	h := pendingTestHashBytes()
+	me := ethcommon.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	col := &confirmCollector{}
+	tc := cmdutil.TxContext{Collector: col}
+	pending := &safe.PendingTx{SafeTxHash: h}
+	if err := persistApproval(tc, pendingTestSafe, pending, me, []byte{9}, "", 1); err != nil {
+		t.Fatal(err)
+	}
+	if col.gotHash != h || col.gotMe != me || len(col.gotSig) != 1 || col.gotSig[0] != 9 {
+		t.Fatalf("confirm %+v %+v %v", col.gotHash, col.gotMe, col.gotSig)
+	}
+}

--- a/cmd/safe_pending_test.go
+++ b/cmd/safe_pending_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"errors"
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	cmdutil "github.com/tranvictor/jarvis/cmd/util"
+	"github.com/tranvictor/jarvis/config"
+	"github.com/tranvictor/jarvis/safe"
+)
+
+const (
+	pendingTestSafe = "0x71f8f067348d47cced223eA24D2D77235bea722B"
+	pendingTestHash = "0x82c28e25b40c865440a0e89fd9578fe62f629f5fafaa0af0587342f7b4b41efe"
+)
+
+type stubCollector struct {
+	byHash  map[[32]byte]*safe.PendingTx
+	pending []*safe.PendingTx
+}
+
+func (s stubCollector) Propose(ethcommon.Address, *safe.SafeTx, [32]byte, ethcommon.Address, []byte) error {
+	return errors.New("unused")
+}
+func (s stubCollector) Confirm([32]byte, ethcommon.Address, []byte) error {
+	return errors.New("unused")
+}
+func (s stubCollector) Get(hash [32]byte) (*safe.PendingTx, error) {
+	if p, ok := s.byHash[hash]; ok {
+		return p, nil
+	}
+	return nil, errors.New("not found")
+}
+func (s stubCollector) FindByNonce(ethcommon.Address, uint64) (*safe.PendingTx, error) {
+	return nil, errors.New("unused")
+}
+func (s stubCollector) ListPending(ethcommon.Address) ([]*safe.PendingTx, error) {
+	return s.pending, nil
+}
+
+func pendingTestHashBytes() [32]byte {
+	var h [32]byte
+	copy(h[:], ethcommon.FromHex(pendingTestHash))
+	return h
+}
+
+func TestParseSafeTxHashArg(t *testing.T) {
+	h, ok := parseSafeTxHashArg(pendingTestHash)
+	if !ok || h != pendingTestHashBytes() {
+		t.Fatalf("got ok=%v hash=%x", ok, h)
+	}
+	if _, ok := parseSafeTxHashArg("0xabc"); ok {
+		t.Fatal("short hash should fail")
+	}
+	if _, ok := parseSafeTxHashArg("7"); ok {
+		t.Fatal("nonce should fail")
+	}
+}
+
+func TestLoadPendingTxNoCollector(t *testing.T) {
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: pendingTestSafe}}
+	_, err := loadPendingTx(tc, []string{pendingTestSafe}, "", false)
+	if !errors.Is(err, errPendingNoCollector) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestLoadPendingTxOnChainHashFromArg(t *testing.T) {
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: pendingTestSafe}}
+	got, err := loadPendingTx(tc, []string{pendingTestSafe, pendingTestHash}, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SafeTxHash != pendingTestHashBytes() {
+		t.Fatalf("hash %x", got.SafeTxHash)
+	}
+	if got.SafeTx != nil {
+		t.Fatal("hash-only pending must not invent a SafeTx body")
+	}
+}
+
+func TestLoadPendingTxOnChainHashFromURL(t *testing.T) {
+	h := pendingTestHashBytes()
+	tc := cmdutil.TxContext{
+		Safe: &safe.SafeContract{Address: pendingTestSafe},
+		SafeAppRef: &safe.SafeAppRef{
+			SafeAddress: ethcommon.HexToAddress(pendingTestSafe),
+			SafeTxHash:  h,
+		},
+	}
+	got, err := loadPendingTx(tc, []string{"https://app.safe.global/"}, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SafeTxHash != h {
+		t.Fatalf("hash %x", got.SafeTxHash)
+	}
+}
+
+func TestLoadPendingTxOnChainNeedsHash(t *testing.T) {
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: pendingTestSafe}}
+	_, err := loadPendingTx(tc, []string{pendingTestSafe}, "", true)
+	if !errors.Is(err, errPendingNeedHash) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestLoadPendingTxFromService(t *testing.T) {
+	h := pendingTestHashBytes()
+	want := &safe.PendingTx{SafeTxHash: h}
+	tc := cmdutil.TxContext{
+		Safe:      &safe.SafeContract{Address: pendingTestSafe},
+		Collector: stubCollector{byHash: map[[32]byte]*safe.PendingTx{h: want}},
+	}
+	got, err := loadPendingTx(tc, []string{pendingTestSafe, pendingTestHash}, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestLoadPendingTxFromFile(t *testing.T) {
+	if err := config.SetNetwork("mainnet"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "tx.json")
+	tx := safe.NewSafeTx(ethcommon.HexToAddress("0x1111111111111111111111111111111111111111"), big.NewInt(0), nil, safe.OpCall, 1)
+	h := pendingTestHashBytes()
+	if err := safe.WriteTxFile(path, pendingTestSafe, 1, tx, h, nil); err != nil {
+		t.Fatal(err)
+	}
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: pendingTestSafe}}
+	got, err := loadPendingTx(tc, nil, path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SafeTxHash != h {
+		t.Fatalf("hash %x", got.SafeTxHash)
+	}
+	if got.SafeTx == nil || got.SafeTx.Nonce.Uint64() != 1 {
+		t.Fatalf("body %+v", got.SafeTx)
+	}
+}
+
+func TestLoadPendingTxFileWrongSafe(t *testing.T) {
+	if err := config.SetNetwork("mainnet"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "tx.json")
+	tx := safe.NewSafeTx(ethcommon.HexToAddress("0x1111111111111111111111111111111111111111"), big.NewInt(0), nil, safe.OpCall, 1)
+	if err := safe.WriteTxFile(path, pendingTestSafe, 1, tx, pendingTestHashBytes(), nil); err != nil {
+		t.Fatal(err)
+	}
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: "0x2222222222222222222222222222222222222222"}}
+	_, err := loadPendingTx(tc, nil, path, false)
+	if err == nil {
+		t.Fatal("expected safe mismatch")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fourth wave. Stacked on #95 (`loadPendingTx`) so this branch includes that commit. Merge #95 first, or merge this and close #95 as superseded.

`approveSafeCmd` and batch `approveSafeRef` now share:

- `verifyPendingSafeTxHash` — skip when there is no SafeTx body (hash-only `--approve-onchain`)
- `ownerAlreadySigned` — on-chain vs off-chain
- `signPendingSafeTx` / `signCause` — unlock + EIP-712 sign
- `persistApproval` — file append or STS `Confirm`
- `pendingWithNewSig` — copy-on-write for auto-execute

Confirm prompts, already-signed wording, and batch errors-as-results stay in each caller. `--approve-onchain` still goes through `runSafeApproveOnChain`.

Tests: hash skip/match/mismatch, already-signed, persist via collector, original sig list not mutated.

Next: propose tail (`initSafeCmd`, `sendFromSafe`, WC `SendTransaction`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0528c-a970-7072-8275-03dc95ef0b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0528c-a970-7072-8275-03dc95ef0b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

