### PR TITLE
Document github-pages tag rule needed for release deploys

### DIFF
--- a/.github/workflows/package-repos.yml
+++ b/.github/workflows/package-repos.yml
@@ -1,12 +1,17 @@
 # Publish signed apt/yum repos to GitHub Pages.
 #
-# Pages setup (once): repo Settings → Pages → Source = "GitHub Actions".
-# Do NOT add a Jekyll/static-HTML starter workflow — this file is the one
-# that deploys the site (Actions tab → "Package repositories").
+# Pages setup (once):
+# 1. Repo Settings → Pages → Source = "GitHub Actions".
+#    Do NOT add a Jekyll/static-HTML starter — this file deploys the site.
+# 2. Repo Settings → Environments → github-pages → Deployment branches and tags
+#    must allow tags. GitHub defaults this to branch "master" only, which
+#    blocks `make release` (the run's ref is the version tag, e.g. v0.2.2).
+#    Add a tag rule named `v*` (or switch the dropdown to no restriction).
 #
 # When it runs: automatically after `make release` publishes a GitHub Release
-# that includes .deb/.rpm (goreleaser nfpms). You can also click "Run workflow"
-# here after the first such release if Pages/the signing key were set up late.
+# that includes .deb/.rpm. If that run was blocked, fix the environment
+# rule above, then Actions → Package repositories → Run workflow from master
+# (or Re-run the failed job once tags are allowed).
 #
 # Requires secret APT_GPG_PRIVATE_KEY (scripts/gen-apt-key.sh).
 name: Package repositories

--- a/scripts/gen-apt-key.sh
+++ b/scripts/gen-apt-key.sh
@@ -9,11 +9,13 @@
 # 3. Repo Settings → Pages → Build and deployment → Source = GitHub Actions.
 #    Ignore the Jekyll / "Static HTML" suggested workflows. The workflow that
 #    deploys Pages is already in the repo: Actions → "Package repositories".
-# 4. Publish a new version the way you always do: `make release`.
-#    That builds .deb/.rpm, uploads them to the GitHub Release, and the
-#    "Package repositories" workflow then fills https://tranvictor.github.io/jarvis/
-#    Do not run that workflow before a release that has .deb/.rpm assets —
-#    current releases do not have them yet.
+# 4. Repo Settings → Environments → github-pages → Deployment branches and tags:
+#    GitHub only allows branch "master" by default. Add a **tag** rule `v*`
+#    (or allow all). Without this, release-triggered deploys fail with
+#    "Tag vX.Y.Z is not allowed to deploy to github-pages".
+# 5. Publish a new version with `make release`. That uploads .deb/.rpm and
+#    starts "Package repositories" by itself. If a run already failed, fix
+#    step 4 then Actions → Package repositories → Run workflow (branch master).
 #
 # Optional: if you pass a passphrase to this script, also add it as
 # APT_GPG_PASSPHRASE. An unprotected key is fine — the GitHub secret is the
@@ -62,4 +64,5 @@ fi
 echo "Key ID: $keyid"
 echo "Next: add the private block as secret APT_GPG_PRIVATE_KEY,"
 echo "set Pages source to GitHub Actions (do not add a Jekyll starter),"
+echo "allow tag rule v* on the github-pages environment,"
 echo "then publish a version with: make release"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub auto-creates the `github-pages` environment with a deployment rule that only allows branch `master`. `make release` runs the Package repositories workflow from the version **tag** (`v0.2.2`), so deploy fails with:

`Tag "v0.2.2" is not allowed to deploy to github-pages due to environment protection rules.`

This PR only documents the fix in the workflow header and `scripts/gen-apt-key.sh`. The actual unblocking step is in repo settings (see below); no workflow logic change.

**To publish v0.2.2 now**

1. Settings → Environments → **github-pages** → **Deployment branches and tags**
2. Keep “Selected branches and tags”, click **Add deployment branch or tag rule**, ref type **Tag**, name `v*`
3. Actions → **Package repositories** → **Run workflow** → use workflow from **master** (or Re-run the failed `v0.2.2` job after the tag rule is saved)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a057a1-9872-7276-98d1-f0daf1aef807?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a057a1-9872-7276-98d1-f0daf1aef807&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

