### PR TITLE
Inject existing EthReader into Safe and Classic constructors

### DIFF
--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -54,6 +54,7 @@ automatically based on an on-chain probe of the address.`,
 		multisigContract, err := msig.NewMultisigContract(
 			msigAddress,
 			config.Network(),
+			msig.WithReader(cmdutil.EthReaderOf(tc.Reader)),
 		)
 		if err != nil {
 			appUI.Error("Couldn't interact with the contract: %s", err)
@@ -132,6 +133,7 @@ or msig tx id / init tx hash for Classic targets.`,
 		multisigContract, err := msig.NewMultisigContract(
 			msigAddress,
 			config.Network(),
+			msig.WithReader(cmdutil.EthReaderOf(tc.Reader)),
 		)
 		if err != nil {
 			appUI.Error("Couldn't interact with the contract: %s", err)
@@ -179,6 +181,7 @@ the on-chain transaction count.`,
 		multisigContract, err := msig.NewMultisigContract(
 			msigAddress,
 			config.Network(),
+			msig.WithReader(cmdutil.EthReaderOf(tc.Reader)),
 		)
 		if err != nil {
 			appUI.Error("Couldn't interact with the contract: %s", err)
@@ -1139,7 +1142,7 @@ the Safe, so the positional Safe address and --network become optional.`,
 		}
 
 		if config.Simulate {
-			multisigContract, err := msig.NewMultisigContract(tc.To, config.Network())
+			multisigContract, err := msig.NewMultisigContract(tc.To, config.Network(), msig.WithReader(cmdutil.EthReaderOf(tc.Reader)))
 			if err != nil {
 				appUI.Error("Couldn't interact with the contract: %s", err)
 				return

--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -573,16 +573,13 @@ over an off-chain signature store. Other owners' off-chain signatures
 		// corner case above we only have the hash, so there's nothing to
 		// cross-check — the Safe itself will reject a wrong hash at
 		// approveHash / execute time.
-		if pending.SafeTx != nil {
-			expected := pending.SafeTx.SafeTxHash(domainSep)
-			if expected != pending.SafeTxHash {
-				appUI.Error(
-					"declared safeTxHash (0x%s) doesn't match locally recomputed hash (0x%s); refusing to sign",
-					ethcommon.Bytes2Hex(pending.SafeTxHash[:]),
-					ethcommon.Bytes2Hex(expected[:]),
-				)
-				return
-			}
+		if expected, err := verifyPendingSafeTxHash(pending, domainSep); errors.Is(err, errPendingHashMismatch) {
+			appUI.Error(
+				"declared safeTxHash (0x%s) doesn't match locally recomputed hash (0x%s); refusing to sign",
+				ethcommon.Bytes2Hex(pending.SafeTxHash[:]),
+				ethcommon.Bytes2Hex(expected[:]),
+			)
+			return
 		}
 
 		// Merge on-chain approvals into the in-memory Sigs before the
@@ -601,15 +598,13 @@ over an off-chain signature store. Other owners' off-chain signatures
 		showSafeSigners("Existing signatures", pending.Sigs)
 
 		me := ethcommon.HexToAddress(tc.From)
-		for _, s := range pending.Sigs {
-			if s.Owner == me {
-				if safe.IsOnChainApproval(s.Sig) {
-					appUI.Warn("You (%s) have already approved this transaction on-chain (approveHash).", me.Hex())
-				} else {
-					appUI.Warn("You (%s) have already signed this transaction off-chain.", me.Hex())
-				}
-				return
+		if onChain, found := ownerAlreadySigned(pending, me); found {
+			if onChain {
+				appUI.Warn("You (%s) have already approved this transaction on-chain (approveHash).", me.Hex())
+			} else {
+				appUI.Warn("You (%s) have already signed this transaction off-chain.", me.Hex())
 			}
+			return
 		}
 
 		if safeApproveOnChain {
@@ -628,41 +623,30 @@ over an off-chain signature store. Other owners' off-chain signatures
 		}
 
 		appUI.Info("Unlock your wallet and sign the EIP-712 safeTxHash now...")
-		account, err := accounts.UnlockAccount(tc.FromAcc)
-		if err != nil {
-			appUI.Error("Couldn't unlock wallet: %s", err)
+		sig, err := signPendingSafeTx(tc.FromAcc, pending, domainSep)
+		if errors.Is(err, errSignSafeHash) {
+			appUI.Error("Couldn't sign safeTxHash: %s", signCause(err))
 			return
 		}
-
-		structHash := pending.SafeTx.StructHash()
-		sig, err := account.SignSafeHash(domainSep, structHash)
 		if err != nil {
-			appUI.Error("Couldn't sign safeTxHash: %s", err)
+			appUI.Error("Couldn't unlock wallet: %s", err)
 			return
 		}
 
 		// Persist the new signature. In file mode we append to the file
 		// (the collective source of truth); otherwise we POST to the Safe
 		// Transaction Service.
-		if safeTxFile != "" {
-			updatedSigs := append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{
-				Owner: me, Sig: sig,
-			})
-			if err := safe.WriteTxFile(
-				safeTxFile,
-				safeContract.Address,
-				config.Network().GetChainID(),
-				pending.SafeTx, pending.SafeTxHash, updatedSigs,
-			); err != nil {
+		if err := persistApproval(tc, safeContract.Address, pending, me, sig, safeTxFile, config.Network().GetChainID()); err != nil {
+			if safeTxFile != "" {
 				appUI.Error("Couldn't write updated Safe tx file: %s", err)
-				return
+			} else {
+				appUI.Error("Submitting confirmation to Safe Transaction Service failed: %s", err)
 			}
+			return
+		}
+		if safeTxFile != "" {
 			appUI.Success("Signature appended to %s", safeTxFile)
 		} else {
-			if err := tc.Collector.Confirm(pending.SafeTxHash, me, sig); err != nil {
-				appUI.Error("Submitting confirmation to Safe Transaction Service failed: %s", err)
-				return
-			}
 			appUI.Success("Confirmation submitted.")
 		}
 		totalSigs := len(pending.Sigs) + 1
@@ -703,12 +687,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 			return
 		}
 
-		augmented := *pending
-		augmented.Sigs = append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{
-			Owner: me,
-			Sig:   sig,
-		})
-		runSafeExecute(tc, safeContract, &augmented, domainSep)
+		runSafeExecute(tc, safeContract, pendingWithNewSig(pending, me, sig), domainSep)
 	},
 }
 
@@ -1456,7 +1435,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		appUI.Error("%s", res.reason)
 		return res
 	}
-	if expected := pending.SafeTx.SafeTxHash(domainSep); expected != pending.SafeTxHash {
+	if _, err := verifyPendingSafeTxHash(pending, domainSep); errors.Is(err, errPendingHashMismatch) {
 		res.status = "failed"
 		res.reason = "service safeTxHash doesn't match locally recomputed hash"
 		appUI.Error("%s", res.reason)
@@ -1473,17 +1452,15 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 	}
 
 	me := ethcommon.HexToAddress(fromAcc.Address)
-	for _, s := range pending.Sigs {
-		if s.Owner == me {
-			res.status = "skipped"
-			if safe.IsOnChainApproval(s.Sig) {
-				res.reason = fmt.Sprintf("%s already approved on-chain", me.Hex())
-			} else {
-				res.reason = fmt.Sprintf("%s already signed off-chain", me.Hex())
-			}
-			appUI.Warn("%s", res.reason)
-			return res
+	if onChain, found := ownerAlreadySigned(pending, me); found {
+		res.status = "skipped"
+		if onChain {
+			res.reason = fmt.Sprintf("%s already approved on-chain", me.Hex())
+		} else {
+			res.reason = fmt.Sprintf("%s already signed off-chain", me.Hex())
 		}
+		appUI.Warn("%s", res.reason)
+		return res
 	}
 
 	// Build a TxContext rich enough for showSafeTxToConfirm and (for the
@@ -1526,7 +1503,13 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 	}
 
 	appUI.Info("Unlock %s and sign the EIP-712 safeTxHash now...", fromAcc.Address)
-	account, err := accounts.UnlockAccount(fromAcc)
+	sig, err := signPendingSafeTx(fromAcc, pending, domainSep)
+	if errors.Is(err, errSignSafeHash) {
+		res.status = "failed"
+		res.reason = fmt.Sprintf("sign safeTxHash: %s", signCause(err))
+		appUI.Error("%s", res.reason)
+		return res
+	}
 	if err != nil {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("unlock wallet: %s", err)
@@ -1534,16 +1517,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		return res
 	}
 
-	structHash := pending.SafeTx.StructHash()
-	sig, err := account.SignSafeHash(domainSep, structHash)
-	if err != nil {
-		res.status = "failed"
-		res.reason = fmt.Sprintf("sign safeTxHash: %s", err)
-		appUI.Error("%s", res.reason)
-		return res
-	}
-
-	if err := collector.Confirm(pending.SafeTxHash, me, sig); err != nil {
+	if err := persistApproval(tc, safeContract.Address, pending, me, sig, "", network.GetChainID()); err != nil {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("submit confirmation: %s", err)
 		appUI.Error("%s", res.reason)
@@ -1568,11 +1542,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		return res
 	}
 
-	augmented := *pending
-	augmented.Sigs = append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{
-		Owner: me, Sig: sig,
-	})
-	runSafeExecute(tc, safeContract, &augmented, domainSep)
+	runSafeExecute(tc, safeContract, pendingWithNewSig(pending, me, sig), domainSep)
 	res.confirmType = "approve+execute"
 	res.status = "executed"
 	return res
@@ -1994,9 +1964,79 @@ func nextSafeNonce(s *safe.SafeContract, c safe.SignatureCollector) (uint64, err
 }
 
 var (
-	errPendingNoCollector = errors.New("safe transaction service is not available")
-	errPendingNeedHash    = errors.New("on-chain approve without a service requires an explicit safeTxHash")
+	errPendingNoCollector  = errors.New("safe transaction service is not available")
+	errPendingNeedHash     = errors.New("on-chain approve without a service requires an explicit safeTxHash")
+	errPendingHashMismatch = errors.New("safeTxHash mismatch")
+	errSignSafeHash        = errors.New("sign safeTxHash")
 )
+
+// verifyPendingSafeTxHash recomputes the EIP-712 hash when a SafeTx body
+// is present. Hash-only --approve-onchain stubs skip the check (nil error).
+func verifyPendingSafeTxHash(pending *safe.PendingTx, domainSep [32]byte) ([32]byte, error) {
+	var expected [32]byte
+	if pending == nil || pending.SafeTx == nil {
+		return expected, nil
+	}
+	expected = pending.SafeTx.SafeTxHash(domainSep)
+	if expected != pending.SafeTxHash {
+		return expected, errPendingHashMismatch
+	}
+	return expected, nil
+}
+
+func ownerAlreadySigned(pending *safe.PendingTx, me ethcommon.Address) (onChain bool, found bool) {
+	if pending == nil {
+		return false, false
+	}
+	for _, s := range pending.Sigs {
+		if s.Owner == me {
+			return safe.IsOnChainApproval(s.Sig), true
+		}
+	}
+	return false, false
+}
+
+func signPendingSafeTx(fromAcc jtypes.AccDesc, pending *safe.PendingTx, domainSep [32]byte) ([]byte, error) {
+	account, err := accounts.UnlockAccount(fromAcc)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := account.SignSafeHash(domainSep, pending.SafeTx.StructHash())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errSignSafeHash, err)
+	}
+	return sig, nil
+}
+
+func signCause(err error) string {
+	prefix := errSignSafeHash.Error() + ": "
+	if strings.HasPrefix(err.Error(), prefix) {
+		return strings.TrimPrefix(err.Error(), prefix)
+	}
+	return err.Error()
+}
+
+func persistApproval(
+	tc cmdutil.TxContext,
+	safeAddr string,
+	pending *safe.PendingTx,
+	me ethcommon.Address,
+	sig []byte,
+	file string,
+	chainID uint64,
+) error {
+	if file != "" {
+		updated := append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{Owner: me, Sig: sig})
+		return safe.WriteTxFile(file, safeAddr, chainID, pending.SafeTx, pending.SafeTxHash, updated)
+	}
+	return tc.Collector.Confirm(pending.SafeTxHash, me, sig)
+}
+
+func pendingWithNewSig(pending *safe.PendingTx, me ethcommon.Address, sig []byte) *safe.PendingTx {
+	augmented := *pending
+	augmented.Sigs = append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{Owner: me, Sig: sig})
+	return &augmented
+}
 
 // loadPendingTx is the shared pending-tx source selector for approve /
 // execute / info: local file, Safe Transaction Service, or (approve only)

--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -536,61 +536,25 @@ over an off-chain signature store. Other owners' off-chain signatures
 		appUI.Section("Safe info")
 		showSafeInfo(safeContract)
 
-		var pending *safe.PendingTx
-		var err error
-		useFile := safeTxFile != ""
-		if useFile {
-			_, pending, err = loadPendingFromTxFile(tc, safeTxFile)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-		} else {
-			if tc.Collector == nil && !safeApproveOnChain {
-				appUI.Error(
-					"Safe Transaction Service is not available for chain %d.",
-					config.Network().GetChainID(),
-				)
-				appUI.Info("Pass --approve-onchain to approve via Safe.approveHash directly, or")
-				appUI.Info("pass --safe-tx-file <path> to load the pending SafeTx from a local file.")
-				return
-			}
-			if tc.Collector == nil && safeApproveOnChain {
-				// On-chain approval without a Tx Service: we need the
-				// safeTxHash directly (can't list the queue). The caller
-				// must have passed it as an argument or via a Safe-app URL.
-				if tc.SafeAppRef != nil && tc.SafeAppRef.HasTxHash() {
-					var hash [32]byte
-					copy(hash[:], tc.SafeAppRef.SafeTxHash[:])
-					pending = &safe.PendingTx{
-						Safe:       ethcommon.HexToAddress(safeContract.Address),
-						SafeTxHash: hash,
-					}
-				} else if len(args) >= 2 && strings.HasPrefix(strings.ToLower(strings.TrimSpace(args[1])), "0x") && len(strings.TrimSpace(args[1])) == 66 {
-					var hash [32]byte
-					copy(hash[:], ethcommon.FromHex(strings.TrimSpace(args[1])))
-					pending = &safe.PendingTx{
-						Safe:       ethcommon.HexToAddress(safeContract.Address),
-						SafeTxHash: hash,
-					}
-				} else {
-					appUI.Error(
-						"--approve-onchain without a Safe Transaction Service requires an explicit safeTxHash (0x... 32 bytes) or a Safe-app URL that carries one.",
-					)
-					return
-				}
-			} else {
-				identifier, err := pickPendingTxIdentifier(tc, args)
-				if err != nil {
-					appUI.Error("%s", err)
-					return
-				}
-				pending, err = resolvePendingTx(tc, identifier)
-				if err != nil {
-					appUI.Error("%s", err)
-					return
-				}
-			}
+		pending, err := loadPendingTx(tc, args, safeTxFile, safeApproveOnChain)
+		if errors.Is(err, errPendingNoCollector) {
+			appUI.Error(
+				"Safe Transaction Service is not available for chain %d.",
+				config.Network().GetChainID(),
+			)
+			appUI.Info("Pass --approve-onchain to approve via Safe.approveHash directly, or")
+			appUI.Info("pass --safe-tx-file <path> to load the pending SafeTx from a local file.")
+			return
+		}
+		if errors.Is(err, errPendingNeedHash) {
+			appUI.Error(
+				"--approve-onchain without a Safe Transaction Service requires an explicit safeTxHash (0x... 32 bytes) or a Safe-app URL that carries one.",
+			)
+			return
+		}
+		if err != nil {
+			appUI.Error("%s", err)
+			return
 		}
 		if pending.IsExecuted {
 			appUI.Warn("This transaction has already been executed; nothing to approve.")
@@ -680,7 +644,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 		// Persist the new signature. In file mode we append to the file
 		// (the collective source of truth); otherwise we POST to the Safe
 		// Transaction Service.
-		if useFile {
+		if safeTxFile != "" {
 			updatedSigs := append(append([]safe.OwnerSig{}, pending.Sigs...), safe.OwnerSig{
 				Owner: me, Sig: sig,
 			})
@@ -710,7 +674,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 			return
 		}
 		nextCmdHint := fmt.Sprintf("  jarvis msig execute %s 0x%s%s", safeContract.Address, ethcommon.Bytes2Hex(pending.SafeTxHash[:]), networkFlag())
-		if useFile {
+		if safeTxFile != "" {
 			nextCmdHint = fmt.Sprintf("  jarvis msig execute %s --safe-tx-file %s%s", safeContract.Address, safeTxFile, networkFlag())
 		}
 		if uint64(totalSigs) < threshold {
@@ -928,33 +892,18 @@ The pending tx can be identified by:
 		appUI.Section("Safe info")
 		showSafeInfo(safeContract)
 
-		var pending *safe.PendingTx
-		var err error
-		if safeTxFile != "" {
-			_, pending, err = loadPendingFromTxFile(tc, safeTxFile)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-		} else {
-			if tc.Collector == nil {
-				appUI.Error(
-					"Safe Transaction Service is not available for chain %d, and --safe-tx-file was not set.",
-					config.Network().GetChainID(),
-				)
-				appUI.Info("Pass --safe-tx-file <path> to execute from a local file, or configure SAFE_TX_SERVICE_URL_%d.", config.Network().GetChainID())
-				return
-			}
-			identifier, err := pickPendingTxIdentifier(tc, args)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-			pending, err = resolvePendingTx(tc, identifier)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
+		pending, err := loadPendingTx(tc, args, safeTxFile, false)
+		if errors.Is(err, errPendingNoCollector) {
+			appUI.Error(
+				"Safe Transaction Service is not available for chain %d, and --safe-tx-file was not set.",
+				config.Network().GetChainID(),
+			)
+			appUI.Info("Pass --safe-tx-file <path> to execute from a local file, or configure SAFE_TX_SERVICE_URL_%d.", config.Network().GetChainID())
+			return
+		}
+		if err != nil {
+			appUI.Error("%s", err)
+			return
 		}
 		if pending.IsExecuted {
 			appUI.Warn("This transaction has already been executed.")
@@ -1057,33 +1006,18 @@ Equivalent to ` + "`jarvis msig info`" + ` for Gnosis Classic.`,
 		appUI.Section("Safe info")
 		showSafeInfo(safeContract)
 
-		var pending *safe.PendingTx
-		var err error
-		if safeTxFile != "" {
-			_, pending, err = loadPendingFromTxFile(tc, safeTxFile)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-		} else {
-			if tc.Collector == nil {
-				appUI.Error(
-					"Safe Transaction Service is not available for chain %d, and --safe-tx-file was not set.",
-					config.Network().GetChainID(),
-				)
-				appUI.Info("Pass --safe-tx-file <path> to inspect a local Safe tx file, or configure SAFE_TX_SERVICE_URL_%d.", config.Network().GetChainID())
-				return
-			}
-			identifier, err := pickPendingTxIdentifier(tc, args)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
-			pending, err = resolvePendingTx(tc, identifier)
-			if err != nil {
-				appUI.Error("%s", err)
-				return
-			}
+		pending, err := loadPendingTx(tc, args, safeTxFile, false)
+		if errors.Is(err, errPendingNoCollector) {
+			appUI.Error(
+				"Safe Transaction Service is not available for chain %d, and --safe-tx-file was not set.",
+				config.Network().GetChainID(),
+			)
+			appUI.Info("Pass --safe-tx-file <path> to inspect a local Safe tx file, or configure SAFE_TX_SERVICE_URL_%d.", config.Network().GetChainID())
+			return
+		}
+		if err != nil {
+			appUI.Error("%s", err)
+			return
 		}
 
 		if _, err := safeContract.MergeOnChainApprovals(pending); err != nil {
@@ -2059,6 +1993,65 @@ func nextSafeNonce(s *safe.SafeContract, c safe.SignatureCollector) (uint64, err
 	return safe.NextNonce(s, c)
 }
 
+var (
+	errPendingNoCollector = errors.New("safe transaction service is not available")
+	errPendingNeedHash    = errors.New("on-chain approve without a service requires an explicit safeTxHash")
+)
+
+// loadPendingTx is the shared pending-tx source selector for approve /
+// execute / info: local file, Safe Transaction Service, or (approve only)
+// a hash-only stub when --approve-onchain is used without a service.
+func loadPendingTx(tc cmdutil.TxContext, args []string, file string, allowOnChainHash bool) (*safe.PendingTx, error) {
+	if file != "" {
+		_, pending, err := loadPendingFromTxFile(tc, file)
+		return pending, err
+	}
+	if tc.Collector == nil {
+		if allowOnChainHash {
+			return pendingFromOnChainHash(tc, args)
+		}
+		return nil, errPendingNoCollector
+	}
+	identifier, err := pickPendingTxIdentifier(tc, args)
+	if err != nil {
+		return nil, err
+	}
+	return resolvePendingTx(tc, identifier)
+}
+
+// pendingFromOnChainHash builds a hash-only PendingTx when there is no
+// Transaction Service. The caller must have passed a Safe-app URL with a
+// hash or a 32-byte 0x… positional arg.
+func pendingFromOnChainHash(tc cmdutil.TxContext, args []string) (*safe.PendingTx, error) {
+	if tc.SafeAppRef != nil && tc.SafeAppRef.HasTxHash() {
+		var hash [32]byte
+		copy(hash[:], tc.SafeAppRef.SafeTxHash[:])
+		return &safe.PendingTx{
+			Safe:       ethcommon.HexToAddress(tc.Safe.Address),
+			SafeTxHash: hash,
+		}, nil
+	}
+	if len(args) >= 2 {
+		if hash, ok := parseSafeTxHashArg(args[1]); ok {
+			return &safe.PendingTx{
+				Safe:       ethcommon.HexToAddress(tc.Safe.Address),
+				SafeTxHash: hash,
+			}, nil
+		}
+	}
+	return nil, errPendingNeedHash
+}
+
+func parseSafeTxHashArg(s string) ([32]byte, bool) {
+	s = strings.TrimSpace(s)
+	var hash [32]byte
+	if !strings.HasPrefix(strings.ToLower(s), "0x") || len(s) != 66 {
+		return hash, false
+	}
+	copy(hash[:], ethcommon.FromHex(s))
+	return hash, true
+}
+
 // loadPendingFromTxFile reads safeTxFile, cross-checks that it matches
 // the Safe and chain the user is currently targeting, and returns a
 // PendingTx in the same shape the Safe Transaction Service would. It is
@@ -2147,9 +2140,7 @@ func pickPendingTxIdentifier(tc cmdutil.TxContext, args []string) (string, error
 // or SafeTx nonce (decimal integer).
 func resolvePendingTx(tc cmdutil.TxContext, identifier string) (*safe.PendingTx, error) {
 	identifier = strings.TrimSpace(identifier)
-	if strings.HasPrefix(strings.ToLower(identifier), "0x") && len(identifier) == 66 {
-		var hash [32]byte
-		copy(hash[:], ethcommon.FromHex(identifier))
+	if hash, ok := parseSafeTxHashArg(identifier); ok {
 		pt, err := tc.Collector.Get(hash)
 		if err != nil {
 			return nil, fmt.Errorf("fetching tx 0x%s from service: %w", ethcommon.Bytes2Hex(hash[:]), err)

--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -427,39 +427,34 @@ approve' and any owner can finalise via 'jarvis msig execute'.`,
 		}
 
 		appUI.Info("Unlock your wallet and sign the EIP-712 safeTxHash now...")
-		account, err := accounts.UnlockAccount(tc.FromAcc)
+		sig, err := signSafeTx(tc.FromAcc, stx, domainSep)
+		if errors.Is(err, errSignSafeHash) {
+			appUI.Error("Couldn't sign safeTxHash: %s", signCause(err))
+			return
+		}
 		if err != nil {
 			appUI.Error("Couldn't unlock wallet: %s", err)
 			return
 		}
 
-		structHash := stx.StructHash()
-		sig, err := account.SignSafeHash(domainSep, structHash)
-		if err != nil {
-			appUI.Error("Couldn't sign safeTxHash: %s", err)
+		if err := safe.SubmitProposal(
+			tc.Collector,
+			safeTxFile,
+			ethcommon.HexToAddress(safeContract.Address),
+			config.Network().GetChainID(),
+			stx, hash,
+			ethcommon.HexToAddress(tc.From),
+			sig,
+		); err != nil {
+			if safeTxFile != "" {
+				appUI.Error("Couldn't write Safe tx file: %s", err)
+			} else {
+				appUI.Error("Submitting proposal to Safe Transaction Service failed: %s", err)
+			}
 			return
 		}
 
-		firstSig := []safe.OwnerSig{{
-			Owner: ethcommon.HexToAddress(tc.From),
-			Sig:   sig,
-		}}
-
 		if safeTxFile != "" {
-			// File mode: persist the proposal locally and tell the user how
-			// to hand the file off to the next signer. We deliberately do
-			// NOT also POST to the Safe Transaction Service in this mode,
-			// since the file becomes the source of truth going forward and
-			// mixing the two would create split-brain state.
-			if err := safe.WriteTxFile(
-				safeTxFile,
-				safeContract.Address,
-				config.Network().GetChainID(),
-				stx, hash, firstSig,
-			); err != nil {
-				appUI.Error("Couldn't write Safe tx file: %s", err)
-				return
-			}
 			appUI.Success("Proposal written to %s", safeTxFile)
 			appUI.Info("network: %s (chain %d)", config.Network().GetName(), config.Network().GetChainID())
 			appUI.Info("safeTxHash: 0x%s", ethcommon.Bytes2Hex(hash[:]))
@@ -469,17 +464,6 @@ approve' and any owner can finalise via 'jarvis msig execute'.`,
 			appUI.Info("  jarvis msig execute %s --safe-tx-file %s%s", safeContract.Address, safeTxFile, networkFlag())
 			return
 		}
-
-		if err := tc.Collector.Propose(
-			ethcommon.HexToAddress(safeContract.Address),
-			stx, hash,
-			ethcommon.HexToAddress(tc.From),
-			sig,
-		); err != nil {
-			appUI.Error("Submitting proposal to Safe Transaction Service failed: %s", err)
-			return
-		}
-
 		appUI.Success("Proposal submitted.")
 		appUI.Info("network: %s (chain %d)", config.Network().GetName(), config.Network().GetChainID())
 		appUI.Info("safeTxHash: 0x%s", ethcommon.Bytes2Hex(hash[:]))
@@ -1996,16 +1980,20 @@ func ownerAlreadySigned(pending *safe.PendingTx, me ethcommon.Address) (onChain 
 	return false, false
 }
 
-func signPendingSafeTx(fromAcc jtypes.AccDesc, pending *safe.PendingTx, domainSep [32]byte) ([]byte, error) {
+func signSafeTx(fromAcc jtypes.AccDesc, stx *safe.SafeTx, domainSep [32]byte) ([]byte, error) {
 	account, err := accounts.UnlockAccount(fromAcc)
 	if err != nil {
 		return nil, err
 	}
-	sig, err := account.SignSafeHash(domainSep, pending.SafeTx.StructHash())
+	sig, err := account.SignSafeHash(domainSep, stx.StructHash())
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errSignSafeHash, err)
 	}
 	return sig, nil
+}
+
+func signPendingSafeTx(fromAcc jtypes.AccDesc, pending *safe.PendingTx, domainSep [32]byte) ([]byte, error) {
+	return signSafeTx(fromAcc, pending.SafeTx, domainSep)
 }
 
 func signCause(err error) string {

--- a/cmd/safe_approve_test.go
+++ b/cmd/safe_approve_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	cmdutil "github.com/tranvictor/jarvis/cmd/util"
+	"github.com/tranvictor/jarvis/safe"
+)
+
+func TestVerifyPendingSafeTxHashSkipsNilBody(t *testing.T) {
+	pending := &safe.PendingTx{SafeTxHash: pendingTestHashBytes()}
+	if _, err := verifyPendingSafeTxHash(pending, [32]byte{1}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyPendingSafeTxHashMatchAndMismatch(t *testing.T) {
+	stx := safe.NewSafeTx(ethcommon.HexToAddress("0x1111111111111111111111111111111111111111"), big.NewInt(0), nil, safe.OpCall, 3)
+	var domain [32]byte
+	domain[0] = 0xab
+	hash := stx.SafeTxHash(domain)
+	pending := &safe.PendingTx{SafeTx: stx, SafeTxHash: hash}
+
+	if _, err := verifyPendingSafeTxHash(pending, domain); err != nil {
+		t.Fatal(err)
+	}
+
+	pending.SafeTxHash = pendingTestHashBytes()
+	expected, err := verifyPendingSafeTxHash(pending, domain)
+	if !errors.Is(err, errPendingHashMismatch) {
+		t.Fatalf("got %v", err)
+	}
+	if expected != hash {
+		t.Fatalf("expected %x want %x", expected, hash)
+	}
+}
+
+func TestOwnerAlreadySigned(t *testing.T) {
+	me := ethcommon.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	other := ethcommon.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	pending := &safe.PendingTx{
+		Sigs: []safe.OwnerSig{
+			{Owner: other, Sig: []byte{1}},
+		},
+	}
+	if _, found := ownerAlreadySigned(pending, me); found {
+		t.Fatal("should not find me")
+	}
+
+	pending.Sigs = append(pending.Sigs, safe.OwnerSig{Owner: me, Sig: append(make([]byte, 64), 27)})
+	onChain, found := ownerAlreadySigned(pending, me)
+	if !found || onChain {
+		t.Fatalf("off-chain: onChain=%v found=%v", onChain, found)
+	}
+
+	pending.Sigs[1] = safe.OnChainApprovalSig(me)
+	onChain, found = ownerAlreadySigned(pending, me)
+	if !found || !onChain {
+		t.Fatalf("on-chain: onChain=%v found=%v", onChain, found)
+	}
+}
+
+func TestPendingWithNewSig(t *testing.T) {
+	me := ethcommon.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	pending := &safe.PendingTx{
+		Sigs: []safe.OwnerSig{{Owner: ethcommon.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), Sig: []byte{1}}},
+	}
+	got := pendingWithNewSig(pending, me, []byte{2})
+	if len(pending.Sigs) != 1 {
+		t.Fatal("must not mutate original")
+	}
+	if len(got.Sigs) != 2 || got.Sigs[1].Owner != me {
+		t.Fatalf("got %+v", got.Sigs)
+	}
+}
+
+type confirmCollector struct {
+	stubCollector
+	gotHash [32]byte
+	gotMe   ethcommon.Address
+	gotSig  []byte
+}
+
+func (c *confirmCollector) Confirm(hash [32]byte, owner ethcommon.Address, sig []byte) error {
+	c.gotHash = hash
+	c.gotMe = owner
+	c.gotSig = sig
+	return nil
+}
+
+func TestPersistApprovalUsesCollector(t *testing.T) {
+	h := pendingTestHashBytes()
+	me := ethcommon.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	col := &confirmCollector{}
+	tc := cmdutil.TxContext{Collector: col}
+	pending := &safe.PendingTx{SafeTxHash: h}
+	if err := persistApproval(tc, pendingTestSafe, pending, me, []byte{9}, "", 1); err != nil {
+		t.Fatal(err)
+	}
+	if col.gotHash != h || col.gotMe != me || len(col.gotSig) != 1 || col.gotSig[0] != 9 {
+		t.Fatalf("confirm %+v %+v %v", col.gotHash, col.gotMe, col.gotSig)
+	}
+}

--- a/cmd/safe_pending_test.go
+++ b/cmd/safe_pending_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"errors"
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	cmdutil "github.com/tranvictor/jarvis/cmd/util"
+	"github.com/tranvictor/jarvis/config"
+	"github.com/tranvictor/jarvis/safe"
+)
+
+const (
+	pendingTestSafe = "0x71f8f067348d47cced223eA24D2D77235bea722B"
+	pendingTestHash = "0x82c28e25b40c865440a0e89fd9578fe62f629f5fafaa0af0587342f7b4b41efe"
+)
+
+type stubCollector struct {
+	byHash  map[[32]byte]*safe.PendingTx
+	pending []*safe.PendingTx
+}
+
+func (s stubCollector) Propose(ethcommon.Address, *safe.SafeTx, [32]byte, ethcommon.Address, []byte) error {
+	return errors.New("unused")
+}
+func (s stubCollector) Confirm([32]byte, ethcommon.Address, []byte) error {
+	return errors.New("unused")
+}
+func (s stubCollector) Get(hash [32]byte) (*safe.PendingTx, error) {
+	if p, ok := s.byHash[hash]; ok {
+		return p, nil
+	}
+	return nil, errors.New("not found")
+}
+func (s stubCollector) FindByNonce(ethcommon.Address, uint64) (*safe.PendingTx, error) {
+	return nil, errors.New("unused")
+}
+func (s stubCollector) ListPending(ethcommon.Address) ([]*safe.PendingTx, error) {
+	return s.pending, nil
+}
+
+func pendingTestHashBytes() [32]byte {
+	var h [32]byte
+	copy(h[:], ethcommon.FromHex(pendingTestHash))
+	return h
+}
+
+func TestParseSafeTxHashArg(t *testing.T) {
+	h, ok := parseSafeTxHashArg(pendingTestHash)
+	if !ok || h != pendingTestHashBytes() {
+		t.Fatalf("got ok=%v hash=%x", ok, h)
+	}
+	if _, ok := parseSafeTxHashArg("0xabc"); ok {
+		t.Fatal("short hash should fail")
+	}
+	if _, ok := parseSafeTxHashArg("7"); ok {
+		t.Fatal("nonce should fail")
+	}
+}
+
+func TestLoadPendingTxNoCollector(t *testing.T) {
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: pendingTestSafe}}
+	_, err := loadPendingTx(tc, []string{pendingTestSafe}, "", false)
+	if !errors.Is(err, errPendingNoCollector) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestLoadPendingTxOnChainHashFromArg(t *testing.T) {
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: pendingTestSafe}}
+	got, err := loadPendingTx(tc, []string{pendingTestSafe, pendingTestHash}, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SafeTxHash != pendingTestHashBytes() {
+		t.Fatalf("hash %x", got.SafeTxHash)
+	}
+	if got.SafeTx != nil {
+		t.Fatal("hash-only pending must not invent a SafeTx body")
+	}
+}
+
+func TestLoadPendingTxOnChainHashFromURL(t *testing.T) {
+	h := pendingTestHashBytes()
+	tc := cmdutil.TxContext{
+		Safe: &safe.SafeContract{Address: pendingTestSafe},
+		SafeAppRef: &safe.SafeAppRef{
+			SafeAddress: ethcommon.HexToAddress(pendingTestSafe),
+			SafeTxHash:  h,
+		},
+	}
+	got, err := loadPendingTx(tc, []string{"https://app.safe.global/"}, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SafeTxHash != h {
+		t.Fatalf("hash %x", got.SafeTxHash)
+	}
+}
+
+func TestLoadPendingTxOnChainNeedsHash(t *testing.T) {
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: pendingTestSafe}}
+	_, err := loadPendingTx(tc, []string{pendingTestSafe}, "", true)
+	if !errors.Is(err, errPendingNeedHash) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestLoadPendingTxFromService(t *testing.T) {
+	h := pendingTestHashBytes()
+	want := &safe.PendingTx{SafeTxHash: h}
+	tc := cmdutil.TxContext{
+		Safe:      &safe.SafeContract{Address: pendingTestSafe},
+		Collector: stubCollector{byHash: map[[32]byte]*safe.PendingTx{h: want}},
+	}
+	got, err := loadPendingTx(tc, []string{pendingTestSafe, pendingTestHash}, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestLoadPendingTxFromFile(t *testing.T) {
+	if err := config.SetNetwork("mainnet"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "tx.json")
+	tx := safe.NewSafeTx(ethcommon.HexToAddress("0x1111111111111111111111111111111111111111"), big.NewInt(0), nil, safe.OpCall, 1)
+	h := pendingTestHashBytes()
+	if err := safe.WriteTxFile(path, pendingTestSafe, 1, tx, h, nil); err != nil {
+		t.Fatal(err)
+	}
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: pendingTestSafe}}
+	got, err := loadPendingTx(tc, nil, path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SafeTxHash != h {
+		t.Fatalf("hash %x", got.SafeTxHash)
+	}
+	if got.SafeTx == nil || got.SafeTx.Nonce.Uint64() != 1 {
+		t.Fatalf("body %+v", got.SafeTx)
+	}
+}
+
+func TestLoadPendingTxFileWrongSafe(t *testing.T) {
+	if err := config.SetNetwork("mainnet"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "tx.json")
+	tx := safe.NewSafeTx(ethcommon.HexToAddress("0x1111111111111111111111111111111111111111"), big.NewInt(0), nil, safe.OpCall, 1)
+	if err := safe.WriteTxFile(path, pendingTestSafe, 1, tx, pendingTestHashBytes(), nil); err != nil {
+		t.Fatal(err)
+	}
+	tc := cmdutil.TxContext{Safe: &safe.SafeContract{Address: "0x2222222222222222222222222222222222222222"}}
+	_, err := loadPendingTx(tc, nil, path, false)
+	if err == nil {
+		t.Fatal("expected safe mismatch")
+	}
+}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/spf13/cobra"
 
-	"github.com/tranvictor/jarvis/accounts"
 	types2 "github.com/tranvictor/jarvis/accounts/types"
 	cmdutil "github.com/tranvictor/jarvis/cmd/util"
 	jarviscommon "github.com/tranvictor/jarvis/common"
@@ -701,24 +700,24 @@ func sendFromSafe(
 	}
 
 	appUI.Info("Unlock %s and sign the EIP-712 safeTxHash now...", fromAddr)
-	account, err := accounts.UnlockAccount(fromAcc)
-	if err != nil {
+	sig, err := signSafeTx(fromAcc, stx, domainSep)
+	if err != nil && !errors.Is(err, errSignSafeHash) {
 		appUI.Error("Couldn't unlock wallet: %s", err)
 		if errors.Is(err, cmdutil.ErrWalletUnlock) {
 			os.Exit(126)
 		}
 		return
 	}
-
-	structHash := stx.StructHash()
-	sig, err := account.SignSafeHash(domainSep, structHash)
-	if err != nil {
-		appUI.Error("Couldn't sign safeTxHash: %s", err)
+	if errors.Is(err, errSignSafeHash) {
+		appUI.Error("Couldn't sign safeTxHash: %s", signCause(err))
 		return
 	}
 
-	if err := collector.Propose(
+	if err := safe.SubmitProposal(
+		collector,
+		"",
 		ethcommon.HexToAddress(safeContract.Address),
+		config.Network().GetChainID(),
 		stx, hash,
 		ethcommon.HexToAddress(fromAddr),
 		sig,

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -166,7 +166,7 @@ func sendFromMsig(reader utilreader.Reader, analyzer util.TxAnalyzer, resolver c
 		return
 	}
 
-	multisigContract, err := msig.NewMultisigContract(msigContractAddr, config.Network())
+	multisigContract, err := msig.NewMultisigContract(msigContractAddr, config.Network(), msig.WithReader(cmdutil.EthReaderOf(reader)))
 	if err != nil {
 		appUI.Error("Couldn't read the multisig: %s", err)
 		return
@@ -540,7 +540,7 @@ func detectSafeForSend(
 	if err != nil || typ != cmdutil.MultisigSafe {
 		return nil, false
 	}
-	sc, err := safe.NewSafeContract(addr, config.Network())
+	sc, err := safe.NewSafeContract(addr, config.Network(), safe.WithReader(cmdutil.EthReaderOf(reader)))
 	if err != nil {
 		return nil, false
 	}

--- a/cmd/util/eth_reader_test.go
+++ b/cmd/util/eth_reader_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/tranvictor/jarvis/util/reader"
 )
 
-type stubReader struct{ reader.Reader }
-
 func TestEthReaderOf(t *testing.T) {
 	if EthReaderOf(nil) != nil {
 		t.Fatal("nil interface")
@@ -16,9 +14,5 @@ func TestEthReaderOf(t *testing.T) {
 	r := &reader.EthReader{}
 	if EthReaderOf(r) != r {
 		t.Fatal("concrete reader")
-	}
-
-	if EthReaderOf(stubReader{}) != nil {
-		t.Fatal("other Reader impl")
 	}
 }

--- a/cmd/util/eth_reader_test.go
+++ b/cmd/util/eth_reader_test.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/tranvictor/jarvis/util/reader"
+)
+
+type stubReader struct{ reader.Reader }
+
+func TestEthReaderOf(t *testing.T) {
+	if EthReaderOf(nil) != nil {
+		t.Fatal("nil interface")
+	}
+
+	r := &reader.EthReader{}
+	if EthReaderOf(r) != r {
+		t.Fatal("concrete reader")
+	}
+
+	if EthReaderOf(stubReader{}) != nil {
+		t.Fatal("other Reader impl")
+	}
+}

--- a/cmd/util/pre_process.go
+++ b/cmd/util/pre_process.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tranvictor/jarvis/txanalyzer"
 	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util"
+	utilreader "github.com/tranvictor/jarvis/util/reader"
 )
 
 // showNodeErrorGuidance prints a structured diagnostic block when an RPC call
@@ -180,10 +181,10 @@ func CommonTxPreprocess(u ui.UI, cmd *cobra.Command, args []string) (err error) 
 
 	var fromAcc jtypes.AccDesc
 	if config.From == "" {
-		if !classicMultisigOwnerPickEligible(config.Network(), tc.To, a) {
+		if !classicMultisigOwnerPickEligible(config.Network(), tc.To, a, EthReaderOf(tc.Reader)) {
 			return fmt.Errorf("please specify the signing wallet with --from")
 		}
-		multisigContract, err := msig.NewMultisigContract(tc.To, config.Network())
+		multisigContract, err := msig.NewMultisigContract(tc.To, config.Network(), msig.WithReader(EthReaderOf(tc.Reader)))
 		if err != nil {
 			return err
 		}
@@ -250,7 +251,7 @@ func CommonSafeReadPreprocess(u ui.UI, cmd *cobra.Command, args []string) error 
 		return fmt.Errorf("please specify the safe address as the first argument")
 	}
 
-	safeContract, err := safe.NewSafeContract(tc.To, config.Network())
+	safeContract, err := safe.NewSafeContract(tc.To, config.Network(), safe.WithReader(EthReaderOf(tc.Reader)))
 	if err != nil {
 		return fmt.Errorf("couldn't init safe reader: %w", err)
 	}
@@ -333,7 +334,7 @@ func CommonSafeTxPreprocess(u ui.UI, cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	safeContract, err := safe.NewSafeContract(tc.To, config.Network())
+	safeContract, err := safe.NewSafeContract(tc.To, config.Network(), safe.WithReader(EthReaderOf(tc.Reader)))
 	if err != nil {
 		return fmt.Errorf("couldn't init safe reader: %w", err)
 	}
@@ -459,13 +460,13 @@ func applyMultisigArgNetworkHint(cmd *cobra.Command, args []string) {
 // multisig so an empty --from can be resolved by picking the sole local owner.
 // Explorer ABIs are often incomplete (proxy/factory shapes), so we fall back
 // to the same on-chain NOTransactions probe used by DetectMultisigType.
-func classicMultisigOwnerPickEligible(network networks.Network, to string, contractABI *abi.ABI) bool {
+func classicMultisigOwnerPickEligible(network networks.Network, to string, contractABI *abi.ABI, r *utilreader.EthReader) bool {
 	if contractABI != nil {
 		if ok, err := util.IsGnosisMultisig(contractABI); err == nil && ok {
 			return true
 		}
 	}
-	mc, err := msig.NewMultisigContract(to, network)
+	mc, err := msig.NewMultisigContract(to, network, msig.WithReader(r))
 	if err != nil {
 		return false
 	}

--- a/cmd/util/transaction_context.go
+++ b/cmd/util/transaction_context.go
@@ -29,20 +29,20 @@ type TxBroadcaster interface {
 // mutated config.* globals.
 type TxContext struct {
 	FromAcc       jtypes.AccDesc
-	From          string             // resolved hex address of the signer
-	To            string             // resolved hex address; empty for contract creation
-	Value         *big.Int           // parsed from config.RawValue
-	GasPrice      float64            // gwei; auto-fetched when config.GasPrice == 0
-	TipGas        float64            // gwei; auto-fetched for dynamic-fee txs
-	Nonce         uint64             // auto-fetched when config.Nonce == 0
+	From          string   // resolved hex address of the signer
+	To            string   // resolved hex address; empty for contract creation
+	Value         *big.Int // parsed from config.RawValue
+	GasPrice      float64  // gwei; auto-fetched when config.GasPrice == 0
+	TipGas        float64  // gwei; auto-fetched for dynamic-fee txs
+	Nonce         uint64   // auto-fetched when config.Nonce == 0
 	TxType        uint8
 	PrefillMode   bool
 	PrefillParams []string
-	TxInfo      *jarviscommon.TxInfo // non-nil when args[0] was a tx hash
-	Reader      reader.Reader        // injected by preprocess; nil in tests that don't need network I/O
-	Broadcaster TxBroadcaster        // injected by CommonTxPreprocess; nil for read-only commands
-	Analyzer    util.TxAnalyzer      // pre-built from Reader in preprocessing; nil in read-only tests
-	Resolver    ABIResolver          // address/ABI lookup; DefaultABIResolver in production; stub in tests
+	TxInfo        *jarviscommon.TxInfo // non-nil when args[0] was a tx hash
+	Reader        reader.Reader        // injected by preprocess; nil in tests that don't need network I/O
+	Broadcaster   TxBroadcaster        // injected by CommonTxPreprocess; nil for read-only commands
+	Analyzer      util.TxAnalyzer      // pre-built from Reader in preprocessing; nil in read-only tests
+	Resolver      ABIResolver          // address/ABI lookup; DefaultABIResolver in production; stub in tests
 
 	// Safe-specific fields, populated by CommonSafeTxPreprocess. Nil for
 	// non-Safe commands so existing code paths are unaffected.
@@ -57,6 +57,14 @@ type TxContext struct {
 	// dispatch in cmd/msig.go can route to the Safe or Classic handler
 	// without re-probing on chain.
 	MultisigType MultisigType
+}
+
+// EthReaderOf returns the concrete *reader.EthReader when r is that
+// type, or nil otherwise. Safe/Classic constructors treat
+// WithReader(nil) as "open a new EthReader".
+func EthReaderOf(r reader.Reader) *reader.EthReader {
+	er, _ := r.(*reader.EthReader)
+	return er
 }
 
 type txContextKey struct{}

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -246,7 +246,7 @@ func HandleApproveOrRevokeOrExecuteMsig(
 		}
 	}
 
-	multisigContract, err := msig.NewMultisigContract(tc.To, config.Network())
+	multisigContract, err := msig.NewMultisigContract(tc.To, config.Network(), msig.WithReader(EthReaderOf(reader)))
 	if err != nil {
 		u.Error("Couldn't interact with the contract: %s", err)
 		return

--- a/msig/msig.go
+++ b/msig/msig.go
@@ -130,16 +130,42 @@ func (self *MultisigContract) TransactionInfo(txid *big.Int) (address string, va
 	return ret.Destination.Hex(), ret.Value, *ret.Data, *ret.Executed, confirmations, nil
 }
 
-func NewMultisigContract(address string, network Network) (*MultisigContract, error) {
-	reader, err := util.EthReader(network)
-	if err != nil {
-		return nil, err
+// Option configures NewMultisigContract. The no-option form still opens a
+// network reader so existing call sites stay valid.
+type Option func(*contractOptions)
+
+type contractOptions struct {
+	reader *reader.EthReader
+}
+
+// WithReader reuses an already-open EthReader instead of calling
+// util.EthReader again. A nil reader is ignored.
+func WithReader(r *reader.EthReader) Option {
+	return func(o *contractOptions) {
+		if r != nil {
+			o.reader = r
+		}
+	}
+}
+
+func NewMultisigContract(address string, network Network, opts ...Option) (*MultisigContract, error) {
+	var o contractOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	rd := o.reader
+	if rd == nil {
+		var err error
+		rd, err = util.EthReader(network)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &MultisigContract{
 		address,
 		network,
-		reader,
+		rd,
 		util.GetGnosisMsigABI(),
 	}, nil
 }

--- a/msig/msig_reader_test.go
+++ b/msig/msig_reader_test.go
@@ -1,0 +1,33 @@
+package msig
+
+import (
+	"testing"
+
+	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/util/reader"
+)
+
+func TestNewMultisigContractWithReader(t *testing.T) {
+	r := &reader.EthReader{}
+	mc, err := NewMultisigContract("0xabc", networks.EthereumMainnet, WithReader(r))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mc.reader != r {
+		t.Fatal("injected reader was not used")
+	}
+	if mc.Address != "0xabc" {
+		t.Fatalf("address %q", mc.Address)
+	}
+	if mc.Abi == nil {
+		t.Fatal("expected Classic ABI")
+	}
+}
+
+func TestWithReaderNilIsIgnored(t *testing.T) {
+	var o contractOptions
+	WithReader(nil)(&o)
+	if o.reader != nil {
+		t.Fatal("nil reader should be ignored")
+	}
+}

--- a/safe/propose.go
+++ b/safe/propose.go
@@ -1,0 +1,29 @@
+package safe
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// SubmitProposal persists a newly signed SafeTx either to a local file
+// or to a SignatureCollector. File mode does not also POST to the
+// collector (the file is the source of truth).
+func SubmitProposal(
+	c SignatureCollector,
+	file string,
+	safeAddr common.Address,
+	chainID uint64,
+	stx *SafeTx,
+	hash [32]byte,
+	owner common.Address,
+	sig []byte,
+) error {
+	if file != "" {
+		return WriteTxFile(file, safeAddr.Hex(), chainID, stx, hash, []OwnerSig{{Owner: owner, Sig: sig}})
+	}
+	if c == nil {
+		return fmt.Errorf("no signature collector")
+	}
+	return c.Propose(safeAddr, stx, hash, owner, sig)
+}

--- a/safe/propose_test.go
+++ b/safe/propose_test.go
@@ -1,0 +1,83 @@
+package safe
+
+import (
+	"errors"
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type proposeCollector struct {
+	called bool
+	addr   common.Address
+	hash   [32]byte
+	owner  common.Address
+	sig    []byte
+}
+
+func (p *proposeCollector) Propose(safe common.Address, _ *SafeTx, hash [32]byte, owner common.Address, sig []byte) error {
+	p.called = true
+	p.addr = safe
+	p.hash = hash
+	p.owner = owner
+	p.sig = sig
+	return nil
+}
+func (p *proposeCollector) Confirm([32]byte, common.Address, []byte) error {
+	return errors.New("unused")
+}
+func (p *proposeCollector) Get([32]byte) (*PendingTx, error) { return nil, errors.New("unused") }
+func (p *proposeCollector) FindByNonce(common.Address, uint64) (*PendingTx, error) {
+	return nil, errors.New("unused")
+}
+func (p *proposeCollector) ListPending(common.Address) ([]*PendingTx, error) {
+	return nil, errors.New("unused")
+}
+
+func TestSubmitProposalToCollector(t *testing.T) {
+	stx := NewSafeTx(common.HexToAddress("0x1111111111111111111111111111111111111111"), big.NewInt(1), nil, OpCall, 0)
+	var hash [32]byte
+	hash[0] = 0xab
+	owner := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	safeAddr := common.HexToAddress("0x71f8f067348d47cced223eA24D2D77235bea722B")
+	col := &proposeCollector{}
+	if err := SubmitProposal(col, "", safeAddr, 1, stx, hash, owner, []byte{1, 2, 3}); err != nil {
+		t.Fatal(err)
+	}
+	if !col.called || col.addr != safeAddr || col.hash != hash || col.owner != owner {
+		t.Fatalf("propose %+v", col)
+	}
+}
+
+func TestSubmitProposalFileSkipsCollector(t *testing.T) {
+	stx := NewSafeTx(common.HexToAddress("0x1111111111111111111111111111111111111111"), big.NewInt(0), nil, OpCall, 4)
+	var hash [32]byte
+	hash[1] = 0xcd
+	owner := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	safeAddr := common.HexToAddress("0x71f8f067348d47cced223eA24D2D77235bea722B")
+	col := &proposeCollector{}
+	path := filepath.Join(t.TempDir(), "tx.json")
+	if err := SubmitProposal(col, path, safeAddr, 1, stx, hash, owner, []byte{9}); err != nil {
+		t.Fatal(err)
+	}
+	if col.called {
+		t.Fatal("file mode must not POST to the collector")
+	}
+	tf, err := ReadTxFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tf.ChainID != 1 {
+		t.Fatalf("chain %d", tf.ChainID)
+	}
+}
+
+func TestSubmitProposalNilCollector(t *testing.T) {
+	stx := NewSafeTx(common.Address{}, big.NewInt(0), nil, OpCall, 0)
+	err := SubmitProposal(nil, "", common.Address{}, 1, stx, [32]byte{}, common.Address{}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/safe/safe.go
+++ b/safe/safe.go
@@ -25,13 +25,39 @@ type SafeContract struct {
 	Abi     *abi.ABI
 }
 
+// Option configures NewSafeContract. The no-option form still opens a
+// network reader so existing call sites stay valid.
+type Option func(*contractOptions)
+
+type contractOptions struct {
+	reader *reader.EthReader
+}
+
+// WithReader reuses an already-open EthReader instead of calling
+// util.EthReader again. A nil reader is ignored.
+func WithReader(r *reader.EthReader) Option {
+	return func(o *contractOptions) {
+		if r != nil {
+			o.reader = r
+		}
+	}
+}
+
 // NewSafeContract constructs a SafeContract bound to the given network.
 // It does NOT verify on-chain that the address is actually a Safe; callers
 // should check IsGnosisSafe(abi) on the address's ABI first.
-func NewSafeContract(address string, network networks.Network) (*SafeContract, error) {
-	r, err := util.EthReader(network)
-	if err != nil {
-		return nil, err
+func NewSafeContract(address string, network networks.Network, opts ...Option) (*SafeContract, error) {
+	var o contractOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	r := o.reader
+	if r == nil {
+		var err error
+		r, err = util.EthReader(network)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &SafeContract{
 		Address: address,

--- a/safe/safe_reader_test.go
+++ b/safe/safe_reader_test.go
@@ -1,0 +1,33 @@
+package safe
+
+import (
+	"testing"
+
+	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/util/reader"
+)
+
+func TestNewSafeContractWithReader(t *testing.T) {
+	r := &reader.EthReader{}
+	sc, err := NewSafeContract("0xabc", networks.EthereumMainnet, WithReader(r))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.reader != r {
+		t.Fatal("injected reader was not used")
+	}
+	if sc.Address != "0xabc" {
+		t.Fatalf("address %q", sc.Address)
+	}
+	if sc.Abi == nil {
+		t.Fatal("expected Safe ABI")
+	}
+}
+
+func TestWithReaderNilIsIgnored(t *testing.T) {
+	var o contractOptions
+	WithReader(nil)(&o)
+	if o.reader != nil {
+		t.Fatal("nil reader should be ignored")
+	}
+}

--- a/walletconnect/gateways/safe.go
+++ b/walletconnect/gateways/safe.go
@@ -192,14 +192,17 @@ func (g *SafeGateway) SendTransaction(
 	if err != nil {
 		return "", err
 	}
-	structHash := stx.StructHash()
-	sig, err := ac.SignSafeHash(domainSep, structHash)
+	sig, err := ac.SignSafeHash(domainSep, stx.StructHash())
 	if err != nil {
 		return "", fmt.Errorf("sign safeTxHash: %w", err)
 	}
 
-	if err := g.collector.Propose(
-		g.addr, stx, hash,
+	if err := safe.SubmitProposal(
+		g.collector,
+		"",
+		g.addr,
+		g.network.GetChainID(),
+		stx, hash,
 		ethcommon.HexToAddress(g.owner.Address),
 		sig,
 	); err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`NewSafeContract` and `NewMultisigContract` always called `util.EthReader`, even when preprocess (or `jarvis send`) already had a reader on `TxContext`.

`NewX(addr, network)` is unchanged for callers that do not pass options. Sites that already hold a reader pass `WithReader`.

```go
sc, err := safe.NewSafeContract(addr, network, safe.WithReader(r))
mc, err := msig.NewMultisigContract(addr, network, msig.WithReader(r))
```

`cmdutil.EthReaderOf` unwraps `reader.Reader` to `*reader.EthReader` (nil if it is not that concrete type). `WithReader(nil)` is ignored and the constructor still opens a new client.

Wired:
- Safe/Classic preprocess
- Classic owner-pick probe (same reader as the follow-up constructor)
- `msig summary` / `info` / `gov` / simulate-submit
- Classic approve/revoke/execute
- `jarvis send` Safe and Classic paths

Left as `NewX(addr, network)`: WalletConnect open, `DetectMultisigType`, cross-network `bapprove` (each ref has its own network).

Stacked on #97 (includes #95–#97). Merge #97 first, or merge this and close #95–#97 as superseded.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0528c-a970-7072-8275-03dc95ef0b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0528c-a970-7072-8275-03dc95ef0b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

