### PR TITLE
Put Homebrew jarvis on PATH automatically

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,13 +151,13 @@ brews:
 
       line = %(eval "$(#{HOMEBREW_PREFIX}/bin/brew shellenv)")
       home = Pathname.new(Dir.home)
-      files = if OS.mac?
-        # .zprofile: Terminal.app login shells. .zshrc: iTerm/VS Code non-login.
-        [home/".zprofile", home/".zshrc"]
-      else
-        [home/".profile", home/".bashrc"]
-      end
-      files << home/".bash_profile" if ENV.fetch("SHELL", "").end_with?("bash")
+      # Write zsh *and* bash files. .zprofile/.zshrc are ignored if the user
+      # is on bash (or vice versa); unused files are harmless.
+      files = [
+        home/".zprofile", home/".zshrc",
+        home/".bash_profile", home/".bashrc",
+      ]
+      files << home/".profile" unless OS.mac?
 
       files.uniq.each do |file|
         text = file.exist? ? file.read : ""

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -136,9 +136,40 @@ brews:
         depends_on "go"
       end
     caveats: |
+      If the `jarvis` command is not found, open a new terminal window.
+      Or run this once in the current window:
+        eval "$(#{HOMEBREW_PREFIX}/bin/brew shellenv)"
+
       After a new GitHub release, refresh the tap before upgrading:
         brew update
         brew upgrade tranvictor/jarvis/jarvis
+    post_install: |
+      # Intel Homebrew already links into /usr/local/bin, which macOS puts on
+      # PATH by default. Apple Silicon (/opt/homebrew) and Linuxbrew do not.
+      brew_bin = HOMEBREW_PREFIX/"bin"
+      return if OS.mac? && brew_bin == Pathname.new("/usr/local/bin")
+
+      line = %(eval "$(#{HOMEBREW_PREFIX}/bin/brew shellenv)")
+      home = Pathname.new(Dir.home)
+      files = if OS.mac?
+        # .zprofile: Terminal.app login shells. .zshrc: iTerm/VS Code non-login.
+        [home/".zprofile", home/".zshrc"]
+      else
+        [home/".profile", home/".bashrc"]
+      end
+      files << home/".bash_profile" if ENV.fetch("SHELL", "").end_with?("bash")
+
+      files.uniq.each do |file|
+        text = file.exist? ? file.read : ""
+        next if text.include?("brew shellenv") || text.include?(brew_bin.to_s)
+
+        file.open("a") do |io|
+          io.puts
+          io.puts "# Added by the jarvis formula so the jarvis command is on PATH"
+          io.puts line
+        end
+        ohai "Added Homebrew to PATH in #{file}"
+      end
     install: |
       system "make", "jarvis" if build.head?
       bin.install "bin/jarvis"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,24 @@ Both Ethereum and BSC :)
 
 ### Homebrew (macOS and Linux)
 
+Easiest on a Mac (installs Homebrew if needed, puts it on PATH, then installs jarvis):
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tranvictor/jarvis/master/scripts/install.sh)"
+```
+
+Then open a **new** Terminal window and run `jarvis`.
+
+If you already use Homebrew:
+
 ```bash
 brew install tranvictor/jarvis/jarvis
+```
+
+On Apple Silicon, Homebrew lives in `/opt/homebrew/bin`, which is not on macOS's default PATH. The formula appends `brew shellenv` to `~/.zprofile` and `~/.zshrc` on install so `jarvis` works in new terminals. Already installed? Run `brew reinstall tranvictor/jarvis/jarvis` once, or:
+
+```bash
+eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
 
 To upgrade to the latest version, refresh the tap first. `brew upgrade jarvis` alone uses the locally cached formula, so after a new GitHub release it can report:
@@ -25,7 +41,7 @@ brew update
 brew upgrade tranvictor/jarvis/jarvis
 ```
 
-Linux users who already have [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) can use the same commands; the tap ships Linux amd64 and arm64 bottles.
+Linux users who already have [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) can use the same `brew install` / `brew upgrade` commands; the tap ships Linux amd64 and arm64 bottles.
 
 ### Linux (apt)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you already use Homebrew:
 brew install tranvictor/jarvis/jarvis
 ```
 
-On Apple Silicon, Homebrew lives in `/opt/homebrew/bin`, which is not on macOS's default PATH. The formula appends `brew shellenv` to `~/.zprofile` and `~/.zshrc` on install so `jarvis` works in new terminals. Already installed? Run `brew reinstall tranvictor/jarvis/jarvis` once, or:
+On Apple Silicon, Homebrew lives in `/opt/homebrew/bin`, which is not on macOS's default PATH. The formula appends `brew shellenv` to zsh (`~/.zprofile`, `~/.zshrc`) and bash (`~/.bash_profile`, `~/.bashrc`) startup files so `jarvis` works in new terminals regardless of which of those shells they use. Already installed? Run `brew reinstall tranvictor/jarvis/jarvis` once, or:
 
 ```bash
 eval "$(/opt/homebrew/bin/brew shellenv)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,17 +15,11 @@ persist_brew_path() {
 	local brew_bin
 	brew_bin="$(dirname "$brew_exe")"
 	local line="eval \"\$(${brew_exe} shellenv)\""
-	local files=()
-	case "${SHELL:-}" in
-	*/bash) files=("$HOME/.bash_profile" "$HOME/.bashrc") ;;
-	*)
-		if [ "$(uname -s)" = Darwin ]; then
-			files=("$HOME/.zprofile" "$HOME/.zshrc")
-		else
-			files=("$HOME/.profile" "$HOME/.bashrc")
-		fi
-		;;
-	esac
+	local files=(
+		"$HOME/.zprofile" "$HOME/.zshrc"
+		"$HOME/.bash_profile" "$HOME/.bashrc"
+	)
+	[ "$(uname -s)" != Darwin ] && files+=("$HOME/.profile")
 	local f contents
 	for f in "${files[@]}"; do
 		contents=""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# One-shot Homebrew install for jarvis. Puts Homebrew on PATH in login shells
+# (needed on Apple Silicon, where /opt/homebrew/bin is not on the default PATH)
+# then installs the formula.
+#
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tranvictor/jarvis/master/scripts/install.sh)"
+set -euo pipefail
+
+say() { printf '%s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+# Write `brew shellenv` into the user's shell startup files if it is not there.
+persist_brew_path() {
+	local brew_exe="$1"
+	local brew_bin
+	brew_bin="$(dirname "$brew_exe")"
+	local line="eval \"\$(${brew_exe} shellenv)\""
+	local files=()
+	case "${SHELL:-}" in
+	*/bash) files=("$HOME/.bash_profile" "$HOME/.bashrc") ;;
+	*)
+		if [ "$(uname -s)" = Darwin ]; then
+			files=("$HOME/.zprofile" "$HOME/.zshrc")
+		else
+			files=("$HOME/.profile" "$HOME/.bashrc")
+		fi
+		;;
+	esac
+	local f contents
+	for f in "${files[@]}"; do
+		contents=""
+		[ -f "$f" ] && contents="$(cat "$f")"
+		case "$contents" in
+		*"brew shellenv"*|*"${brew_bin}"*) continue ;;
+		esac
+		mkdir -p "$(dirname "$f")"
+		printf '\n# Added by jarvis install.sh so the jarvis command is on PATH\n%s\n' "$line" >>"$f"
+		say "Added Homebrew to PATH in $f"
+	done
+}
+
+ensure_brew() {
+	if command -v brew >/dev/null 2>&1; then
+		return 0
+	fi
+	local candidate
+	for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew \
+		"$HOME/.linuxbrew/bin/brew" /home/linuxbrew/.linuxbrew/bin/brew; do
+		if [ -x "$candidate" ]; then
+			# shellcheck disable=SC1090
+			eval "$("$candidate" shellenv)"
+			return 0
+		fi
+	done
+	say "Homebrew is not installed. Installing it (you may be asked for your password)..."
+	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+	for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew \
+		"$HOME/.linuxbrew/bin/brew" /home/linuxbrew/.linuxbrew/bin/brew; do
+		if [ -x "$candidate" ]; then
+			# shellcheck disable=SC1090
+			eval "$("$candidate" shellenv)"
+			return 0
+		fi
+	done
+	die "Homebrew installed but brew was not found on PATH. Open a new terminal and re-run this script."
+}
+
+ensure_brew
+BREW_PREFIX="$(brew --prefix)"
+persist_brew_path "$BREW_PREFIX/bin/brew"
+eval "$("$BREW_PREFIX/bin/brew" shellenv)"
+
+say "Installing jarvis..."
+brew install tranvictor/jarvis/jarvis
+
+if command -v jarvis >/dev/null 2>&1; then
+	say ""
+	say "Done. In this terminal you can run: jarvis"
+else
+	say ""
+	say "Installed. Open a new terminal window and run: jarvis"
+	say "Or in this window run:"
+	say "  eval \"\$($BREW_PREFIX/bin/brew shellenv)\""
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Homebrew already installs `jarvis` into `$(brew --prefix)/bin`. On Apple Silicon that directory is `/opt/homebrew/bin`, which is **not** on macOS’s default PATH, so non-technical users get `command not found` after a successful `brew install`.

This change makes PATH setup automatic:

- The Homebrew formula `post_install` appends `eval "$(brew shellenv)"` to **zsh** (`~/.zprofile`, `~/.zshrc`) and **bash** (`~/.bash_profile`, `~/.bashrc`) when missing. Unused files are ignored by the other shell. Intel Homebrew (`/usr/local/bin`) is skipped because that path is already default on macOS.
- `scripts/install.sh` is a one-line Mac installer: install Homebrew if needed, persist PATH, then `brew install jarvis`.
- Caveats tell people to open a new terminal, or `eval "$(brew shellenv)"` in the current one.

This does **not** cover fish (or other shells); those would need a different `brew shellenv` syntax. zsh is the macOS default; bash is the other common case.

Already installed? After this ships in a release, run `brew reinstall tranvictor/jarvis/jarvis` once (or use the eval line above).

The formula change lands in the tap on the next `make release`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a057a1-9872-7276-98d1-f0daf1aef807?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a057a1-9872-7276-98d1-f0daf1aef807&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

