### PR TITLE
UI phase 0: terminal primitives for the improved layout

### DIFF
--- a/cmd/clearsign.go
+++ b/cmd/clearsign.go
@@ -60,12 +60,12 @@ mirror. Existing user-added descriptors under local/ are untouched.
 Network access is required.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		reg := erc7730.SharedRegistry()
-		stop := appUI.Spinner("Fetching ERC-7730 registry...")
+		progress := appUI.Spinner("Fetching ERC-7730 registry...")
 		ctx := context.Background()
 		count, err := reg.SyncRegistry(ctx, erc7730.SyncOptions{
 			OnProgress: func(stage string, n int) {},
 		})
-		stop()
+		progress.Stop(ui.StyledText{})
 		if err != nil {
 			appUI.Error("clearsign update failed: %s", err)
 			os.Exit(1)

--- a/common/printer.go
+++ b/common/printer.go
@@ -70,6 +70,42 @@ func PlainAddress(addr Address) string {
 	return addr.Address
 }
 
+// IsKnownAddress reports whether addr carries a usable description from the
+// address book / token list. "unknown" is what the analyzer fills in when no
+// entry matched, so it counts as not known.
+func IsKnownAddress(addr Address) bool {
+	return addr.Desc != "" && addr.Desc != "unknown"
+}
+
+// ShortAddress abbreviates a hex address to its first four and last four hex
+// digits ("0x9642…5D4E"). Anything too short to abbreviate is returned as is.
+// Never use this on a signing screen: lookalike-address attacks rely on the
+// middle of the address being invisible.
+func ShortAddress(hex string) string {
+	if len(hex) <= 13 {
+		return hex
+	}
+	return hex[:6] + "…" + hex[len(hex)-4:]
+}
+
+// NameFirst formats an address for dense, read-only views. Known addresses
+// lead with their name and put the hex in parentheses; unknown ones lead with
+// the hex followed by "(unknown)". full selects the complete hex over the
+// ShortAddress form.
+func NameFirst(addr Address, full bool) string {
+	if addr.Address == "" {
+		return ""
+	}
+	hex := addr.Address
+	if !full {
+		hex = ShortAddress(hex)
+	}
+	if !IsKnownAddress(addr) {
+		return hex + " (unknown)"
+	}
+	return fmt.Sprintf("%s (%s)", addr.Desc, hex)
+}
+
 // VerboseAddress formats an Address for terminal display. The description is
 // wrapped in ANSI color via NameWithColor. Do NOT use the output as data
 // (e.g. JSON) — use PlainAddress for that.

--- a/common/printer_test.go
+++ b/common/printer_test.go
@@ -1,0 +1,49 @@
+package common
+
+import "testing"
+
+func TestShortAddress(t *testing.T) {
+	cases := map[string]string{
+		"0x9642b23Ed1E01Df1092B92641051881a322F5D4E": "0x9642…5D4E",
+		"0xabc":           "0xabc",
+		"":                "",
+		"0x1234567890abc": "0x1234…0abc",
+	}
+	for in, want := range cases {
+		if got := ShortAddress(in); got != want {
+			t.Errorf("ShortAddress(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNameFirst(t *testing.T) {
+	known := Address{Address: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D", Desc: "Uniswap V2 Router"}
+	unknown := Address{Address: "0x9642b23Ed1E01Df1092B92641051881a322F5D4E", Desc: "unknown"}
+	blank := Address{Address: "0x9642b23Ed1E01Df1092B92641051881a322F5D4E"}
+
+	cases := []struct {
+		addr Address
+		full bool
+		want string
+	}{
+		{known, false, "Uniswap V2 Router (0x7a25…488D)"},
+		{known, true, "Uniswap V2 Router (0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D)"},
+		{unknown, false, "0x9642…5D4E (unknown)"},
+		{blank, true, "0x9642b23Ed1E01Df1092B92641051881a322F5D4E (unknown)"},
+		{Address{}, false, ""},
+	}
+	for _, c := range cases {
+		if got := NameFirst(c.addr, c.full); got != c.want {
+			t.Errorf("NameFirst(%v, %v) = %q, want %q", c.addr, c.full, got, c.want)
+		}
+	}
+}
+
+func TestIsKnownAddress(t *testing.T) {
+	if IsKnownAddress(Address{Desc: "unknown"}) || IsKnownAddress(Address{}) {
+		t.Fatal("unknown/blank descriptions must not count as known")
+	}
+	if !IsKnownAddress(Address{Desc: "USDC"}) {
+		t.Fatal("named address must count as known")
+	}
+}

--- a/ui/recording.go
+++ b/ui/recording.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Entry records a single UI method call for test assertions.
@@ -101,6 +102,16 @@ func (r *RecordingUI) Section(title string) {
 	r.record("Section", title)
 }
 
+func (r *RecordingUI) Subsection(title string) {
+	r.record("Subsection", title)
+}
+
+// RewriteLastLine records a "Rewrite" entry; the previous entry is kept so
+// tests can see both what was shown and what replaced it.
+func (r *RecordingUI) RewriteLastLine(line string) {
+	r.record("Rewrite", line)
+}
+
 // BoxedSection records a "BoxedSection" entry with the title, then runs
 // body against the same RecordingUI so the inner output remains visible
 // in Entries() exactly as if it had been emitted without the box. Tests
@@ -176,6 +187,12 @@ func (r *RecordingUI) KeyValue(rows [][2]string) {
 	}
 }
 
+func (r *RecordingUI) KeyValueCells(rows [][2]TableCell) {
+	for _, row := range rows {
+		r.record("KeyValue", row[0].Text+": "+row[1].Text)
+	}
+}
+
 // Table records each data row (not the header) as a pipe-separated "Table"
 // entry so tests can assert on cell contents with HasMessage.
 func (r *RecordingUI) Table(headers []string, rows [][]string) {
@@ -229,10 +246,23 @@ func (r *RecordingUI) PrintTable(t *Table) {
 	}
 }
 
-// Spinner is a no-op in RecordingUI — no goroutines, no output.
-// The returned function is also a no-op.
-func (r *RecordingUI) Spinner(_ string) func() {
-	return func() {}
+// Spinner records "Spinner" for the initial message, "SpinnerUpdate" for each
+// Update and "SpinnerStop" for the final line, so tests can assert on the
+// sequence of states a wait went through. No goroutines are started.
+func (r *RecordingUI) Spinner(msg string) Progress {
+	r.record("Spinner", msg)
+	return &recordingProgress{r: r, start: time.Now()}
+}
+
+type recordingProgress struct {
+	r     *RecordingUI
+	start time.Time
+}
+
+func (p *recordingProgress) Update(msg string)      { p.r.record("SpinnerUpdate", msg) }
+func (p *recordingProgress) Elapsed() time.Duration { return time.Since(p.start) }
+func (p *recordingProgress) Stop(final StyledText) {
+	p.r.record("SpinnerStop", final.Text)
 }
 
 // Indent returns a child RecordingUI at one deeper indent level.

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -17,9 +18,9 @@ import (
 )
 
 const (
-	indentUnit  = "  "   // 2 spaces per indent level
-	sectionWidth = 50    // total character width for Section separators
-	promptPrefix = "> "  // shown on the input line before the cursor
+	indentUnit      = "  " // 2 spaces per indent level
+	sectionWidth    = 50   // total character width for Section separators
+	promptPrefix    = "> " // shown on the input line before the cursor
 	interpretPrefix = "→ " // shown after Ask to display what Jarvis understood
 )
 
@@ -31,16 +32,31 @@ type TerminalUI struct {
 	out         io.Writer
 	in          *bufio.Reader
 	au          aurora.Aurora
+	// tty is true only when out is an interactive terminal. It gates cursor
+	// movement and animation; colours are gated separately through au so a
+	// caller can force colours into a buffer without enabling animation.
+	tty bool
 }
 
 // NewTerminalUI creates a TerminalUI that writes to os.Stdout and reads from
 // os.Stdin. Colours are enabled automatically when stdout is a real terminal.
 func NewTerminalUI() *TerminalUI {
-	colorsEnabled := term.IsTerminal(int(os.Stdout.Fd()))
+	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
 	return &TerminalUI{
 		out: os.Stdout,
 		in:  bufio.NewReader(os.Stdin),
-		au:  aurora.NewAurora(colorsEnabled),
+		au:  aurora.NewAurora(isTTY),
+		tty: isTTY,
+	}
+}
+
+func (u *TerminalUI) child(indentLevel int, out io.Writer, tty bool) *TerminalUI {
+	return &TerminalUI{
+		indentLevel: indentLevel,
+		out:         out,
+		in:          u.in,
+		au:          u.au,
+		tty:         tty,
 	}
 }
 
@@ -63,6 +79,8 @@ func (u *TerminalUI) Style(t StyledText) string {
 		return u.au.Red(t.Text).String()
 	case SeverityCritical:
 		return u.au.Bold(t.Text).String()
+	case SeverityMuted:
+		return u.au.Faint(t.Text).String()
 	default: // SeverityInfo
 		return t.Text
 	}
@@ -106,8 +124,25 @@ func (u *TerminalUI) Section(title string) {
 	}
 	left := bars / 2
 	right := bars - left
-	line := strings.Repeat("=", left) + titled + strings.Repeat("=", right)
+	// The title carries the weight; the rule is there to be skimmed past.
+	line := u.au.Faint(strings.Repeat("=", left)).String() +
+		u.au.Bold(titled).String() +
+		u.au.Faint(strings.Repeat("=", right)).String()
 	fmt.Fprintf(u.out, "\n%s%s\n\n", u.prefix(), line)
+}
+
+// Subsection prints a bold heading after a blank line.
+func (u *TerminalUI) Subsection(title string) {
+	fmt.Fprintf(u.out, "\n%s%s\n", u.prefix(), u.au.Bold(title).String())
+}
+
+// RewriteLastLine moves the cursor up one line, clears it and writes line
+// there. Off-TTY it degrades to a plain writeLine.
+func (u *TerminalUI) RewriteLastLine(line string) {
+	if u.tty {
+		fmt.Fprint(u.out, "\x1b[1A\x1b[2K")
+	}
+	u.writeLine(line)
 }
 
 // BoxedSection renders body inside a rounded coloured-border box.
@@ -119,13 +154,8 @@ func (u *TerminalUI) Section(title string) {
 // writer with this UI's indent prefix preserved.
 func (u *TerminalUI) BoxedSection(severity Severity, title string, body func(UI)) {
 	var buf bytes.Buffer
-	inner := &TerminalUI{
-		indentLevel: 0,
-		out:         &buf,
-		in:          u.in,
-		au:          u.au,
-	}
-	body(inner)
+	// The buffer is not a terminal: no cursor movement or animation inside.
+	body(u.child(0, &buf, false))
 	writeBoxed(u.out, u.prefix(), severity, title, buf.String())
 }
 
@@ -203,18 +233,31 @@ func (u *TerminalUI) Choose(prompt string, options []string) int {
 // The label column is right-padded to the width of the longest label so all
 // values line up, making metadata blocks easy to scan at a glance.
 func (u *TerminalUI) KeyValue(rows [][2]string) {
+	cells := make([][2]TableCell, len(rows))
+	for i, r := range rows {
+		cells[i] = [2]TableCell{TC(r[0]), TC(r[1])}
+	}
+	u.KeyValueCells(cells)
+}
+
+// KeyValueCells renders an aligned 2-column block with per-cell colour.
+// Padding is computed on visible width so styled labels still line up.
+func (u *TerminalUI) KeyValueCells(rows [][2]TableCell) {
 	if len(rows) == 0 {
 		return
 	}
 	maxLabel := 0
 	for _, r := range rows {
-		if len(r[0]) > maxLabel {
-			maxLabel = len(r[0])
+		if w := runeLen(r[0].Text); w > maxLabel {
+			maxLabel = w
 		}
 	}
 	p := u.prefix()
 	for _, r := range rows {
-		fmt.Fprintf(u.out, "%s%-*s  %s\n", p, maxLabel, r[0], r[1])
+		label := u.Style(StyledText{Text: r[0].Text, Severity: r[0].Severity})
+		pad := strings.Repeat(" ", maxLabel-runeLen(r[0].Text))
+		value := u.Style(StyledText{Text: r[1].Text, Severity: r[1].Severity})
+		fmt.Fprintf(u.out, "%s%s%s  %s\n", p, label, pad, value)
 	}
 }
 
@@ -254,35 +297,101 @@ func (u *TerminalUI) PrintTable(t *Table) {
 	})
 }
 
-// Spinner starts an animated spinner with msg and returns a stop function.
-// The stop function clears the spinner line. On non-terminal outputs the
-// spinner is a no-op and only the message is printed once.
-func (u *TerminalUI) Spinner(msg string) func() {
-	if !term.IsTerminal(int(os.Stdout.Fd())) {
-		fmt.Fprintf(u.out, "%s%s\n", u.prefix(), msg)
-		return func() {}
+// Spinner starts a live status line. On a terminal it animates and appends
+// the elapsed time (m:ss), refreshing once a second; otherwise each distinct
+// message is printed once as a plain line so piped output stays readable.
+func (u *TerminalUI) Spinner(msg string) Progress {
+	p := &terminalProgress{u: u, start: time.Now(), msg: msg}
+	if !u.tty {
+		u.writeLine(msg)
+		return p
 	}
-	s := spinner.New(spinner.CharSets[14], 80*time.Millisecond, spinner.WithWriter(u.out))
-	s.Suffix = " " + msg
-	s.Start()
-	return func() {
-		s.Stop()
-		// briandowns/spinner clears the line with \r but no trailing \n,
-		// so we emit one to ensure the next output starts on a fresh line.
-		fmt.Fprintf(u.out, "\n")
+	p.s = spinner.New(spinner.CharSets[14], 80*time.Millisecond, spinner.WithWriter(u.out))
+	p.s.Prefix = u.prefix()
+	p.s.Suffix = p.suffix()
+	p.s.Start()
+	p.done = make(chan struct{})
+	go p.tick()
+	return p
+}
+
+type terminalProgress struct {
+	u     *TerminalUI
+	s     *spinner.Spinner // nil off-TTY
+	start time.Time
+	mu    sync.Mutex
+	msg   string
+	done  chan struct{}
+	once  sync.Once
+}
+
+func formatElapsed(d time.Duration) string {
+	secs := int(d.Seconds())
+	return fmt.Sprintf("%d:%02d", secs/60, secs%60)
+}
+
+func (p *terminalProgress) suffix() string {
+	return " " + p.msg + "  " + p.u.au.Faint(formatElapsed(time.Since(p.start))).String()
+}
+
+func (p *terminalProgress) refresh() {
+	p.s.Lock()
+	p.s.Suffix = p.suffix()
+	p.s.Unlock()
+}
+
+func (p *terminalProgress) tick() {
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-p.done:
+			return
+		case <-t.C:
+			p.mu.Lock()
+			p.refresh()
+			p.mu.Unlock()
+		}
 	}
+}
+
+func (p *terminalProgress) Update(msg string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if msg == p.msg {
+		return
+	}
+	p.msg = msg
+	if p.s == nil {
+		p.u.writeLine(msg)
+		return
+	}
+	p.refresh()
+}
+
+func (p *terminalProgress) Elapsed() time.Duration {
+	return time.Since(p.start)
+}
+
+func (p *terminalProgress) Stop(final StyledText) {
+	p.once.Do(func() {
+		if p.s != nil {
+			close(p.done)
+			// briandowns/spinner clears the line with \r but no trailing \n,
+			// so the final line (or the next output) starts on the same row.
+			p.s.Stop()
+		}
+		if final.Text != "" {
+			p.u.writeLine(p.u.Style(final))
+		}
+	})
 }
 
 // Indent returns a child UI at one deeper indent level.
 // The child shares the underlying writer and reader with the parent, so
 // input sequencing and output ordering are preserved across nested scopes.
 func (u *TerminalUI) Indent() UI {
-	return &TerminalUI{
-		indentLevel: u.indentLevel + 1,
-		out:         u.out,
-		in:          u.in,
-		au:          u.au,
-	}
+	return u.child(u.indentLevel+1, u.out, u.tty)
 }
 
 // Writer returns an io.Writer that automatically prepends the current

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -1,0 +1,155 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStyleMutedUsesFaint(t *testing.T) {
+	u := NewTerminalUIWithWriter(&bytes.Buffer{}, true)
+	got := u.Style(StyledText{Text: "uint256", Severity: SeverityMuted})
+	if !strings.Contains(got, "\x1b[2m") {
+		t.Fatalf("expected faint SGR in %q", got)
+	}
+	plain := NewTerminalUIWithWriter(&bytes.Buffer{}, false)
+	if got := plain.Style(StyledText{Text: "uint256", Severity: SeverityMuted}); got != "uint256" {
+		t.Fatalf("expected plain text when colours are off, got %q", got)
+	}
+}
+
+func TestKeyValueCellsAlignsOnVisibleWidth(t *testing.T) {
+	var buf bytes.Buffer
+	u := NewTerminalUIWithWriter(&buf, true)
+	u.KeyValueCells([][2]TableCell{
+		{TCS("Sign with", SeverityMuted), TC("0xabc")},
+		{TCS("To", SeverityMuted), TCS("0xdef", SeveritySuccess)},
+	})
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), buf.String())
+	}
+	col0 := strings.Index(stripANSI(lines[0]), "0xabc")
+	col1 := strings.Index(stripANSI(lines[1]), "0xdef")
+	if col0 != col1 {
+		t.Fatalf("values not aligned: %d vs %d in\n%s", col0, col1, stripANSI(buf.String()))
+	}
+	if !strings.Contains(lines[1], "\x1b[32m") {
+		t.Fatalf("expected green value, got %q", lines[1])
+	}
+}
+
+func TestSubsectionAndRewriteOffTTY(t *testing.T) {
+	var buf bytes.Buffer
+	u := NewTerminalUIWithWriter(&buf, false)
+	u.Subsection("Transfers")
+	u.Info("first")
+	u.RewriteLastLine("second")
+	want := "\nTransfers\nfirst\nsecond\n"
+	if buf.String() != want {
+		t.Fatalf("got %q, want %q", buf.String(), want)
+	}
+}
+
+func TestRewriteOnTTYMovesCursorUp(t *testing.T) {
+	var buf bytes.Buffer
+	u := NewTerminalUIWithWriter(&buf, false)
+	u.tty = true
+	u.Indent().RewriteLastLine("done")
+	if got := buf.String(); got != "\x1b[1A\x1b[2K  done\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSpinnerOffTTYPrintsDistinctMessagesOnce(t *testing.T) {
+	var buf bytes.Buffer
+	u := NewTerminalUIWithWriter(&buf, false)
+	p := u.Spinner("waiting")
+	p.Update("waiting")
+	p.Update("in mempool")
+	p.Stop(StyledText{Text: "✓ mined", Severity: SeveritySuccess})
+	p.Stop(StyledText{Text: "again"}) // second Stop is ignored
+	want := "waiting\nin mempool\n✓ mined\n"
+	if buf.String() != want {
+		t.Fatalf("got %q, want %q", buf.String(), want)
+	}
+	if p.Elapsed() < 0 || p.Elapsed() > time.Minute {
+		t.Fatalf("unexpected elapsed %v", p.Elapsed())
+	}
+}
+
+func TestSpinnerStopWithEmptyFinalPrintsNothing(t *testing.T) {
+	var buf bytes.Buffer
+	u := NewTerminalUIWithWriter(&buf, false)
+	p := u.Spinner("fetching")
+	p.Stop(StyledText{})
+	if buf.String() != "fetching\n" {
+		t.Fatalf("got %q", buf.String())
+	}
+}
+
+func TestFormatElapsed(t *testing.T) {
+	cases := map[time.Duration]string{
+		0:                              "0:00",
+		14 * time.Second:               "0:14",
+		61 * time.Second:               "1:01",
+		10*time.Minute + 5*time.Second: "10:05",
+	}
+	for d, want := range cases {
+		if got := formatElapsed(d); got != want {
+			t.Errorf("formatElapsed(%v) = %q, want %q", d, got, want)
+		}
+	}
+}
+
+func TestRecordingSpinnerRecordsStates(t *testing.T) {
+	r := NewRecordingUI()
+	p := r.Spinner("waiting")
+	p.Update("in mempool")
+	p.Stop(StyledText{Text: "✓ mined"})
+	got := r.Entries()
+	want := []Entry{
+		{"Spinner", "waiting"},
+		{"SpinnerUpdate", "in mempool"},
+		{"SpinnerStop", "✓ mined"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("entry %d: got %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestTreeGlyphs(t *testing.T) {
+	if TreeBranch(false) != "├─ " || TreeBranch(true) != "└─ " {
+		t.Fatal("unexpected branch glyphs")
+	}
+	if TreeGuide(false) != "│  " || TreeGuide(true) != "   " {
+		t.Fatal("unexpected guide glyphs")
+	}
+	if VisibleWidth(TreeBranch(false)) != VisibleWidth(TreeGuide(false)) {
+		t.Fatal("branch and guide must have equal width so nested lines align")
+	}
+}
+
+func stripANSI(s string) string {
+	var out strings.Builder
+	inEsc := false
+	for _, r := range s {
+		switch {
+		case inEsc:
+			if r == 'm' {
+				inEsc = false
+			}
+		case r == '\x1b':
+			inEsc = true
+		default:
+			out.WriteRune(r)
+		}
+	}
+	return out.String()
+}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"encoding/json"
 	"io"
+	"time"
 )
 
 // Severity classifies the visual weight of a piece of inline text, mirroring
@@ -16,7 +17,40 @@ const (
 	SeverityWarn                     // yellow — uncertain / needs attention
 	SeverityError                    // red    — unknown / negative
 	SeverityCritical                 // bold   — must-review before action
+	SeverityMuted                    // faint  — metadata that should recede (types, indices, hints)
 )
+
+// Progress is a live status line started by [UI.Spinner]. On a terminal it is
+// an animated spinner with the elapsed time appended; elsewhere it degrades to
+// one plain line per distinct message so logs stay readable.
+type Progress interface {
+	// Update replaces the message shown next to the spinner.
+	Update(msg string)
+	// Elapsed returns the time since the spinner was started.
+	Elapsed() time.Duration
+	// Stop clears the spinner and prints final as the line that stays in the
+	// transcript. Pass an empty Text to print nothing.
+	Stop(final StyledText)
+}
+
+// TreeBranch returns the glyph that introduces a nested item: "└─ " for the
+// last sibling, "├─ " otherwise.
+func TreeBranch(last bool) string {
+	if last {
+		return "└─ "
+	}
+	return "├─ "
+}
+
+// TreeGuide returns the continuation prefix placed under a TreeBranch for the
+// lines that belong to the same item: "   " after a last sibling, "│  "
+// otherwise, so vertical guides line up with the branch glyphs.
+func TreeGuide(last bool) string {
+	if last {
+		return "   "
+	}
+	return "│  "
+}
 
 // StyledText pairs a plain string with a Severity annotation.
 //
@@ -94,6 +128,16 @@ type UI interface {
 	// Example: "===== Confirm tx data before signing ====="
 	Section(title string)
 
+	// Subsection writes a bold heading preceded by a blank line, with no
+	// rule. Use it for the blocks inside a Section (e.g. "Transfers",
+	// "Events (4)") so they stand out without adding visual weight.
+	Subsection(title string)
+
+	// RewriteLastLine replaces the previous line of output with line. On a
+	// terminal this moves the cursor up and clears the line; elsewhere it
+	// simply writes line so transcripts and tests stay linear.
+	RewriteLastLine(line string)
+
 	// BoxedSection renders the output emitted by body inside a rounded
 	// rectangular box whose border colour reflects severity. The optional
 	// title is injected into the top border ("╭─ <title> ─...─╮") so the
@@ -115,6 +159,10 @@ type UI interface {
 	// Use for compact metadata like Status/From/To/Value or gas details.
 	KeyValue(rows [][2]string)
 
+	// KeyValueCells is KeyValue with per-cell severity so labels can recede
+	// (SeverityMuted) while values carry colour.
+	KeyValueCells(rows [][2]TableCell)
+
 	// Table renders a full bordered table with a header row followed by data
 	// rows. Use when there are 3+ columns or the data is inherently tabular
 	// (e.g. a decoded parameter list).
@@ -131,15 +179,16 @@ type UI interface {
 	// Use this instead of Table when cells need per-cell colour (e.g. node status).
 	PrintTable(t *Table)
 
-	// Spinner starts an animated spinner with the given message and returns a
-	// stop function. Call the stop function (or defer it) to clear the spinner
-	// once the work is done:
+	// Spinner starts a live status line with the given message and returns a
+	// Progress handle to update it and eventually stop it:
 	//
-	//   stop := u.Spinner("Fetching transaction...")
-	//   defer stop()
+	//   p := u.Spinner("Fetching transaction...")
+	//   p.Update("Decoding calldata...")
+	//   p.Stop(StyledText{Text: "✓ done", Severity: SeveritySuccess})
 	//
-	// In RecordingUI and non-terminal contexts the stop function is a no-op.
-	Spinner(msg string) func()
+	// On a terminal this animates and shows elapsed time; on non-terminal
+	// outputs each distinct message is printed once as a plain line.
+	Spinner(msg string) Progress
 
 	// Interpret writes what Jarvis understood from the user's last input.
 	// Always shown immediately after Ask, indented and prefixed with "→".


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 0 of `docs/improved-ui-plan.md`. Foundation only; the only user-visible change is `Section` titles now render bold over a faint rule.

- `SeverityMuted` on `Severity`; `TerminalUI.Style` renders it with aurora `Faint`, `RecordingUI` stays plain.
- `UI.Spinner` now returns a `Progress` handle (`Update`, `Elapsed`, `Stop(final)`). On a TTY the spinner shows elapsed `m:ss` refreshed every second; off-TTY each distinct message prints once as a plain line. `RecordingUI` records `Spinner` / `SpinnerUpdate` / `SpinnerStop` entries. The one caller (`clearsign update`) is updated.
- `UI.KeyValueCells([][2]TableCell)` for per-cell colour; `KeyValue` delegates to it. Padding uses visible width so styled labels align.
- `UI.Subsection(title)` (bold heading, no rule) and `UI.RewriteLastLine(line)` (cursor-up + clear on TTY, plain line otherwise).
- `TerminalUI` tracks `tty` separately from colours; `BoxedSection` inner UI and `NewTerminalUIWithWriter` are non-TTY.
- `ui.TreeBranch` / `ui.TreeGuide` glyph helpers (`├─ `, `└─ `, `│  `).
- `common.ShortAddress`, `common.NameFirst`, `common.IsKnownAddress` for dense read-only views (documented as never to be used on signing screens).

## Tests

`ui/terminal_test.go` and `common/printer_test.go` added. `go test ./...` passes except the pre-existing libusb tests that need a USB stack.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

