### PR TITLE
Write mixed bapprove JSON without clobbering Safe results

### DIFF
--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -567,7 +567,7 @@ type jsonBatchSummary struct {
 	Results     []jsonBatchResult `json:"results"`
 }
 
-func writeBatchSummaryJSON(path string, results []batchResult) {
+func buildClassicBatchSummary(results []batchResult) jsonBatchSummary {
 	summary := jsonBatchSummary{
 		Total:   len(results),
 		Results: make([]jsonBatchResult, 0, len(results)),
@@ -606,8 +606,11 @@ func writeBatchSummaryJSON(path string, results []batchResult) {
 			summary.Failed++
 		}
 	}
+	return summary
+}
 
-	data, err := json.MarshalIndent(summary, "", "  ")
+func writeJSONSummary(path string, v any) {
+	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		appUI.Error("Couldn't marshal JSON: %s", err)
 		return
@@ -617,6 +620,74 @@ func writeBatchSummaryJSON(path string, results []batchResult) {
 		return
 	}
 	appUI.Success("Summary written to %s", path)
+}
+
+func writeBatchSummaryJSON(path string, results []batchResult) {
+	writeJSONSummary(path, buildClassicBatchSummary(results))
+}
+
+// jsonMixedBatchSummary is written when bapprove processes both Safe and
+// Classic refs. Safe-only and Classic-only runs keep their existing
+// single-flavor shapes (a top-level results array). Mixed runs use
+// separate safe and classic arrays so the second write cannot clobber
+// the first.
+type jsonMixedBatchSummary struct {
+	Total       int                   `json:"total"`
+	Approved    int                   `json:"approved"`
+	Broadcasted int                   `json:"broadcasted"`
+	Executed    int                   `json:"executed"`
+	Skipped     int                   `json:"skipped"`
+	Failed      int                   `json:"failed"`
+	Generated   string                `json:"generated_at"`
+	Safe        []jsonSafeBatchResult `json:"safe"`
+	Classic     []jsonBatchResult     `json:"classic"`
+}
+
+func buildMixedBatchSummary(safe []safeBatchResult, classic []batchResult) jsonMixedBatchSummary {
+	s := buildSafeBatchSummary(safe)
+	c := buildClassicBatchSummary(classic)
+	return jsonMixedBatchSummary{
+		Total:       s.Total + c.Total,
+		Approved:    s.Approved + c.Approved,
+		Broadcasted: c.Broadcasted,
+		Executed:    s.Executed,
+		Skipped:     s.Skipped + c.Skipped,
+		Failed:      s.Failed + c.Failed,
+		Generated:   s.Generated,
+		Safe:        s.Results,
+		Classic:     c.Results,
+	}
+}
+
+func batchApproveJSONPayload(safe []safeBatchResult, classic []batchResult) any {
+	switch {
+	case len(safe) > 0 && len(classic) > 0:
+		return buildMixedBatchSummary(safe, classic)
+	case len(safe) > 0:
+		return buildSafeBatchSummary(safe)
+	case len(classic) > 0:
+		return buildClassicBatchSummary(classic)
+	default:
+		return nil
+	}
+}
+
+func writeBatchApproveJSON(path string, safe []safeBatchResult, classic []batchResult) {
+	switch {
+	case len(safe) > 0 && len(classic) > 0:
+		writeJSONSummary(path, buildMixedBatchSummary(safe, classic))
+	case len(safe) > 0:
+		writeSafeBatchSummaryJSON(path, safe)
+	case len(classic) > 0:
+		writeBatchSummaryJSON(path, classic)
+	}
+}
+
+func writeBatchApproveJSONIfRequested(safe []safeBatchResult, classic []batchResult) {
+	if config.JSONOutputFile == "" {
+		return
+	}
+	writeBatchApproveJSON(config.JSONOutputFile, safe, classic)
 }
 
 var batchApproveMsigCmd = &cobra.Command{
@@ -637,7 +708,8 @@ Each whitespace- or comma-separated token may be:
 
 Safe references are extracted first; remaining tokens are treated as
 Gnosis Classic init tx hashes. A summary table is printed at the end;
-with --json-output, the same data is also written as JSON.`,
+with --json-output, the same data is also written as JSON. Mixed
+Safe+Classic runs write both arrays into one file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			appUI.Error("Please provide one or more multisig tx references.")
@@ -654,9 +726,10 @@ with --json-output, the same data is also written as JSON.`,
 		// Process the Safe portion of the input first so any auto-execute
 		// flow runs before we start touching Classic broadcasters that may
 		// share a wallet.
+		var safeResults []safeBatchResult
 		if len(safeRefs) > 0 {
 			total := len(safeRefs)
-			results := make([]safeBatchResult, 0, total)
+			safeResults = make([]safeBatchResult, 0, total)
 			appUI.Section(fmt.Sprintf("Batch Approve (Safe): %d transactions", total))
 			for i, ref := range safeRefs {
 				r := safeBatchResult{ref: ref.original}
@@ -671,18 +744,17 @@ with --json-output, the same data is also written as JSON.`,
 				r.execTxHash = res.execTxHash
 				r.status = res.status
 				r.reason = res.reason
-				results = append(results, r)
+				safeResults = append(safeResults, r)
 			}
-			printSafeBatchSummary(results)
-			if config.JSONOutputFile != "" {
-				writeSafeBatchSummaryJSON(config.JSONOutputFile, results)
-			}
+			printSafeBatchSummary(safeResults)
 		}
 
 		networkNames, txs := cmdutil.ScanForTxs(residual)
 		if len(networkNames) == 0 || len(txs) == 0 {
 			if len(safeRefs) == 0 {
 				appUI.Error("No txs passed to the first param. Did nothing.")
+			} else {
+				writeBatchApproveJSONIfRequested(safeResults, nil)
 			}
 			return
 		}
@@ -802,9 +874,7 @@ with --json-output, the same data is also written as JSON.`,
 				r.reason = fmt.Sprintf("tx type: %s", err)
 				results = append(results, r)
 				printBatchSummary(results)
-				if config.JSONOutputFile != "" {
-					writeBatchSummaryJSON(config.JSONOutputFile, results)
-				}
+				writeBatchApproveJSONIfRequested(safeResults, results)
 				return
 			}
 
@@ -896,9 +966,7 @@ with --json-output, the same data is also written as JSON.`,
 		}
 
 		printBatchSummary(results)
-		if config.JSONOutputFile != "" {
-			writeBatchSummaryJSON(config.JSONOutputFile, results)
-		}
+		writeBatchApproveJSONIfRequested(safeResults, results)
 	},
 }
 

--- a/cmd/msig_bapprove_json_test.go
+++ b/cmd/msig_bapprove_json_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestBuildSafeBatchSummaryCounts(t *testing.T) {
+	out := buildSafeBatchSummary([]safeBatchResult{
+		{ref: "a", status: "approved"},
+		{ref: "b", status: "executed", execTxHash: "0xexec"},
+		{ref: "c", status: "skipped", reason: "already signed"},
+		{ref: "d", status: "failed", reason: "boom"},
+		{ref: "e", status: "approved"},
+	})
+	if out.Total != 5 || out.Approved != 2 || out.Executed != 1 || out.Skipped != 1 || out.Failed != 1 {
+		t.Fatalf("counts: %+v", out)
+	}
+	if _, err := time.Parse(time.RFC3339, out.Generated); err != nil {
+		t.Fatalf("generated_at: %v", err)
+	}
+	if out.Results[1].ExecTxHash != "0xexec" {
+		t.Fatalf("exec hash %q", out.Results[1].ExecTxHash)
+	}
+}
+
+func TestBuildClassicBatchSummaryCountsAndHistory(t *testing.T) {
+	out := buildClassicBatchSummary([]batchResult{
+		{network: "mainnet", msigTxID: "1", status: "approved", initTxHash: "0xinit"},
+		{network: "bsc", status: "broadcasted"},
+		{network: "mainnet", status: "skipped", reason: "already executed"},
+		{
+			network: "mainnet",
+			status:  "failed",
+			history: &msigTxHistory{
+				confirmations: []msigTxConfirmation{
+					{txHash: "0xa", sender: "0xb"},
+				},
+				executionTxHash: "0xc",
+			},
+		},
+	})
+	if out.Total != 4 || out.Approved != 1 || out.Broadcasted != 1 || out.Skipped != 1 || out.Failed != 1 {
+		t.Fatalf("counts: %+v", out)
+	}
+	jr := out.Results[3]
+	if jr.ExecutionTx != "0xc" || len(jr.Confirmations) != 1 || jr.Confirmations[0].TxHash != "0xa" {
+		t.Fatalf("history: %+v", jr)
+	}
+}
+
+func TestBuildMixedBatchSummaryCombinesBoth(t *testing.T) {
+	out := buildMixedBatchSummary(
+		[]safeBatchResult{
+			{ref: "safe-1", status: "approved"},
+			{ref: "safe-2", status: "executed"},
+		},
+		[]batchResult{
+			{network: "mainnet", status: "broadcasted"},
+			{network: "bsc", status: "skipped", reason: "pending"},
+		},
+	)
+	if out.Total != 4 || out.Approved != 1 || out.Executed != 1 || out.Broadcasted != 1 || out.Skipped != 1 || out.Failed != 0 {
+		t.Fatalf("counts: %+v", out)
+	}
+	if len(out.Safe) != 2 || len(out.Classic) != 2 {
+		t.Fatalf("arrays safe=%d classic=%d", len(out.Safe), len(out.Classic))
+	}
+	if out.Safe[0].Ref != "safe-1" || out.Classic[0].Network != "mainnet" {
+		t.Fatalf("rows: %+v %+v", out.Safe[0], out.Classic[0])
+	}
+}
+
+func TestBatchApproveJSONPayloadShapes(t *testing.T) {
+	safe := []safeBatchResult{{
+		ref:         "multisig_0xsafe_0xhash",
+		network:     "mainnet",
+		safeAddress: "0xsafe",
+		safeTxHash:  "0xhash",
+		status:      "approved",
+		confirmType: "approve",
+	}}
+	classic := []batchResult{{
+		network:    "mainnet",
+		msigTxID:   "3",
+		initTxHash: "0xinit",
+		status:     "approved",
+	}}
+
+	assertKeys := func(t *testing.T, payload any, want, deny []string) map[string]json.RawMessage {
+		t.Helper()
+		data, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatal(err)
+		}
+		for _, k := range want {
+			if _, ok := raw[k]; !ok {
+				t.Fatalf("missing key %q in %s", k, data)
+			}
+		}
+		for _, k := range deny {
+			if _, ok := raw[k]; ok {
+				t.Fatalf("unexpected key %q in %s", k, data)
+			}
+		}
+		return raw
+	}
+
+	assertKeys(t, batchApproveJSONPayload(safe, nil),
+		[]string{"results", "generated_at", "executed", "approved"},
+		[]string{"safe", "classic", "broadcasted"},
+	)
+	assertKeys(t, batchApproveJSONPayload(nil, classic),
+		[]string{"results", "broadcasted", "approved"},
+		[]string{"safe", "classic", "generated_at", "executed"},
+	)
+	assertKeys(t, batchApproveJSONPayload(safe, classic),
+		[]string{"safe", "classic", "generated_at", "executed", "broadcasted"},
+		[]string{"results"},
+	)
+	data, err := json.Marshal(batchApproveJSONPayload(safe, classic))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mixed jsonMixedBatchSummary
+	if err := json.Unmarshal(data, &mixed); err != nil {
+		t.Fatal(err)
+	}
+	if mixed.Total != 2 || len(mixed.Safe) != 1 || len(mixed.Classic) != 1 {
+		t.Fatalf("mixed: %+v", mixed)
+	}
+	if mixed.Safe[0].SafeTxHash != "0xhash" || mixed.Classic[0].MsigTxID != "3" {
+		t.Fatalf("mixed rows: %+v %+v", mixed.Safe[0], mixed.Classic[0])
+	}
+
+	if batchApproveJSONPayload(nil, nil) != nil {
+		t.Fatal("empty payload should be nil")
+	}
+}

--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -1749,7 +1747,7 @@ type jsonSafeBatchSummary struct {
 	Results   []jsonSafeBatchResult `json:"results"`
 }
 
-func writeSafeBatchSummaryJSON(path string, results []safeBatchResult) {
+func buildSafeBatchSummary(results []safeBatchResult) jsonSafeBatchSummary {
 	out := jsonSafeBatchSummary{
 		Total:     len(results),
 		Generated: time.Now().UTC().Format(time.RFC3339),
@@ -1777,16 +1775,11 @@ func writeSafeBatchSummaryJSON(path string, results []safeBatchResult) {
 			out.Failed++
 		}
 	}
-	data, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		appUI.Error("Couldn't marshal JSON: %s", err)
-		return
-	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		appUI.Error("Couldn't write JSON file: %s", err)
-		return
-	}
-	appUI.Success("Summary written to %s", path)
+	return out
+}
+
+func writeSafeBatchSummaryJSON(path string, results []safeBatchResult) {
+	writeJSONSummary(path, buildSafeBatchSummary(results))
 }
 
 // runSafeExecute drives the on-chain execTransaction call for a Safe


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`jarvis msig bapprove` accepts mixed Safe + Classic refs in one invocation. `--json-output` wrote the Safe summary first, then the Classic writer overwrote the same file.

This keeps the existing single-flavor JSON shapes so Safe-only and Classic-only consumers are unchanged. Mixed runs write one document with both arrays.

**Safe-only / Classic-only** (unchanged):
```json
{ "total": …, "approved": …, "results": [ … ] }
```

**Mixed**:
```json
{
  "total": 4,
  "approved": 1,
  "broadcasted": 1,
  "executed": 1,
  "skipped": 1,
  "failed": 0,
  "generated_at": "…",
  "safe": [ { "ref": "…", "safe_tx_hash": "…", "status": "approved" } ],
  "classic": [ { "network": "mainnet", "msig_tx_id": "3", "status": "broadcasted" } ]
}
```

Console summaries are still printed separately per flavor. Classic abort-on-tx-type still writes the combined file so prior Safe outcomes are not dropped.

Independent of the Safe-core stack (#95–#97).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0528c-a970-7072-8275-03dc95ef0b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0528c-a970-7072-8275-03dc95ef0b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

