### PR TITLE
Add Linux apt/yum repos and Windows Scoop distribution

### DIFF
--- a/.github/workflows/package-repos.yml
+++ b/.github/workflows/package-repos.yml
@@ -1,0 +1,114 @@
+# Rebuild the signed apt/yum repos on GitHub Pages after each GitHub release.
+# Requires repository secret APT_GPG_PRIVATE_KEY (see scripts/gen-apt-key.sh)
+# and Pages source = GitHub Actions.
+name: Package repositories
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to include (empty = all recent non-prerelease tags)
+        required: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: package-repos
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.gpg.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Import packaging key
+        id: gpg
+        env:
+          APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+        run: |
+          if [ -z "${APT_GPG_PRIVATE_KEY:-}" ]; then
+            echo "APT_GPG_PRIVATE_KEY is not set."
+            echo "Generate one with scripts/gen-apt-key.sh and add it as a repository secret."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mkdir -p ~/.gnupg
+          chmod 700 ~/.gnupg
+          printf '%s\n' "$APT_GPG_PRIVATE_KEY" | gpg --batch --import
+          gpg --list-secret-keys --keyid-format long
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Warn if signing key is missing
+        if: steps.gpg.outputs.skip == 'true'
+        run: |
+          echo "::warning::APT_GPG_PRIVATE_KEY is not set; apt/yum repo was not published. Run scripts/gen-apt-key.sh and add the private key as a repository secret, then enable GitHub Pages (source: GitHub Actions)."
+
+      - name: Install repo tools
+        if: steps.gpg.outputs.skip != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev apt-utils createrepo-c rpm gnupg
+
+      - name: Collect .deb and .rpm from GitHub Releases
+        if: steps.gpg.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          mkdir -p incoming
+          download() {
+            local tag="$1"
+            gh release download "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern '*.deb' \
+              --pattern '*.rpm' \
+              --dir incoming \
+              --clobber 2>/dev/null || true
+          }
+          if [ -n "${INPUT_TAG:-}" ]; then
+            download "$INPUT_TAG"
+          fi
+          # Keep recent versions so apt/dnf can still see older packages.
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            download "$tag"
+          done < <(gh release list --repo "$GITHUB_REPOSITORY" --limit 30 \
+            --json tagName,isPrerelease,isDraft \
+            --jq '.[] | select((.isPrerelease|not) and (.isDraft|not)) | .tagName')
+          echo "Collected packages:"
+          ls -l incoming || true
+          if ! compgen -G 'incoming/*.deb' >/dev/null && ! compgen -G 'incoming/*.rpm' >/dev/null; then
+            echo "No .deb/.rpm assets on recent releases yet. Ship a release with nfpms first."
+            exit 1
+          fi
+
+      - name: Build signed apt and yum trees
+        if: steps.gpg.outputs.skip != 'true'
+        env:
+          APT_GPG_PASSPHRASE: ${{ secrets.APT_GPG_PASSPHRASE }}
+        run: bash scripts/build-package-repos.sh incoming site
+
+      - name: Upload Pages artifact
+        if: steps.gpg.outputs.skip != 'true'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    if: needs.build.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/package-repos.yml
+++ b/.github/workflows/package-repos.yml
@@ -1,6 +1,14 @@
-# Rebuild the signed apt/yum repos on GitHub Pages after each GitHub release.
-# Requires repository secret APT_GPG_PRIVATE_KEY (see scripts/gen-apt-key.sh)
-# and Pages source = GitHub Actions.
+# Publish signed apt/yum repos to GitHub Pages.
+#
+# Pages setup (once): repo Settings → Pages → Source = "GitHub Actions".
+# Do NOT add a Jekyll/static-HTML starter workflow — this file is the one
+# that deploys the site (Actions tab → "Package repositories").
+#
+# When it runs: automatically after `make release` publishes a GitHub Release
+# that includes .deb/.rpm (goreleaser nfpms). You can also click "Run workflow"
+# here after the first such release if Pages/the signing key were set up late.
+#
+# Requires secret APT_GPG_PRIVATE_KEY (scripts/gen-apt-key.sh).
 name: Package repositories
 
 on:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -86,6 +86,38 @@ archives:
     files:
       - LICENSE
 
+# Linux packages attached to the GitHub release. A Pages workflow then turns
+# them into signed apt/yum repos so users can apt/dnf upgrade.
+nfpms:
+  - id: linux-packages
+    builds: [linux-amd64, linux-arm64]
+    vendor: tranvictor
+    homepage: https://github.com/tranvictor/jarvis
+    maintainer: Victor Tran <vu.tran54@gmail.com>
+    description: Onchain (EVM compatible) operation made easy
+    license: MIT
+    formats: [deb, rpm]
+    bindir: /usr/bin
+    section: utils
+    priority: optional
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/jarvis/LICENSE
+        file_info:
+          mode: 0644
+
+scoops:
+  - name: jarvis
+    ids: [windows]
+    repository:
+      owner: tranvictor
+      name: homebrew-tranvictor
+    skip_upload: auto
+    homepage: https://github.com/tranvictor/jarvis
+    description: Onchain (EVM compatible) operation made easy
+    license: MIT
+    commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+
 brews:
   - name: jarvis
     ids: [nix]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -90,6 +90,8 @@ archives:
 # them into signed apt/yum repos so users can apt/dnf upgrade.
 nfpms:
   - id: linux-packages
+    # goreleaser-cross v1.23.2 predates nfpms.ids (v2.8); `builds` is still
+    # accepted there and aliased to ids on newer goreleaser.
     builds: [linux-amd64, linux-arm64]
     vendor: tranvictor
     homepage: https://github.com/tranvictor/jarvis
@@ -104,7 +106,7 @@ nfpms:
       - src: LICENSE
         dst: /usr/share/doc/jarvis/LICENSE
         file_info:
-          mode: 0644
+          mode: 0o644
 
 scoops:
   - name: jarvis

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 
 # Interactive release: draft notes from git/PRs, let you edit them, commit
 # leftovers, prompt for the version, then tag + push + goreleaser-cross.
-# Requires a TTY and GITHUB_TOKEN (repo + homebrew-tranvictor tap).
+# Requires a TTY and GITHUB_TOKEN (repo + homebrew-tranvictor tap/Scoop bucket).
 .PHONY: release
 release:
 	@GORELEASER_CROSS_VERSION=$(GORELEASER_CROSS_VERSION) bash scripts/release.sh

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ sudo apt install jarvis
 
 Upgrade with `sudo apt update && sudo apt install --only-upgrade jarvis`.
 
+The apt (and dnf) repo is published to GitHub Pages on each GitHub release (`make release`). Until that has happened once after these packages were added, the URLs above will 404.
+
 ### Linux (dnf / yum)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Both Ethereum and BSC :)
 
 ## Installation
 
-### MacOS via Homebrew
+### Homebrew (macOS and Linux)
 
 ```bash
 brew install tranvictor/jarvis/jarvis
@@ -24,6 +24,42 @@ To upgrade to the latest version, refresh the tap first. `brew upgrade jarvis` a
 brew update
 brew upgrade tranvictor/jarvis/jarvis
 ```
+
+Linux users who already have [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) can use the same commands; the tap ships Linux amd64 and arm64 bottles.
+
+### Linux (apt)
+
+```bash
+sudo mkdir -p /etc/apt/keyrings
+sudo curl -fsSL https://tranvictor.github.io/jarvis/gpg/jarvis-archive-keyring.gpg \
+  -o /etc/apt/keyrings/jarvis-archive-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/jarvis-archive-keyring.gpg] https://tranvictor.github.io/jarvis/apt stable main" \
+  | sudo tee /etc/apt/sources.list.d/jarvis.list
+sudo apt update
+sudo apt install jarvis
+```
+
+Upgrade with `sudo apt update && sudo apt install --only-upgrade jarvis`.
+
+### Linux (dnf / yum)
+
+```bash
+sudo rpm --import https://tranvictor.github.io/jarvis/gpg/jarvis-archive-keyring.asc
+sudo curl -fsSL https://tranvictor.github.io/jarvis/jarvis.repo \
+  -o /etc/yum.repos.d/jarvis.repo
+sudo dnf install jarvis
+```
+
+Upgrade with `sudo dnf upgrade jarvis`.
+
+### Windows (Scoop)
+
+```powershell
+scoop bucket add tranvictor https://github.com/tranvictor/homebrew-tranvictor
+scoop install jarvis
+```
+
+Upgrade with `scoop update jarvis`.
 
 ## Build from source
 

--- a/scripts/build-package-repos.sh
+++ b/scripts/build-package-repos.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Build a GPG-signed apt + yum repo tree from .deb/.rpm files.
+#
+# Usage:
+#   scripts/build-package-repos.sh <packages-dir> <site-dir>
+#
+# Expects GNUPGHOME to already contain a secret key (imported by the caller).
+# Optional: APT_GPG_PASSPHRASE for a protected key.
+set -euo pipefail
+
+PACKAGES="${1:?packages dir}"
+SITE="${2:?site output dir}"
+ORIGIN="${ORIGIN:-jarvis}"
+LABEL="${LABEL:-jarvis}"
+SUITE="${SUITE:-stable}"
+COMPONENT="${COMPONENT:-main}"
+BASE_URL="${BASE_URL:-https://tranvictor.github.io/jarvis}"
+
+GPG_PASSPHRASE="${APT_GPG_PASSPHRASE-}"
+gpg_sign() {
+	# usage: gpg_sign <gpg extra args...>
+	if [ -n "$GPG_PASSPHRASE" ]; then
+		gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" "$@"
+	else
+		gpg --batch --yes --pinentry-mode loopback "$@"
+	fi
+}
+
+need_cmd() {
+	command -v "$1" >/dev/null 2>&1 || { echo "ERROR: missing $1" >&2; exit 1; }
+}
+need_cmd gzip
+need_cmd gpg
+
+keyid="$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/{print $5; exit}')"
+[ -n "$keyid" ] || { echo "ERROR: no GPG secret key in GNUPGHOME" >&2; exit 1; }
+
+shopt -s nullglob
+debs=("$PACKAGES"/*.deb)
+rpms=("$PACKAGES"/*.rpm)
+if [ ${#debs[@]} -eq 0 ] && [ ${#rpms[@]} -eq 0 ]; then
+	echo "ERROR: no .deb or .rpm files in $PACKAGES" >&2
+	exit 1
+fi
+if [ ${#debs[@]} -gt 0 ]; then
+	need_cmd dpkg-scanpackages
+	need_cmd apt-ftparchive
+fi
+if [ ${#rpms[@]} -gt 0 ]; then
+	need_cmd createrepo_c
+fi
+
+rm -rf "$SITE"
+mkdir -p "$SITE/gpg" "$SITE/apt" "$SITE/rpm"
+
+gpg --batch --yes --export "$keyid" >"$SITE/gpg/jarvis-archive-keyring.gpg"
+gpg --batch --yes --armor --export "$keyid" >"$SITE/gpg/jarvis-archive-keyring.asc"
+
+# --- apt (dists/stable layout, amd64 + arm64) ---
+if [ ${#debs[@]} -gt 0 ]; then
+	pool="$SITE/apt/pool/${COMPONENT}/j/jarvis"
+	mkdir -p "$pool"
+	cp -a "${debs[@]}" "$pool/"
+
+	# Paths in Packages must be relative to the apt root.
+	pushd "$SITE/apt" >/dev/null
+	for arch in amd64 arm64; do
+		bindir="dists/${SUITE}/${COMPONENT}/binary-${arch}"
+		mkdir -p "$bindir"
+		# dpkg-scanpackages --arch filters by the package Architecture field.
+		dpkg-scanpackages --multiversion --arch "$arch" "pool/${COMPONENT}" /dev/null \
+			>"$bindir/Packages"
+		gzip -9kf "$bindir/Packages"
+	done
+
+	apt-ftparchive \
+		-o "APT::FTPArchive::Release::Origin=${ORIGIN}" \
+		-o "APT::FTPArchive::Release::Label=${LABEL}" \
+		-o "APT::FTPArchive::Release::Suite=${SUITE}" \
+		-o "APT::FTPArchive::Release::Codename=${SUITE}" \
+		-o "APT::FTPArchive::Release::Architectures=amd64 arm64" \
+		-o "APT::FTPArchive::Release::Components=${COMPONENT}" \
+		-o "APT::FTPArchive::Release::Description=jarvis packages" \
+		release "dists/${SUITE}" >"dists/${SUITE}/Release"
+
+	gpg_sign --clearsign -u "$keyid" -o "dists/${SUITE}/InRelease" "dists/${SUITE}/Release"
+	gpg_sign -abs -u "$keyid" -o "dists/${SUITE}/Release.gpg" "dists/${SUITE}/Release"
+	popd >/dev/null
+fi
+
+# --- yum/dnf ---
+rpm_gpgcheck=0
+if [ ${#rpms[@]} -gt 0 ]; then
+	cp -a "${rpms[@]}" "$SITE/rpm/"
+
+	# Sign packages when rpmsign is available so dnf gpgcheck=1 works.
+	# Passphrase-protected keys still sign apt Release files; rpmsign here
+	# only runs for unprotected keys (the default from gen-apt-key.sh).
+	if command -v rpmsign >/dev/null 2>&1 && [ -z "$GPG_PASSPHRASE" ]; then
+		cat >"${HOME}/.rpmmacros" <<EOF
+%_signature gpg
+%_gpg_name ${keyid}
+%__gpg /usr/bin/gpg
+%__gpg_sign_cmd %{__gpg} gpg --batch --yes --no-armor --pinentry-mode loopback -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
+EOF
+		for rpm in "$SITE"/rpm/*.rpm; do
+			rpmsign --addsign "$rpm"
+		done
+		rpm_gpgcheck=1
+	else
+		echo "WARN: RPM packages left unsigned (missing rpmsign or key has a passphrase); repo metadata is still signed" >&2
+	fi
+
+	createrepo_c --quiet "$SITE/rpm"
+	gpg_sign --detach-sign --armor -u "$keyid" -o "$SITE/rpm/repodata/repomd.xml.asc" \
+		"$SITE/rpm/repodata/repomd.xml"
+fi
+
+if [ ${#debs[@]} -gt 0 ]; then
+	cat >"$SITE/jarvis.list" <<EOF
+deb [signed-by=/etc/apt/keyrings/jarvis-archive-keyring.gpg] ${BASE_URL}/apt ${SUITE} ${COMPONENT}
+EOF
+fi
+
+if [ ${#rpms[@]} -gt 0 ]; then
+	cat >"$SITE/jarvis.repo" <<EOF
+[jarvis]
+name=jarvis
+baseurl=${BASE_URL}/rpm
+enabled=1
+gpgcheck=${rpm_gpgcheck}
+repo_gpgcheck=1
+gpgkey=${BASE_URL}/gpg/jarvis-archive-keyring.asc
+EOF
+fi
+
+cat >"$SITE/index.html" <<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>jarvis packages</title>
+<style>
+body { font-family: system-ui, sans-serif; max-width: 44rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
+pre { background: #f4f4f4; padding: 1rem; overflow-x: auto; }
+code { font-family: ui-monospace, monospace; }
+</style>
+</head>
+<body>
+<h1>jarvis package repository</h1>
+<p>Signed apt and yum/dnf packages for <a href="https://github.com/tranvictor/jarvis">tranvictor/jarvis</a>.</p>
+<h2>apt (Debian / Ubuntu)</h2>
+<pre><code>sudo mkdir -p /etc/apt/keyrings
+sudo curl -fsSL ${BASE_URL}/gpg/jarvis-archive-keyring.gpg \\
+  -o /etc/apt/keyrings/jarvis-archive-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/jarvis-archive-keyring.gpg] ${BASE_URL}/apt ${SUITE} ${COMPONENT}" \\
+  | sudo tee /etc/apt/sources.list.d/jarvis.list
+sudo apt update
+sudo apt install jarvis</code></pre>
+<h2>dnf / yum (Fedora / RHEL / CentOS)</h2>
+<pre><code>sudo rpm --import ${BASE_URL}/gpg/jarvis-archive-keyring.asc
+sudo curl -fsSL ${BASE_URL}/jarvis.repo -o /etc/yum.repos.d/jarvis.repo
+sudo dnf install jarvis</code></pre>
+<p><a href="https://github.com/tranvictor/jarvis#installation">Full install docs</a></p>
+</body>
+</html>
+EOF
+
+# Prevent Jekyll from hiding files on GitHub Pages.
+touch "$SITE/.nojekyll"
+
+echo "Built package repos in $SITE (key $keyid)"

--- a/scripts/gen-apt-key.sh
+++ b/scripts/gen-apt-key.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 # One-time: generate a dedicated GPG key for signing the jarvis apt/yum repos.
 #
-# 1. Run this script.
-# 2. Add the printed private key as GitHub secret APT_GPG_PRIVATE_KEY
-#    (repo Settings → Secrets and variables → Actions).
-# 3. Enable GitHub Pages on this repo: Settings → Pages → Source = GitHub Actions.
-# 4. Re-run the "Package repositories" workflow (or cut the next release).
+# After this PR is merged:
+# 1. Run this script (no args). It prints a private key and a public key.
+# 2. Repo Settings → Secrets and variables → Actions → New repository secret
+#    Name: APT_GPG_PRIVATE_KEY
+#    Value: the whole "BEGIN PGP PRIVATE KEY BLOCK" … "END" block.
+# 3. Repo Settings → Pages → Build and deployment → Source = GitHub Actions.
+#    Ignore the Jekyll / "Static HTML" suggested workflows. The workflow that
+#    deploys Pages is already in the repo: Actions → "Package repositories".
+# 4. Publish a new version the way you always do: `make release`.
+#    That builds .deb/.rpm, uploads them to the GitHub Release, and the
+#    "Package repositories" workflow then fills https://tranvictor.github.io/jarvis/
+#    Do not run that workflow before a release that has .deb/.rpm assets —
+#    current releases do not have them yet.
 #
 # Optional: if you pass a passphrase to this script, also add it as
 # APT_GPG_PASSPHRASE. An unprotected key is fine — the GitHub secret is the
@@ -52,4 +60,6 @@ if [ -n "$PASSPHRASE" ]; then
 	echo "Also add GitHub secret APT_GPG_PASSPHRASE with the passphrase you passed."
 fi
 echo "Key ID: $keyid"
-echo "Add the private block as APT_GPG_PRIVATE_KEY, then enable GitHub Pages (Actions source)."
+echo "Next: add the private block as secret APT_GPG_PRIVATE_KEY,"
+echo "set Pages source to GitHub Actions (do not add a Jekyll starter),"
+echo "then publish a version with: make release"

--- a/scripts/gen-apt-key.sh
+++ b/scripts/gen-apt-key.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# One-time: generate a dedicated GPG key for signing the jarvis apt/yum repos.
+#
+# 1. Run this script.
+# 2. Add the printed private key as GitHub secret APT_GPG_PRIVATE_KEY
+#    (repo Settings → Secrets and variables → Actions).
+# 3. Enable GitHub Pages on this repo: Settings → Pages → Source = GitHub Actions.
+# 4. Re-run the "Package repositories" workflow (or cut the next release).
+#
+# Optional: if you pass a passphrase to this script, also add it as
+# APT_GPG_PASSPHRASE. An unprotected key is fine — the GitHub secret is the
+# protection.
+set -euo pipefail
+
+PASSPHRASE="${1-}"
+NAME="${JARVIS_PACKAGING_NAME:-jarvis packaging}"
+EMAIL="${JARVIS_PACKAGING_EMAIL:-vu.tran54@gmail.com}"
+GNUPGHOME="$(mktemp -d)"
+export GNUPGHOME
+chmod 700 "$GNUPGHOME"
+cleanup() { rm -rf "$GNUPGHOME"; }
+trap cleanup EXIT
+
+batch="$(mktemp)"
+{
+	printf 'Key-Type: RSA\n'
+	printf 'Key-Length: 4096\n'
+	printf 'Key-Usage: sign\n'
+	printf 'Name-Real: %s\n' "$NAME"
+	printf 'Name-Email: %s\n' "$EMAIL"
+	printf 'Expire-Date: 0\n'
+	if [ -n "$PASSPHRASE" ]; then
+		printf 'Passphrase: %s\n' "$PASSPHRASE"
+	else
+		printf '%%no-protection\n'
+	fi
+} >"$batch"
+
+gpg --batch --generate-key "$batch"
+rm -f "$batch"
+
+keyid="$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/{print $5; exit}')"
+[ -n "$keyid" ] || { echo "ERROR: failed to generate a key" >&2; exit 1; }
+
+echo "=== GitHub secret APT_GPG_PRIVATE_KEY (private — do not commit) ==="
+gpg --armor --export-secret-keys "$keyid"
+echo
+echo "=== Public key (also exported automatically on each Pages deploy) ==="
+gpg --armor --export "$keyid"
+echo
+if [ -n "$PASSPHRASE" ]; then
+	echo "Also add GitHub secret APT_GPG_PASSPHRASE with the passphrase you passed."
+fi
+echo "Key ID: $keyid"
+echo "Add the private block as APT_GPG_PRIVATE_KEY, then enable GitHub Pages (Actions source)."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -71,7 +71,7 @@ need_cmd python3
 [ -n "${GITHUB_TOKEN:-}" ] || die "GITHUB_TOKEN is not set.
 
 Create a GitHub token with repo access (classic) or Contents read/write on
-jarvis + the homebrew-tranvictor tap (fine-grained), then:
+jarvis + the homebrew-tranvictor tap (Homebrew formula and Scoop bucket), then:
 
   export GITHUB_TOKEN=ghp_..."
 
@@ -195,7 +195,7 @@ git push origin "$version"
 need_cmd docker
 docker info >/dev/null 2>&1 || die "docker is not running"
 
-say "Running goreleaser-cross (cgo + GitHub + Homebrew tap)..."
+say "Running goreleaser-cross (cgo + GitHub + Homebrew tap + Scoop)..."
 if ! docker run --rm --privileged \
 	-e CGO_ENABLED=1 \
 	-e GITHUB_TOKEN \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
macOS already has `brew install` / `brew upgrade`. This adds the same kind of install-and-upgrade path for Linux and Windows, using goreleaser OSS only (no Pro, no winget).

## What users get

- **Homebrew on Linux** — same tap and commands as macOS. Linux bottles were already in [homebrew-tranvictor](https://github.com/tranvictor/homebrew-tranvictor); the README now documents them.
- **apt** — `apt update && apt install jarvis` from `https://tranvictor.github.io/jarvis/apt`
- **dnf/yum** — `dnf install jarvis` from `https://tranvictor.github.io/jarvis/rpm`
- **Scoop** — `scoop bucket add tranvictor https://github.com/tranvictor/homebrew-tranvictor` then `scoop install jarvis` / `scoop update`

## How it is wired

- [`.goreleaser.yml`](.goreleaser.yml) emits `.deb`/`.rpm` (nfpms) and a Scoop manifest at the **root** of `homebrew-tranvictor` (so `scoop bucket list` sees it next to the existing Formula).
- [`.github/workflows/package-repos.yml`](.github/workflows/package-repos.yml) rebuilds a GPG-signed apt + yum tree from those release assets and deploys it to GitHub Pages.

`nfpms.builds` is used on purpose: the release image is `goreleaser-cross:v1.23.2`, which predates the `nfpms.ids` rename.

## One-time maintainer setup (apt/yum)

Do these after merge, in this order:

1. `scripts/gen-apt-key.sh` → add the private key as repo secret **`APT_GPG_PRIVATE_KEY`**.
2. **Settings → Pages → Source = GitHub Actions.** Do not add a Jekyll or “Static HTML” starter. The deployer is already in the repo: **Actions → Package repositories**.
3. **`make release`** as you already do for Homebrew. That is what creates the first `.deb`/`.rpm` on a GitHub Release; the Package repositories workflow then runs by itself and fills `https://tranvictor.github.io/jarvis/`. Existing releases do not have those packages, so running the workflow *before* that first new release will fail.

Scoop needs no extra repo: goreleaser already has write access to `homebrew-tranvictor`. If the signing secret is missing, releases still succeed and the Pages job warns and skips.

## Verification so far

- `scripts/build-package-repos.sh` was run against dummy amd64+arm64 debs: Packages files, signed `InRelease`/`Release.gpg`, and `apt-get update` against a `file://` repo accepted the signature.
- `goreleaser check` (OSS v2.18) reports the config as valid aside from deprecations that already existed (`archives.format`, `archives.builds`, `brews`) plus `nfpms.builds` kept for the current cross image.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a057a1-9872-7276-98d1-f0daf1aef807?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a057a1-9872-7276-98d1-f0daf1aef807&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

