### PR TITLE
Delete unused exported constants, methods, and dead reader cascade (−214 lines)

### DIFF
--- a/common/eth_util.go
+++ b/common/eth_util.go
@@ -2,13 +2,10 @@ package common
 
 import (
 	"strings"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 )
-
-var Start time.Time
 
 func GetERC20ABI() *abi.ABI {
 	result, _ := abi.JSON(strings.NewReader(erc20abi))

--- a/db/default_address_database.go
+++ b/db/default_address_database.go
@@ -19,11 +19,6 @@ func (self *DefaultAddressDatabase) Register(addr string, name string) {
 	self.Data[common.HexToAddress(addr)] = name
 }
 
-type tokens []struct {
-	Address string `json:"address"`
-	Symbol  string `json:"symbol"`
-}
-
 func registerTokens(db *DefaultAddressDatabase) error {
 	tokens := AllTokenAddresses()
 	for addr, symbol := range tokens {

--- a/main.go
+++ b/main.go
@@ -21,13 +21,9 @@
 package main
 
 import (
-  "time"
-
 	"github.com/tranvictor/jarvis/cmd"
-	"github.com/tranvictor/jarvis/common"
 )
 
 func main() {
-  common.Start = time.Now()
 	cmd.Execute()
 }

--- a/util/account/account.go
+++ b/util/account/account.go
@@ -68,10 +68,6 @@ func (self *Account) Address() common.Address {
 	return self.address
 }
 
-func (self *Account) AddressHex() string {
-	return self.address.Hex()
-}
-
 func (self *Account) SignTx(
 	tx *types.Transaction,
 	chainId *big.Int,

--- a/util/erc20_util.go
+++ b/util/erc20_util.go
@@ -8,18 +8,6 @@ import (
 	"github.com/tranvictor/jarvis/util/cache"
 )
 
-var ERC20_METHODS = [...]string{
-	"name",
-	"symbol",
-	"decimals",
-	"totalSupply",
-	"balanceOf",
-	"transfer",
-	"transferFrom",
-	"approve",
-	"allowance",
-}
-
 var PROXY_METHODS = [...]string{
 	"implementation",
 	"upgradeTo",

--- a/util/explorers/etherscan_alike_explorer.go
+++ b/util/explorers/etherscan_alike_explorer.go
@@ -119,10 +119,6 @@ type abiresponse struct {
 	Result  string `json:"result"`
 }
 
-func (ar *abiresponse) IsOK() bool {
-	return ar.Status == "1"
-}
-
 func (ee *EtherscanLikeExplorer) GetABIString(address string) (string, error) {
 	url := ee.GetABIStringAPIURL(address)
 	resp, err := http.Get(url)
@@ -162,11 +158,11 @@ type sourceCodeResponse struct {
 	Status  string `json:"status"`
 	Message string `json:"message"`
 	Result  []struct {
-		ContractName        string `json:"ContractName"`
-		ABI                 string `json:"ABI"`
-		Proxy               string `json:"Proxy"`
-		Implementation      string `json:"Implementation"`
-		CompilerVersion     string `json:"CompilerVersion"`
+		ContractName    string `json:"ContractName"`
+		ABI             string `json:"ABI"`
+		Proxy           string `json:"Proxy"`
+		Implementation  string `json:"Implementation"`
+		CompilerVersion string `json:"CompilerVersion"`
 	} `json:"result"`
 }
 

--- a/util/explorers/optimistic_rollup_explorer.go
+++ b/util/explorers/optimistic_rollup_explorer.go
@@ -9,9 +9,7 @@ import (
 )
 
 type OptimisticRollupExplorer struct {
-	gpmu              sync.Mutex
-	latestGasPrice    float64
-	gasPriceTimestamp int64
+	gpmu sync.Mutex
 
 	Domain string
 	APIKey string

--- a/util/reader/ethereum_node.go
+++ b/util/reader/ethereum_node.go
@@ -27,8 +27,6 @@ type EthereumNode interface {
 	GetPendingNonce(address string) (nonce uint64, err error)
 	TransactionReceipt(txHash string) (receipt *types.Receipt, err error)
 	TransactionByHash(txHash string) (tx *common.Transaction, isPending bool, err error)
-	// Call(result interface{}, method string, args ...interface{}) error
-	GetGasPriceSuggestion() (*big.Int, error)
 	SuggestedGasPrice() (*big.Int, error)
 	SuggestedGasTipCap() (*big.Int, error)
 	ReadContractToBytes(

--- a/util/reader/one_node_reader.go
+++ b/util/reader/one_node_reader.go
@@ -120,16 +120,6 @@ func (onr *OneNodeReader) GetCode(address string) (code []byte, err error) {
 	return ethcli.CodeAt(timeout, addr, nil)
 }
 
-func (onr *OneNodeReader) GetGasPriceSuggestion() (*big.Int, error) {
-	ethcli, err := onr.EthClient()
-	if err != nil {
-		return nil, err
-	}
-	timeout, cancel := context.WithTimeout(context.Background(), TIMEOUT)
-	defer cancel()
-	return ethcli.SuggestGasPrice(timeout)
-}
-
 func (onr *OneNodeReader) GetBalance(address string) (balance *big.Int, err error) {
 	ethcli, err := onr.EthClient()
 	if err != nil {

--- a/util/reader/reader.go
+++ b/util/reader/reader.go
@@ -35,12 +35,6 @@ type Reader interface {
 	ReadContractToBytes(atBlock int64, from string, caddr string, abi *abi.ABI, method string, args ...interface{}) ([]byte, error)
 }
 
-const (
-	DEFAULT_ETHERSCAN_APIKEY string = "UBB257TI824FC7HUSPT66KZUMGBPRN3IWV"
-	DEFAULT_BSCSCAN_APIKEY   string = "62TU8Z81F7ESNJT38ZVRBSX7CNN4QZSP5I"
-	DEFAULT_TOMOSCAN_APIKEY  string = ""
-)
-
 type EthReader struct {
 	nodes map[string]EthereumNode
 	be    jarvisnetworks.BlockExplorer
@@ -204,34 +198,6 @@ func (er *EthReader) TxInfoFromHash(tx string) (jarviscommon.TxInfo, error) {
 			Receipt:     receipt,
 		}, nil
 	}
-}
-
-type getGasSuggestionResponse struct {
-	GasPrice *big.Int
-	Error    error
-}
-
-func (er *EthReader) GetGasPriceWeiSuggestion() (*big.Int, error) {
-	resCh := make(chan getGasSuggestionResponse, len(er.nodes))
-	for i := range er.nodes {
-		n := er.nodes[i]
-		go func() {
-			price, err := n.GetGasPriceSuggestion()
-			resCh <- getGasSuggestionResponse{
-				GasPrice: price,
-				Error:    wrapError(err, n.NodeName()),
-			}
-		}()
-	}
-	errs := []error{}
-	for i := 0; i < len(er.nodes); i++ {
-		result := <-resCh
-		if result.Error == nil {
-			return result.GasPrice, result.Error
-		}
-		errs = append(errs, result.Error)
-	}
-	return nil, fmt.Errorf("couldn't read from any nodes: %w", errors.Join(errs...))
 }
 
 type getBalanceResponse struct {
@@ -549,37 +515,6 @@ func (er *EthReader) StorageAt(atBlock int64, caddr string, slot string) ([]byte
 	return nil, fmt.Errorf("couldn't read from any nodes: %w", errors.Join(errs...))
 }
 
-func (er *EthReader) ReadHistoryContractWithABI(
-	atBlock int64,
-	result interface{},
-	caddr string,
-	abi *abi.ABI,
-	method string,
-	args ...interface{},
-) error {
-	responseBytes, err := er.ReadContractToBytes(
-		int64(atBlock), DEFAULT_ADDRESS, caddr, abi, method, args...)
-	if err != nil {
-		return err
-	}
-	return abi.UnpackIntoInterface(result, method, responseBytes)
-}
-
-func (er *EthReader) ReadContractWithABIAndFrom(
-	result interface{},
-	from string,
-	caddr string,
-	abi *abi.ABI,
-	method string,
-	args ...interface{},
-) error {
-	responseBytes, err := er.ReadContractToBytes(-1, from, caddr, abi, method, args...)
-	if err != nil {
-		return err
-	}
-	return abi.UnpackIntoInterface(result, method, responseBytes)
-}
-
 func (er *EthReader) ReadContractWithABI(
 	result interface{},
 	caddr string,
@@ -592,20 +527,6 @@ func (er *EthReader) ReadContractWithABI(
 		return err
 	}
 	return abi.UnpackIntoInterface(result, method, responseBytes)
-}
-
-func (er *EthReader) ReadHistoryContract(
-	atBlock int64,
-	result interface{},
-	caddr string,
-	method string,
-	args ...interface{},
-) error {
-	abi, err := er.GetABI(caddr)
-	if err != nil {
-		return err
-	}
-	return er.ReadHistoryContractWithABI(atBlock, result, caddr, abi, method, args...)
 }
 
 func (er *EthReader) ReadContract(
@@ -621,24 +542,6 @@ func (er *EthReader) ReadContract(
 	return er.ReadContractWithABI(result, caddr, abi, method, args...)
 }
 
-func (er *EthReader) HistoryERC20Balance(
-	atBlock int64,
-	caddr string,
-	user string,
-) (*big.Int, error) {
-	abi := jarviscommon.GetERC20ABI()
-	result := big.NewInt(0)
-	err := er.ReadHistoryContractWithABI(
-		atBlock,
-		&result,
-		caddr,
-		abi,
-		"balanceOf",
-		jarviscommon.HexToAddress(user),
-	)
-	return result, err
-}
-
 func (er *EthReader) ERC20Symbol(caddr string) (string, error) {
 	abi := jarviscommon.GetERC20ABI()
 	var result string
@@ -651,13 +554,6 @@ func (er *EthReader) ERC20Balance(caddr string, user string) (*big.Int, error) {
 	result := big.NewInt(0)
 	err := er.ReadContractWithABI(&result, caddr, abi, "balanceOf", jarviscommon.HexToAddress(user))
 	return result, err
-}
-
-func (er *EthReader) HistoryERC20Decimal(atBlock int64, caddr string) (int64, error) {
-	abi := jarviscommon.GetERC20ABI()
-	var result uint8
-	err := er.ReadHistoryContractWithABI(atBlock, &result, caddr, abi, "decimals")
-	return int64(result), err
 }
 
 func (er *EthReader) ERC20Decimal(caddr string) (uint64, error) {
@@ -785,40 +681,6 @@ func (er *EthReader) RecommendedGasPrice() (float64, error) {
 	return 0, fmt.Errorf("couldn't read from any nodes: %w", errors.Join(errs...))
 }
 
-func (er *EthReader) HistoryERC20Allowance(
-	atBlock int64,
-	caddr string,
-	owner string,
-	spender string,
-) (*big.Int, error) {
-	abi := jarviscommon.GetERC20ABI()
-	result := big.NewInt(0)
-	err := er.ReadHistoryContractWithABI(
-		atBlock,
-		&result, caddr, abi,
-		"allowance",
-		jarviscommon.HexToAddress(owner),
-		jarviscommon.HexToAddress(spender),
-	)
-	return result, err
-}
-
-func (er *EthReader) ERC20Allowance(
-	caddr string,
-	owner string,
-	spender string,
-) (*big.Int, error) {
-	abi := jarviscommon.GetERC20ABI()
-	result := big.NewInt(0)
-	err := er.ReadContractWithABI(
-		&result, caddr, abi,
-		"allowance",
-		jarviscommon.HexToAddress(owner),
-		jarviscommon.HexToAddress(spender),
-	)
-	return result, err
-}
-
 func (er *EthReader) AddressFromContractWithABI(
 	contract string,
 	abi *abi.ABI,
@@ -826,18 +688,6 @@ func (er *EthReader) AddressFromContractWithABI(
 ) (*common.Address, error) {
 	result := common.Address{}
 	err := er.ReadContractWithABI(&result, contract, abi, method)
-	if err != nil {
-		return nil, err
-	}
-	return &result, nil
-}
-
-func (er *EthReader) AddressFromContract(
-	contract string,
-	method string,
-) (*common.Address, error) {
-	result := common.Address{}
-	err := er.ReadContract(&result, contract, method)
 	if err != nil {
 		return nil, err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -30,18 +30,9 @@ import (
 )
 
 const (
-	ETH_ADDR                  string = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-	MAX_ADDR                  string = "0xffffffffffffffffffffffffffffffffffffffff"
-	MIN_ADDR                  string = "0x00000000000000ffffffffffffffffffffffffff"
-	ETHEREUM_MAINNET_NODE_VAR string = "ETHEREUM_MAINNET_NODE"
-	ETHEREUM_ROPSTEN_NODE_VAR string = "ETHEREUM_ROPSTEN_NODE"
-	TOMO_MAINNET_NODE_VAR     string = "TOMO_MAINNET_NODE"
-	ETHEREUM_KOVAN_NODE_VAR   string = "ETHEREUM_KOVAN_NODE"
-	ETHEREUM_RINKEBY_NODE_VAR string = "ETHEREUM_RINKEBY_NODE"
-	BSC_MAINNET_NODE_VAR      string = "BSC_MAINNET_NODE"
-	BSC_TESTNET_NODE_VAR      string = "BSC_TESTNET_NODE"
-	ETHERSCAN_API_KEY_VAR     string = "ETHERSCAN_API_KEY"
-	BSCSCAN_API_KEY_VAR       string = "BSCSCAN_API_KEY"
+	ETH_ADDR string = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	MAX_ADDR string = "0xffffffffffffffffffffffffffffffffffffffff"
+	MIN_ADDR string = "0x00000000000000ffffffffffffffffffffffffff"
 )
 
 // GetExactAddressFromDatabases resolves str against the local address


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Follow-up to #101. `deadcode` only reports *functions*, so this pass audits what it cannot see: exported constants, vars, types, and methods. Every top-level identifier was reference-counted across jarvis **and its three known dependents** (tranvictor/walletarmy, its fork, piavgh/abierr-example), plus `staticcheck -checks U1000` for unexported leftovers. Everything removed here has zero references anywhere. Net result: **+9 / −214 lines**, no behavior change.

## What was deleted

**Dead `EthReader` API and its cascade**
- Methods with no callers anywhere: `GetGasPriceWeiSuggestion`, `ReadHistoryContractWithABI`, `ReadContractWithABIAndFrom`, `ReadHistoryContract`, `HistoryERC20Balance`, `HistoryERC20Decimal`, `HistoryERC20Allowance`, `ERC20Allowance`, `AddressFromContract`
- The now-orphaned `getGasSuggestionResponse` type and `GetGasPriceSuggestion` (removed from the `EthereumNode` interface and its `OneNodeReader` implementation — nothing outside the deleted chain ever called it)

**Legacy constants**
- Env-var name constants for dead networks: `ETHEREUM_ROPSTEN/KOVAN/RINKEBY_NODE_VAR`, `TOMO_MAINNET_NODE_VAR`, `BSC_*_NODE_VAR`, `ETHEREUM_MAINNET_NODE_VAR`, `*SCAN_API_KEY_VAR`
- Hardcoded `DEFAULT_ETHERSCAN/BSCSCAN/TOMOSCAN_APIKEY` constants (also removes two stale API keys from the source)
- `ERC20_METHODS` (orphaned by the `IsERC20ABI` removal in #101)

**Small stragglers**
- `Account.AddressHex` (callers use `Address()`), `abiresponse.IsOK`, the unused `db.tokens` type, unused gas-price cache fields on `OptimisticRollupExplorer`
- The `common.Start` global — written once in `main.go`, never read; `main.go` shrinks to just `cmd.Execute()`

**Deliberately kept**
- `orderedMethods.Less` — satisfies `sort.Interface`, called dynamically by `sort.Sort`
- All JSON wire-format struct fields (Safe Transaction Builder, tx-service, ERC-7730 descriptors, explorer responses, WalletConnect payloads) — they stay faithful to the external APIs they mirror even where jarvis doesn't read every field

## Verification

- Reference-count audit over jarvis + all three dependent repos: zero usages of every deleted identifier
- `staticcheck -checks U1000` is clean
- `deadcode -test ./...` is clean except the two documented intentional keeps and the vendored `util/account/usb` package
- `go build ./...` passes; `go mod tidy` is a no-op (no dependencies freed)
- `go test $(go list ./... | grep -v util/account/usb)` (same as CI) passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0528c-a970-7072-8275-03dc95ef0b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0528c-a970-7072-8275-03dc95ef0b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

