### PR TITLE
UI phase 1: importance-ordered `jarvis info` layout

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -30,9 +30,11 @@ var txCmd = &cobra.Command{
 			return
 		}
 
-		appUI.Info("Following tx hash(es) will be analyzed shortly:")
-		for i, t := range txs {
-			appUI.Info("  %d. %s", i, t)
+		if len(txs) > 1 {
+			appUI.Info("Analyzing %d transactions:", len(txs))
+			for i, t := range txs {
+				appUI.Info("  %d. %s", i+1, t)
+			}
 		}
 
 		displays := map[string]*util.TxDisplay{}
@@ -47,8 +49,7 @@ var txCmd = &cobra.Command{
 		}
 
 		for _, t := range txs {
-			appUI.Info("Analyzing tx: %s...", t)
-
+			appUI.Info("%s", t)
 			d := util.AnalyzeAndPrint(
 				appUI,
 				tc.Reader,
@@ -59,10 +60,10 @@ var txCmd = &cobra.Command{
 				config.CustomABI,
 				nil,
 				nil,
-				config.DegenMode,
+				util.InfoLayout(config.DegenMode),
 			)
 			displays[t] = d
-			appUI.Info("----------------------------------------------------------")
+			appUI.Info("")
 		}
 	},
 }

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -949,7 +949,7 @@ Safe+Classic runs write both arrays into one file.`,
 				util.AnalyzeAndPrint(
 					appUI,
 					cm.Reader(network), cm.Analyzer(network),
-					minedTx.Hash().Hex(), network, false, "", a, nil, config.DegenMode,
+					minedTx.Hash().Hex(), network, false, "", a, nil, util.InfoLayout(config.DegenMode),
 				)
 			}
 

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -392,7 +392,7 @@ func HandlePostSign(
 		}
 		util.DisplayWaitAnalyze(
 			u, reader, analyzer, signedTx, broadcasted, err, config.Network(),
-			a, nil, config.DegenMode,
+			a, nil, util.InfoLayout(config.DegenMode),
 		)
 		return broadcasted, err
 	}
@@ -426,7 +426,7 @@ func HandlePostSign(
 
 	util.DisplayWaitAnalyze(
 		u, reader, analyzer, signedTx, broadcasted, err, config.Network(),
-		a, nil, config.DegenMode,
+		a, nil, util.InfoLayout(config.DegenMode),
 	)
 	return broadcasted, err
 }

--- a/common/ethereum_data.go
+++ b/common/ethereum_data.go
@@ -107,25 +107,30 @@ type TopicResult struct {
 }
 
 type LogResult struct {
-	Name   string
-	Topics []TopicResult
-	Data   []ParamResult
+	Name string
+	// Address is the contract that emitted the log, resolved through the
+	// address book so token symbols are available to the display layer.
+	Address Address
+	Topics  []TopicResult
+	Data    []ParamResult
 }
 
 type TxResult struct {
-	Hash      string
-	Network   string
-	Status    string
-	From      Address
-	Value     string
-	To        Address
-	Nonce     string
-	GasPrice  string
-	GasLimit  string
-	GasUsed   string
-	GasCost   string
-	Timestamp string
-	TxType    string
+	Hash     string
+	Network  string
+	Status   string
+	From     Address
+	Value    string
+	To       Address
+	Nonce    string
+	GasPrice string
+	GasLimit string
+	GasUsed  string
+	GasCost  string
+	// BlockNumber is the decimal block the tx was mined in; empty while pending.
+	BlockNumber string
+	Timestamp   string
+	TxType      string
 
 	FunctionCall *FunctionCall
 	Logs         []LogResult

--- a/txanalyzer/analyzer.go
+++ b/txanalyzer/analyzer.go
@@ -33,6 +33,9 @@ func (self *TxAnalyzer) setBasicTxInfo(txinfo TxInfo, result *TxResult) {
 	result.GasLimit = fmt.Sprintf("%d", txinfo.Tx.Gas())
 	result.GasUsed = fmt.Sprintf("%d", txinfo.Receipt.GasUsed)
 	result.GasCost = fmt.Sprintf("%.8f", BigToFloat(txinfo.GasCost(), self.ctx.Network.GetNativeTokenDecimal()))
+	if txinfo.Receipt != nil && txinfo.Receipt.BlockNumber != nil {
+		result.BlockNumber = txinfo.Receipt.BlockNumber.String()
+	}
 }
 
 // nonArrayParamAsJarvisValue converts a scalar ABI value to a jarvis Value,
@@ -469,9 +472,10 @@ func (self *TxAnalyzer) AnalyzeLog(
 	l *types.Log,
 ) (LogResult, error) {
 	logResult := LogResult{
-		Name:   "",
-		Topics: []TopicResult{},
-		Data:   []ParamResult{},
+		Name:    "",
+		Address: self.ctx.GetJarvisAddress(l.Address.Hex()),
+		Topics:  []TopicResult{},
+		Data:    []ParamResult{},
 	}
 
 	var err error
@@ -498,6 +502,10 @@ func (self *TxAnalyzer) AnalyzeLog(
 
 	// Annotate token amounts if the emitting contract is a known ERC20.
 	hint := self.ctx.ERC20InfoFor(l.Address.Hex())
+	if hint != nil && hint.Symbol != "" && !IsKnownAddress(logResult.Address) {
+		logResult.Address.Desc = hint.Symbol + " token"
+		logResult.Address.Decimal = int64(hint.Decimal)
+	}
 
 	iArgs, niArgs := SplitEventArguments(event.Inputs)
 	for j, topic := range l.Topics[1:] {

--- a/util/display.go
+++ b/util/display.go
@@ -13,23 +13,36 @@ import (
 
 // ── Severity helpers ─────────────────────────────────────────────────────────
 
-// StyledAddress wraps a common.Address in a StyledText.
-// Known addresses (non-empty, non-"unknown" description) are Success (green);
-// unknown ones are Warn (yellow) so they stand out without being alarming.
+// StyledAddress wraps the *target* of a call (tx `to`, inner-call destination)
+// in a StyledText. Known addresses are Success (green); an unknown target is
+// Warn (yellow) because sending a call somewhere the address book has never
+// seen is the one address-level fact worth the reader's attention.
 func StyledAddress(addr jarviscommon.Address) ui.StyledText {
 	text := jarviscommon.PlainAddress(addr)
-	if addr.Desc == "" || addr.Desc == "unknown" {
+	if !jarviscommon.IsKnownAddress(addr) {
 		return ui.StyledText{Text: text, Severity: ui.SeverityWarn}
 	}
 	return ui.StyledText{Text: text, Severity: ui.SeveritySuccess}
 }
 
+// styledParamAddress wraps an address that appears as data (a parameter, an
+// event argument, the sender, a log emitter). Known addresses are green;
+// unknown ones stay plain — most addresses in a busy tx are unknown, and
+// colouring them all yellow would drown the warnings that matter.
+func styledParamAddress(addr jarviscommon.Address) ui.StyledText {
+	text := jarviscommon.PlainAddress(addr)
+	if !jarviscommon.IsKnownAddress(addr) {
+		return ui.StyledText{Text: text, Severity: ui.SeverityInfo}
+	}
+	return ui.StyledText{Text: text, Severity: ui.SeveritySuccess}
+}
+
 // styledValue wraps a common.Value in a StyledText.
-// Address values inherit their severity from StyledAddress; all other values
-// are SeverityInfo (plain).
+// Address values inherit their severity from styledParamAddress; all other
+// values are SeverityInfo (plain).
 func styledValue(v jarviscommon.Value) ui.StyledText {
 	if v.Kind == jarviscommon.DisplayAddress && v.Address != nil {
-		return StyledAddress(*v.Address)
+		return styledParamAddress(*v.Address)
 	}
 	return ui.StyledText{Text: jarviscommon.PlainValue(v), Severity: ui.SeverityInfo}
 }
@@ -88,6 +101,9 @@ func buildFunctionCallDisplay(fc *jarviscommon.FunctionCall, nested bool) *Funct
 
 func buildLogDisplay(log jarviscommon.LogResult) LogDisplay {
 	d := LogDisplay{Name: log.Name}
+	if log.Address.Address != "" {
+		d.Address = styledParamAddress(log.Address)
+	}
 	for _, topic := range log.Topics {
 		d.Topics = append(d.Topics, TopicDisplay{
 			Name:    topic.Name,
@@ -100,32 +116,113 @@ func buildLogDisplay(log jarviscommon.LogResult) LogDisplay {
 	return d
 }
 
-func buildTxDisplay(result *jarviscommon.TxResult, fullDetail bool) *TxDisplay {
+func buildTxDisplay(result *jarviscommon.TxResult) *TxDisplay {
 	d := &TxDisplay{
-		Status: result.Status,
-		From:   StyledAddress(result.From),
-		To:     StyledAddress(result.To),
-		Value:  result.Value,
-		TxType: result.TxType,
-		Error:  result.Error,
-	}
-	if fullDetail {
-		d.Nonce = result.Nonce
-		d.GasPrice = result.GasPrice
-		d.GasLimit = result.GasLimit
-		d.GasUsed = result.GasUsed
-		d.GasCost = result.GasCost
+		Status:      result.Status,
+		From:        styledParamAddress(result.From),
+		To:          StyledAddress(result.To),
+		Value:       result.Value,
+		TxType:      result.TxType,
+		Error:       result.Error,
+		Nonce:       result.Nonce,
+		GasPrice:    result.GasPrice,
+		GasLimit:    result.GasLimit,
+		GasUsed:     result.GasUsed,
+		GasCost:     result.GasCost,
+		BlockNumber: result.BlockNumber,
 	}
 	if result.TxType == "" || result.TxType == "normal" {
 		return d
 	}
-	if fullDetail && result.FunctionCall != nil {
+	if result.FunctionCall != nil {
 		d.FunctionCall = buildFunctionCallDisplay(result.FunctionCall, false)
 	}
+	d.Transfers = buildTransfers(result.Logs)
 	for _, l := range result.Logs {
 		d.Logs = append(d.Logs, buildLogDisplay(l))
 	}
 	return d
+}
+
+// buildTransfers derives asset movements from the well-known token events so
+// the reader gets "what moved" without scanning the event table.
+func buildTransfers(logs []jarviscommon.LogResult) []TransferDisplay {
+	var out []TransferDisplay
+	for _, l := range logs {
+		args := map[string]jarviscommon.Value{}
+		for _, t := range l.Topics {
+			args[strings.ToLower(t.Name)] = t.Value
+		}
+		for _, p := range l.Data {
+			if len(p.Values) == 1 {
+				args[strings.ToLower(p.Name)] = p.Values[0]
+			}
+		}
+		amount, unlimited, ok := transferAmount(args)
+		if !ok {
+			continue
+		}
+		td := TransferDisplay{Amount: amount, Unlimited: unlimited, Token: transferToken(l, args)}
+		switch l.Name {
+		case "Transfer":
+			td.Kind = "transfer"
+			td.From, td.To = transferParty(args, "from", "src", "_from"), transferParty(args, "to", "dst", "_to")
+		case "Approval":
+			td.Kind = "approval"
+			td.From, td.To = transferParty(args, "owner", "_owner"), transferParty(args, "spender", "_spender")
+		case "Deposit":
+			td.Kind = "deposit"
+			td.To = transferParty(args, "dst", "to", "user", "account")
+		case "Withdrawal":
+			td.Kind = "withdrawal"
+			td.From = transferParty(args, "src", "from", "user", "account")
+		default:
+			continue
+		}
+		out = append(out, td)
+	}
+	return out
+}
+
+// transferAmount picks the amount-like argument of a token event and renders
+// it with the token's decimals when the analyzer attached a hint. The symbol
+// is carried separately by TransferDisplay.Token.
+func transferAmount(args map[string]jarviscommon.Value) (amount string, unlimited, ok bool) {
+	if v, has := args["tokenid"]; has {
+		return "#" + v.Raw, false, true
+	}
+	for _, name := range []string{"value", "amount", "wad", "_value", "_amount"} {
+		v, has := args[name]
+		if !has {
+			continue
+		}
+		if _, isMax := jarviscommon.MaxUintLabel(v.Raw); isMax {
+			return "unlimited", true, true
+		}
+		if v.Kind == jarviscommon.DisplayToken && v.Token != nil {
+			return jarviscommon.BigToFloatString(jarviscommon.StringToBig(v.Raw), v.Token.Decimal), false, true
+		}
+		return v.Raw, false, true
+	}
+	return "", false, false
+}
+
+func transferToken(l jarviscommon.LogResult, args map[string]jarviscommon.Value) ui.StyledText {
+	for _, v := range args {
+		if v.Kind == jarviscommon.DisplayToken && v.Token != nil && v.Token.Symbol != "" {
+			return ui.StyledText{Text: v.Token.Symbol, Severity: ui.SeveritySuccess}
+		}
+	}
+	return styledParamAddress(l.Address)
+}
+
+func transferParty(args map[string]jarviscommon.Value, names ...string) ui.StyledText {
+	for _, n := range names {
+		if v, ok := args[n]; ok {
+			return styledValue(v)
+		}
+	}
+	return ui.StyledText{}
 }
 
 // ── Print phase (reads only from the display struct, colours via u.Style) ────
@@ -390,49 +487,6 @@ func printAllLogs(u ui.UI, logs []LogDisplay) {
 	})
 }
 
-func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network) {
-	// Transaction summary card.
-	statusVal := d.Status
-	if d.Status == "done" {
-		statusVal = "✓ " + d.Status
-	}
-	txGroup := [][]ui.TableCell{
-		{ui.TC("Status"), ui.TC(statusVal)},
-		{ui.TC("From"), tableCell(d.From)},
-		{ui.TC("Value"), ui.TC(d.Value + " " + network.GetNativeTokenSymbol())},
-		{ui.TC("To"), tableCell(d.To)},
-	}
-	if d.Hash != "" {
-		txGroup = append([][]ui.TableCell{{ui.TC("Hash"), ui.TC(d.Hash)}}, txGroup...)
-	}
-
-	if d.Nonce != "" {
-		// Degen mode: gas details in the same card, separated by a divider.
-		gasGroup := [][]ui.TableCell{
-			{ui.TC("Nonce"), ui.TC(d.Nonce)},
-			{ui.TC("Gas price"), ui.TC(d.GasPrice + " gwei")},
-			{ui.TC("Gas limit"), ui.TC(d.GasLimit)},
-			{ui.TC("Gas used"), ui.TC(d.GasUsed)},
-			{ui.TC("Gas cost"), ui.TC(d.GasCost)},
-		}
-		u.PrintTable(&ui.Table{Groups: [][][]ui.TableCell{txGroup, gasGroup}})
-	} else {
-		u.PrintTable(&ui.Table{Rows: txGroup})
-	}
-
-	if d.TxType == "" {
-		u.Error("Checking tx type failed: %s", d.Error)
-		return
-	}
-	if d.TxType == "normal" {
-		return
-	}
-	if d.FunctionCall != nil {
-		printFunctionCallDisplay(u, d.FunctionCall, false)
-	}
-	printAllLogs(u, d.Logs)
-}
-
 // ── Public API ───────────────────────────────────────────────────────────────
 
 // DisplayParam builds the human-readable view-model for a single decoded ABI
@@ -465,15 +519,23 @@ func DisplayFunctionCall(u ui.UI, fc *jarviscommon.FunctionCall) *FunctionCallDi
 }
 
 // DisplayTxResult builds the human-readable view-model for an analyzed
-// transaction and writes it to u. The returned *TxDisplay serializes cleanly
-// to JSON (StyledText fields marshal as plain strings); the terminal sees
-// coloured output via u.Style.
+// transaction and writes it to u using the given layout. The returned
+// *TxDisplay is always complete regardless of layout and serializes cleanly
+// to JSON (StyledText fields marshal as plain strings).
 //
-// hash is the transaction hash string shown in the summary card; pass an empty
+// hash is the transaction hash shown in the headline/footer; pass an empty
 // string to omit it (e.g. when the hash is already shown by the caller).
-func DisplayTxResult(u ui.UI, result *jarviscommon.TxResult, network networks.Network, fullDetail bool, hash string) *TxDisplay {
-	d := buildTxDisplay(result, fullDetail)
+func DisplayTxResult(u ui.UI, result *jarviscommon.TxResult, network networks.Network, layout TxLayout, hash string) *TxDisplay {
+	d := buildTxDisplay(result)
 	d.Hash = hash
-	printTxDisplay(u, d, network)
+	printTxDisplay(u, d, network, layout)
 	return d
+}
+
+// InfoLayout maps the --degen flag onto the `jarvis info` layouts.
+func InfoLayout(degen bool) TxLayout {
+	if degen {
+		return LayoutInfoFull
+	}
+	return LayoutInfo
 }

--- a/util/display_model.go
+++ b/util/display_model.go
@@ -30,9 +30,10 @@ type TopicDisplay struct {
 
 // LogDisplay is the human-readable view-model for a single event log entry.
 type LogDisplay struct {
-	Name   string         `json:"name"`
-	Topics []TopicDisplay `json:"topics"`
-	Data   []ParamDisplay `json:"data"`
+	Name    string         `json:"name"`
+	Address ui.StyledText  `json:"address,omitempty"` // emitting contract; serializes as string
+	Topics  []TopicDisplay `json:"topics"`
+	Data    []ParamDisplay `json:"data"`
 }
 
 // FunctionCallDisplay is the human-readable view-model for a decoded function
@@ -51,6 +52,36 @@ type FunctionCallDisplay struct {
 	Error      string                 `json:"error,omitempty"`
 }
 
+// TxLayout selects how much of a TxDisplay is rendered and how densely.
+// The view-model is always built in full; the layout only affects printing.
+type TxLayout int
+
+const (
+	// LayoutInfo is the default for `jarvis info`: headline, transfers,
+	// collapsed call, one line per event, shortened addresses.
+	LayoutInfo TxLayout = iota
+	// LayoutInfoFull is `jarvis info -x`: nothing collapsed, gas card, full
+	// addresses, events as a table.
+	LayoutInfoFull
+	// LayoutPostSign is shown right after a tx the user just signed was
+	// mined: the call was already confirmed on the signing screen, so only
+	// status, gas, transfers and events are printed (the call reappears only
+	// when the tx reverted).
+	LayoutPostSign
+)
+
+// TransferDisplay is one asset movement derived from the event logs
+// (ERC-20/721 Transfer, Approval, WETH Deposit/Withdrawal).
+type TransferDisplay struct {
+	Kind   string        `json:"kind"` // transfer | approval | deposit | withdrawal
+	Token  ui.StyledText `json:"token"`
+	Amount string        `json:"amount"`
+	From   ui.StyledText `json:"from,omitempty"`
+	To     ui.StyledText `json:"to,omitempty"`
+	// Unlimited marks a max-uint approval, which deserves attention.
+	Unlimited bool `json:"unlimited,omitempty"`
+}
+
 // TxDisplay is the complete human-readable view-model for a single analyzed
 // transaction. StyledText fields carry Severity annotations used only by the
 // terminal print phase; JSON consumers receive clean plain strings.
@@ -61,15 +92,16 @@ type TxDisplay struct {
 	To     ui.StyledText `json:"to"`   // serializes as string
 	Value  string        `json:"value"`
 
-	// Gas/nonce detail — populated only when fullDetail (degen) mode is on.
-	Nonce    string `json:"nonce,omitempty"`
-	GasPrice string `json:"gas_price,omitempty"`
-	GasLimit string `json:"gas_limit,omitempty"`
-	GasUsed  string `json:"gas_used,omitempty"`
-	GasCost  string `json:"gas_cost,omitempty"`
+	Nonce       string `json:"nonce,omitempty"`
+	GasPrice    string `json:"gas_price,omitempty"`
+	GasLimit    string `json:"gas_limit,omitempty"`
+	GasUsed     string `json:"gas_used,omitempty"`
+	GasCost     string `json:"gas_cost,omitempty"`
+	BlockNumber string `json:"block_number,omitempty"`
 
 	TxType       string               `json:"tx_type"`
 	FunctionCall *FunctionCallDisplay `json:"function_call,omitempty"`
+	Transfers    []TransferDisplay    `json:"transfers,omitempty"`
 	Logs         []LogDisplay         `json:"logs,omitempty"`
 	Error        string               `json:"error,omitempty"`
 }

--- a/util/display_tx.go
+++ b/util/display_tx.go
@@ -1,0 +1,464 @@
+package util
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/ui"
+)
+
+// collapseAbove is the element count past which arrays are summarised as
+// "[n items]" in LayoutInfo. Small arrays (a swap path, a pair of recipients)
+// are worth reading inline; long ones are noise until asked for with -x.
+const collapseAbove = 4
+
+// longHexLen is the text length past which a bare hex blob is shortened in
+// compact layouts. A 32-byte word is 66 characters, so anything longer is
+// calldata-like rather than a hash or address.
+const longHexLen = 66
+
+// addressWithDesc matches the "0x… (Desc)" form produced by PlainAddress so
+// compact layouts can re-shape it without the view-model carrying a second,
+// display-only representation of every address. The boundary groups keep a
+// 40-digit run inside a longer hash or calldata blob from being mistaken for
+// an address.
+var addressWithDesc = regexp.MustCompile(`(^|[^0-9a-fA-Fx])(0x[0-9a-fA-F]{40})( \(([^()]*)\))?([^0-9a-fA-F]|$)`)
+
+var descDecimalSuffix = regexp.MustCompile(` - \d+$`)
+
+// compactAddressText rewrites every "0x… (Desc)" occurrence in text into the
+// NameFirst / ShortAddress form. Text without addresses is returned unchanged.
+func compactAddressText(text string) string {
+	// Two passes: adjacent addresses separated by a single character share
+	// that character as both the trailing and leading boundary, so the first
+	// pass consumes it and skips the second address.
+	for pass := 0; pass < 2; pass++ {
+		text = addressWithDesc.ReplaceAllStringFunc(text, func(m string) string {
+			sub := addressWithDesc.FindStringSubmatch(m)
+			desc := descDecimalSuffix.ReplaceAllString(sub[4], "")
+			return sub[1] + jarviscommon.NameFirst(jarviscommon.Address{Address: sub[2], Desc: desc}, false) + sub[5]
+		})
+	}
+	return text
+}
+
+// compactHex shortens a bare, long hex blob to its ends plus a byte count.
+func compactHex(text string) string {
+	if len(text) <= longHexLen || !strings.HasPrefix(text, "0x") || strings.ContainsAny(text, " (") {
+		return text
+	}
+	return fmt.Sprintf("%s…%s (%d bytes)", text[:6], text[len(text)-4:], (len(text)-2)/2)
+}
+
+// txPrinter carries the per-render choices so the helpers below stay short.
+type txPrinter struct {
+	u       ui.UI
+	layout  TxLayout
+	compact bool // shorten addresses / hex, collapse long arrays
+}
+
+func (p txPrinter) text(st ui.StyledText) string {
+	t := st.Text
+	if p.compact {
+		t = compactHex(compactAddressText(t))
+	}
+	return p.u.Style(ui.StyledText{Text: t, Severity: st.Severity})
+}
+
+func (p txPrinter) muted(s string) string {
+	return p.u.Style(ui.StyledText{Text: s, Severity: ui.SeverityMuted})
+}
+
+func (p txPrinter) bold(s string) string {
+	return p.u.Style(ui.StyledText{Text: s, Severity: ui.SeverityCritical})
+}
+
+func statusText(status string) ui.StyledText {
+	switch status {
+	case "done":
+		return ui.StyledText{Text: "✓ done", Severity: ui.SeveritySuccess}
+	case "reverted":
+		return ui.StyledText{Text: "✗ reverted", Severity: ui.SeverityError}
+	case "pending":
+		return ui.StyledText{Text: "… pending", Severity: ui.SeverityWarn}
+	case "lost":
+		return ui.StyledText{Text: "✗ lost", Severity: ui.SeverityError}
+	default:
+		return ui.StyledText{Text: status, Severity: ui.SeverityInfo}
+	}
+}
+
+// intent is the short description of what the tx did: the method name for a
+// contract call, "transfer <value>" for a plain value transfer.
+func (p txPrinter) intent(d *TxDisplay, network networks.Network) string {
+	switch {
+	case d.TxType == "normal":
+		return "transfer " + d.Value + " " + network.GetNativeTokenSymbol()
+	case d.FunctionCall == nil:
+		return "contract call"
+	case d.FunctionCall.Method == "":
+		return "<undecoded call>"
+	default:
+		return d.FunctionCall.Method
+	}
+}
+
+func (p txPrinter) headline(d *TxDisplay, network networks.Network) string {
+	return fmt.Sprintf("%s   %s  →  %s",
+		p.u.Style(statusText(d.Status)),
+		p.bold(p.intent(d, network)),
+		p.text(d.To),
+	)
+}
+
+// printTxDisplay renders d according to layout. The order is by importance:
+// what happened (headline), what moved (transfers), what was called, what was
+// emitted, and the headline again so the last line on screen is the summary.
+func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network, layout TxLayout) {
+	p := txPrinter{u: u, layout: layout, compact: layout != LayoutInfoFull}
+
+	if d.TxType == "" {
+		u.Info("%s", p.headline(d, network))
+		u.Error("Checking tx type failed: %s", d.Error)
+		return
+	}
+
+	u.Info("%s", p.headline(d, network))
+	u.Info("%s", p.muted(strings.Repeat(" ", ui.VisibleWidth(statusText(d.Status).Text)+3)+p.details(d, network)))
+
+	if layout == LayoutInfoFull {
+		p.printCard(d, network)
+	}
+	if d.TxType == "normal" {
+		return
+	}
+
+	printed := false
+	if len(d.Transfers) > 0 {
+		p.printTransfers(d.Transfers)
+		printed = true
+	}
+	showCall := d.FunctionCall != nil && (layout != LayoutPostSign || d.Status == "reverted")
+	if showCall {
+		p.printCall(d.FunctionCall)
+		printed = true
+	}
+	if len(d.Logs) > 0 {
+		if layout == LayoutInfoFull {
+			printAllLogs(u, d.Logs)
+		} else {
+			p.printEvents(d.Logs)
+		}
+		printed = true
+	}
+	if d.Error != "" {
+		u.Warn("! %s", d.Error)
+	}
+	if printed && layout != LayoutPostSign {
+		u.Info("")
+		footer := p.headline(d, network)
+		if d.Hash != "" {
+			footer += "   " + p.muted(jarviscommon.ShortAddress(d.Hash))
+		}
+		u.Info("%s", footer)
+	}
+}
+
+// details is the second headline line: the numbers that qualify the tx.
+func (p txPrinter) details(d *TxDisplay, network networks.Network) string {
+	sym := network.GetNativeTokenSymbol()
+	from := d.From.Text
+	if p.compact {
+		from = compactAddressText(from)
+	}
+	parts := []string{"from " + from}
+	if d.TxType != "normal" && d.Value != "" {
+		parts = append(parts, "value "+d.Value+" "+sym)
+	}
+	if d.GasCost != "" {
+		gas := "gas " + d.GasCost + " " + sym
+		if p.layout == LayoutPostSign && d.GasUsed != "" && d.GasLimit != "" {
+			gas += fmt.Sprintf(" (%s / %s)", d.GasUsed, d.GasLimit)
+		}
+		parts = append(parts, gas)
+	}
+	if d.Nonce != "" {
+		parts = append(parts, "nonce "+d.Nonce)
+	}
+	if d.BlockNumber != "" {
+		parts = append(parts, "block "+d.BlockNumber)
+	}
+	return strings.Join(parts, "   ")
+}
+
+// printCard is the full key/value summary shown with -x.
+func (p txPrinter) printCard(d *TxDisplay, network networks.Network) {
+	label := func(s string) ui.TableCell { return ui.TCS(s, ui.SeverityMuted) }
+	rows := [][2]ui.TableCell{}
+	if d.Hash != "" {
+		rows = append(rows, [2]ui.TableCell{label("Hash"), ui.TC(d.Hash)})
+	}
+	st := statusText(d.Status)
+	rows = append(rows,
+		[2]ui.TableCell{label("Status"), ui.TCS(st.Text, st.Severity)},
+		[2]ui.TableCell{label("From"), tableCell(d.From)},
+		[2]ui.TableCell{label("To"), tableCell(d.To)},
+		[2]ui.TableCell{label("Value"), ui.TC(d.Value + " " + network.GetNativeTokenSymbol())},
+	)
+	if d.Nonce != "" {
+		rows = append(rows,
+			[2]ui.TableCell{label("Nonce"), ui.TC(d.Nonce)},
+			[2]ui.TableCell{label("Gas price"), ui.TC(d.GasPrice + " gwei")},
+			[2]ui.TableCell{label("Gas limit"), ui.TC(d.GasLimit)},
+			[2]ui.TableCell{label("Gas used"), ui.TC(d.GasUsed)},
+			[2]ui.TableCell{label("Gas cost"), ui.TC(d.GasCost + " " + network.GetNativeTokenSymbol())},
+		)
+	}
+	if d.BlockNumber != "" {
+		rows = append(rows, [2]ui.TableCell{label("Block"), ui.TC(d.BlockNumber)})
+	}
+	p.u.Info("")
+	p.u.KeyValueCells(rows)
+}
+
+func (p txPrinter) printTransfers(ts []TransferDisplay) {
+	p.u.Subsection("Transfers")
+	amountWidth := 0
+	plain := func(t TransferDisplay) string {
+		if t.Unlimited {
+			return compactAddressText(t.Token.Text)
+		}
+		return t.Amount + " " + compactAddressText(t.Token.Text)
+	}
+	for _, t := range ts {
+		if w := ui.VisibleWidth(plain(t)); w > amountWidth {
+			amountWidth = w
+		}
+	}
+	for _, t := range ts {
+		amount := t.Amount + " " + p.text(t.Token)
+		if t.Unlimited {
+			amount = p.text(t.Token)
+		}
+		pad := strings.Repeat(" ", amountWidth-ui.VisibleWidth(plain(t)))
+		var line string
+		switch t.Kind {
+		case "approval":
+			verb := "approves"
+			if t.Unlimited {
+				verb = p.u.Style(ui.StyledText{Text: "approves UNLIMITED", Severity: ui.SeverityWarn})
+			}
+			line = fmt.Sprintf("%s%s   %s %s  %s", amount, pad, p.text(t.From), verb, p.text(t.To))
+		case "deposit":
+			line = fmt.Sprintf("%s%s   → %s  %s", amount, pad, p.text(t.To), p.muted("(deposit)"))
+		case "withdrawal":
+			line = fmt.Sprintf("%s%s   %s →  %s", amount, pad, p.text(t.From), p.muted("(withdrawal)"))
+		default:
+			line = fmt.Sprintf("%s%s   %s  →  %s", amount, pad, p.text(t.From), p.text(t.To))
+		}
+		p.u.Indent().Info("%s", line)
+	}
+}
+
+// printCall renders the top-level call and its inner calls as an indented
+// tree instead of bordered tables.
+func (p txPrinter) printCall(d *FunctionCallDisplay) {
+	if d.Method == "" {
+		p.u.Subsection("Call  <undecoded>  →  " + p.text(d.Destination))
+	} else {
+		p.u.Subsection("Call  " + d.Method + "  →  " + p.text(d.Destination))
+	}
+	p.printCallBody(p.u.Indent(), d)
+}
+
+func (p txPrinter) printCallBody(u ui.UI, d *FunctionCallDisplay) {
+	if d.Value != "" {
+		u.Info("%s %s", p.muted("value"), d.Value)
+	}
+	if d.Error != "" {
+		u.Error("%s", d.Error)
+	}
+	if d.Method == "" && d.Data != "" {
+		selector := d.Data
+		if len(selector) > 10 {
+			selector = selector[:10]
+		}
+		u.Info("%s %s   %s", p.muted("selector"), selector, p.muted(fmt.Sprintf("%d bytes", (len(d.Data)-2)/2)))
+		if !p.compact {
+			printRawCalldata(u, d.Data)
+		}
+	}
+	for _, line := range p.paramLines(d.Params) {
+		u.Info("%s", line)
+	}
+	for _, inner := range d.InnerCalls {
+		method := inner.Method
+		if method == "" {
+			method = "<undecoded>"
+		}
+		u.Info("↳ %s  →  %s", p.bold(method), p.text(inner.Destination))
+		p.printCallBody(u.Indent(), inner)
+	}
+}
+
+// paramLines renders a parameter list as aligned "name  value  type" lines,
+// with tuples and arrays expanded underneath as a tree.
+func (p txPrinter) paramLines(params []ParamDisplay) []string {
+	nameWidth := 0
+	for _, prm := range params {
+		if w := ui.VisibleWidth(prm.Name); w > nameWidth {
+			nameWidth = w
+		}
+	}
+	var lines []string
+	for _, prm := range params {
+		lines = append(lines, p.paramTree(prm, nameWidth)...)
+	}
+	return lines
+}
+
+func (p txPrinter) row(name string, nameWidth int, value, typ string) string {
+	pad := strings.Repeat(" ", nameWidth-ui.VisibleWidth(name))
+	if value == "" {
+		return fmt.Sprintf("%s%s  %s", name, pad, p.muted(typ))
+	}
+	return fmt.Sprintf("%s%s  %s  %s", name, pad, value, p.muted(typ))
+}
+
+// children prefixes each child's lines with tree glyphs: the first line gets a
+// branch, continuation lines get a guide, so nested structures stay legible.
+func children(lines [][]string) []string {
+	var out []string
+	for i, child := range lines {
+		last := i == len(lines)-1
+		for j, l := range child {
+			if j == 0 {
+				out = append(out, ui.TreeBranch(last)+l)
+			} else {
+				out = append(out, ui.TreeGuide(last)+l)
+			}
+		}
+	}
+	return out
+}
+
+func (p txPrinter) paramTree(d ParamDisplay, nameWidth int) []string {
+	collapse := func(n int) bool { return p.compact && n > collapseAbove }
+	summary := func(n int) string {
+		s := p.muted(fmt.Sprintf("[%d items]", n))
+		if collapse(n) {
+			s += p.muted("  (-x to expand)")
+		}
+		return s
+	}
+
+	switch {
+	case d.Values != nil && len(d.Values) == 1:
+		return []string{p.row(d.Name, nameWidth, p.text(d.Values[0]), d.Type)}
+
+	case d.Values != nil:
+		lines := []string{p.row(d.Name, nameWidth, summary(len(d.Values)), d.Type)}
+		if collapse(len(d.Values)) {
+			return lines
+		}
+		var kids [][]string
+		for _, v := range d.Values {
+			kids = append(kids, []string{p.text(v)})
+		}
+		return append(lines, children(kids)...)
+
+	case len(d.Tuples) == 1:
+		lines := []string{p.row(d.Name, nameWidth, "", d.Type)}
+		return append(lines, children(p.fieldLines(d.Tuples[0].Fields))...)
+
+	case d.Tuples != nil:
+		lines := []string{p.row(d.Name, nameWidth, summary(len(d.Tuples)), d.Type)}
+		if collapse(len(d.Tuples)) {
+			return lines
+		}
+		var kids [][]string
+		for i, t := range d.Tuples {
+			kid := []string{p.muted(fmt.Sprintf("[%d]", i))}
+			kid = append(kid, children(p.fieldLines(t.Fields))...)
+			kids = append(kids, kid)
+		}
+		return append(lines, children(kids)...)
+
+	case d.Arrays != nil:
+		lines := []string{p.row(d.Name, nameWidth, summary(len(d.Arrays)), d.Type)}
+		if collapse(len(d.Arrays)) {
+			return lines
+		}
+		var kids [][]string
+		for _, elem := range d.Arrays {
+			kids = append(kids, p.paramTree(elem, ui.VisibleWidth(elem.Name)))
+		}
+		return append(lines, children(kids)...)
+	}
+	return nil
+}
+
+func (p txPrinter) fieldLines(fields []ParamDisplay) [][]string {
+	nameWidth := 0
+	for _, f := range fields {
+		if w := ui.VisibleWidth(f.Name); w > nameWidth {
+			nameWidth = w
+		}
+	}
+	var out [][]string
+	for _, f := range fields {
+		out = append(out, p.paramTree(f, nameWidth))
+	}
+	return out
+}
+
+// printEvents renders one line per event: "N. Name  emitter   arg value  arg value".
+func (p txPrinter) printEvents(logs []LogDisplay) {
+	p.u.Subsection(fmt.Sprintf("Events (%d)", len(logs)))
+	nameWidth := 0
+	for _, l := range logs {
+		if w := ui.VisibleWidth(l.Name); w > nameWidth {
+			nameWidth = w
+		}
+	}
+	for i, l := range logs {
+		var args []string
+		for _, t := range l.Topics {
+			args = append(args, p.muted(t.Name)+" "+p.text(t.Verbose))
+		}
+		for _, prm := range l.Data {
+			args = append(args, p.muted(prm.Name)+" "+p.paramInline(prm))
+		}
+		name := l.Name + strings.Repeat(" ", nameWidth-ui.VisibleWidth(l.Name))
+		line := fmt.Sprintf("%d. %s  %s", i+1, p.bold(name), p.text(l.Address))
+		if len(args) > 0 {
+			line += "   " + strings.Join(args, "  ")
+		}
+		p.u.Indent().Info("%s", line)
+	}
+}
+
+// paramInline is the single-line form of a parameter used in event lines.
+func (p txPrinter) paramInline(d ParamDisplay) string {
+	switch {
+	case d.Values != nil && len(d.Values) == 1:
+		return p.text(d.Values[0])
+	case d.Values != nil:
+		if p.compact && len(d.Values) > collapseAbove {
+			return p.muted(fmt.Sprintf("[%d items]", len(d.Values)))
+		}
+		parts := make([]string, len(d.Values))
+		for i, v := range d.Values {
+			parts[i] = p.text(v)
+		}
+		return "[" + strings.Join(parts, ", ") + "]"
+	case len(d.Tuples) > 0:
+		return p.muted(fmt.Sprintf("[%d items]", len(d.Tuples)))
+	case d.Arrays != nil:
+		return p.muted(fmt.Sprintf("[%d items]", len(d.Arrays)))
+	}
+	return ""
+}

--- a/util/display_tx_internal_test.go
+++ b/util/display_tx_internal_test.go
@@ -1,0 +1,49 @@
+package util
+
+import "testing"
+
+func TestCompactAddressText(t *testing.T) {
+	const a = "0x9642b23Ed1E01Df1092B92641051881a322F5D4E"
+	const b = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"
+	const hash = "0x3f9a1c2b4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e1c2"
+
+	cases := map[string]string{
+		a:                                 a[:6] + "…5D4E (unknown)",
+		a + " (me)":                       "me (0x9642…5D4E)",
+		a + " (USDC - 6)":                 "USDC (0x9642…5D4E)",
+		a + " (unknown)":                  "0x9642…5D4E (unknown)",
+		"from " + a + " to " + b:          "from 0x9642…5D4E (unknown) to 0x7a25…488D (unknown)",
+		a + "," + b:                       "0x9642…5D4E (unknown),0x7a25…488D (unknown)",
+		hash:                              hash,
+		"1000000000 (1000 USDC)":          "1000000000 (1000 USDC)",
+		"0x" + a[2:] + "deadbeef":         "0x" + a[2:] + "deadbeef",
+		"[" + a + " (me), " + b + " (r)]": "[me (0x9642…5D4E), r (0x7a25…488D)]",
+	}
+	for in, want := range cases {
+		if got := compactAddressText(in); got != want {
+			t.Errorf("compactAddressText(%q)\n got %q\nwant %q", in, got, want)
+		}
+	}
+}
+
+func TestCompactHex(t *testing.T) {
+	long := "0x" + repeatHex("ab", 40)
+	if got := compactHex(long); got != "0xabab…abab (40 bytes)" {
+		t.Fatalf("got %q", got)
+	}
+	hash := "0x" + repeatHex("cd", 32)
+	if got := compactHex(hash); got != hash {
+		t.Fatalf("32-byte words must stay intact, got %q", got)
+	}
+	if got := compactHex("hello"); got != "hello" {
+		t.Fatalf("non-hex must be untouched, got %q", got)
+	}
+}
+
+func repeatHex(unit string, n int) string {
+	out := ""
+	for i := 0; i < n; i++ {
+		out += unit
+	}
+	return out
+}

--- a/util/display_tx_test.go
+++ b/util/display_tx_test.go
@@ -1,0 +1,319 @@
+package util_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/ui"
+	"github.com/tranvictor/jarvis/util"
+)
+
+const (
+	meHex     = "0x9642b23Ed1E01Df1092B92641051881a322F5D4E"
+	routerHex = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"
+	pairHex   = "0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852"
+	usdcHex   = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+	wethHex   = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+	hashHex   = "0x3f9a1c2b4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e1c2"
+)
+
+func addr(hex, desc string) jarviscommon.Address {
+	return jarviscommon.Address{Address: hex, Desc: desc}
+}
+
+func addrValue(hex, desc string) jarviscommon.Value {
+	a := addr(hex, desc)
+	return jarviscommon.Value{Raw: hex, Kind: jarviscommon.DisplayAddress, Address: &a}
+}
+
+func tokenValue(raw, symbol string, decimals uint64) jarviscommon.Value {
+	return jarviscommon.Value{
+		Raw:   raw,
+		Kind:  jarviscommon.DisplayToken,
+		Token: &jarviscommon.TokenHint{Symbol: symbol, Decimal: decimals},
+	}
+}
+
+func intValue(raw string) jarviscommon.Value {
+	return jarviscommon.Value{Raw: raw, Kind: jarviscommon.DisplayInteger}
+}
+
+func scalar(name, typ string, v jarviscommon.Value) jarviscommon.ParamResult {
+	return jarviscommon.ParamResult{Name: name, Type: typ, Values: []jarviscommon.Value{v}}
+}
+
+func transferLog(token, symbol string, decimals uint64, from, to jarviscommon.Address, raw string) jarviscommon.LogResult {
+	return jarviscommon.LogResult{
+		Name:    "Transfer",
+		Address: addr(token, symbol+" token"),
+		Topics: []jarviscommon.TopicResult{
+			{Name: "from", Value: addrValue(from.Address, from.Desc)},
+			{Name: "to", Value: addrValue(to.Address, to.Desc)},
+		},
+		Data: []jarviscommon.ParamResult{scalar("value", "uint256", tokenValue(raw, symbol, decimals))},
+	}
+}
+
+func swapTxResult() *jarviscommon.TxResult {
+	me := addr(meHex, "me")
+	pair := addr(pairHex, "USDC/WETH pair")
+	r := jarviscommon.NewTxResult()
+	r.Status = "done"
+	r.From = me
+	r.To = addr(routerHex, "Uniswap V2 Router")
+	r.Value = "0"
+	r.Nonce = "412"
+	r.GasPrice = "12.5000"
+	r.GasLimit = "185123"
+	r.GasUsed = "171203"
+	r.GasCost = "0.00213000"
+	r.BlockNumber = "19234567"
+	r.TxType = "contract call"
+	r.FunctionCall = &jarviscommon.FunctionCall{
+		Destination: r.To,
+		Method:      "swapExactTokensForTokens",
+		Params: []jarviscommon.ParamResult{
+			scalar("amountIn", "uint256", intValue("1000000000")),
+			scalar("amountOutMin", "uint256", intValue("311200000000000000")),
+			{Name: "path", Type: "address[]", Values: []jarviscommon.Value{
+				addrValue(usdcHex, "USDC"), addrValue(wethHex, "WETH"),
+			}},
+			scalar("to", "address", addrValue(meHex, "me")),
+			scalar("deadline", "uint256", intValue("1725600000")),
+		},
+	}
+	r.Logs = []jarviscommon.LogResult{
+		transferLog(usdcHex, "USDC", 6, me, pair, "1000000000"),
+		{Name: "Sync", Address: pair, Data: []jarviscommon.ParamResult{
+			scalar("reserve0", "uint112", intValue("5000000000000")),
+			scalar("reserve1", "uint112", intValue("1500000000000000000000")),
+		}},
+		transferLog(wethHex, "WETH", 18, pair, me, "312100000000000000"),
+	}
+	return r
+}
+
+func render(t *testing.T, r *jarviscommon.TxResult, layout util.TxLayout, hash string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	u := ui.NewTerminalUIWithWriter(&buf, false)
+	util.DisplayTxResult(u, r, networks.EthereumMainnet, layout, hash)
+	return buf.String()
+}
+
+func TestInfoLayoutOrdersByImportance(t *testing.T) {
+	out := render(t, swapTxResult(), util.LayoutInfo, hashHex)
+
+	want := []string{
+		"✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)",
+		"         from me (0x9642…5D4E)   value 0 ETH   gas 0.00213000 ETH   nonce 412   block 19234567",
+		"Transfers",
+		"  1000 USDC     me (0x9642…5D4E)  →  USDC/WETH pair (0x0d4a…1852)",
+		"  0.3121 WETH   USDC/WETH pair (0x0d4a…1852)  →  me (0x9642…5D4E)",
+		"Call  swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)",
+		"  amountIn      1000000000 (1‸000￺000￺000)  uint256",
+		"  path          [2 items]  address[]",
+		"  ├─ USDC (0xA0b8…eB48)",
+		"  └─ WETH (0xC02a…6Cc2)",
+		"  to            me (0x9642…5D4E)  address",
+		"Events (3)",
+		"  1. Transfer  USDC token (0xA0b8…eB48)   from me (0x9642…5D4E)  to USDC/WETH pair (0x0d4a…1852)  value 1000000000 (1000 USDC)",
+		"  2. Sync      USDC/WETH pair (0x0d4a…1852)   reserve0 5000000000000",
+		"✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)   0x3f9a…e1c2",
+	}
+	pos := -1
+	for _, w := range want {
+		idx := strings.Index(out, w)
+		if idx < 0 {
+			t.Fatalf("missing %q in output:\n%s", w, out)
+		}
+		if idx < pos {
+			t.Fatalf("%q appears out of order in output:\n%s", w, out)
+		}
+		pos = idx
+	}
+	if strings.Contains(out, "│") || strings.Contains(out, "╭") {
+		t.Fatalf("compact layout must not draw table borders:\n%s", out)
+	}
+}
+
+func TestFullLayoutKeepsFullAddressesAndEventTable(t *testing.T) {
+	out := render(t, swapTxResult(), util.LayoutInfoFull, hashHex)
+
+	for _, w := range []string{
+		"Hash       " + hashHex,
+		"Status     ✓ done",
+		"Gas price  12.5000 gwei",
+		"Block      19234567",
+		routerHex + " (Uniswap V2 Router)",
+		"Event Logs",
+		"│",
+	} {
+		if !strings.Contains(out, w) {
+			t.Fatalf("missing %q in full output:\n%s", w, out)
+		}
+	}
+	if strings.Contains(out, "0x7a25…488D") {
+		t.Fatalf("full layout must not shorten addresses:\n%s", out)
+	}
+}
+
+func TestInfoLayoutCollapsesLongArraysAndHex(t *testing.T) {
+	r := swapTxResult()
+	var many []jarviscommon.Value
+	for i := 0; i < 6; i++ {
+		many = append(many, intValue("1"))
+	}
+	r.FunctionCall.Params = []jarviscommon.ParamResult{
+		{Name: "ids", Type: "uint256[]", Values: many},
+		scalar("data", "bytes", jarviscommon.Value{Raw: "0x" + strings.Repeat("ab", 100), Kind: jarviscommon.DisplayRaw}),
+	}
+	r.Logs = nil
+
+	out := render(t, r, util.LayoutInfo, "")
+	if !strings.Contains(out, "ids   [6 items]  (-x to expand)  uint256[]") {
+		t.Fatalf("expected collapsed array:\n%s", out)
+	}
+	if !strings.Contains(out, "data  0xabab…abab (100 bytes)  bytes") {
+		t.Fatalf("expected shortened hex:\n%s", out)
+	}
+
+	full := render(t, r, util.LayoutInfoFull, "")
+	if strings.Count(full, "├─ 1") != 5 || !strings.Contains(full, "└─ 1") {
+		t.Fatalf("expected expanded array in full layout:\n%s", full)
+	}
+	if !strings.Contains(full, "0x"+strings.Repeat("ab", 100)) {
+		t.Fatalf("full layout must keep the whole hex blob:\n%s", full)
+	}
+}
+
+func TestRevertedHeadlineAndPostSignLayout(t *testing.T) {
+	r := swapTxResult()
+	r.Status = "reverted"
+	r.Logs = nil
+
+	post := render(t, r, util.LayoutPostSign, hashHex)
+	if !strings.HasPrefix(post, "✗ reverted   swapExactTokensForTokens  →  Uniswap V2 Router") {
+		t.Fatalf("expected reverted headline first:\n%s", post)
+	}
+	if !strings.Contains(post, "gas 0.00213000 ETH (171203 / 185123)") {
+		t.Fatalf("post-sign layout should show gas used vs limit:\n%s", post)
+	}
+	if !strings.Contains(post, "Call  swapExactTokensForTokens") {
+		t.Fatalf("reverted tx must show the call in post-sign layout:\n%s", post)
+	}
+
+	r.Status = "done"
+	r.Logs = swapTxResult().Logs
+	post = render(t, r, util.LayoutPostSign, hashHex)
+	if strings.Contains(post, "Call  ") {
+		t.Fatalf("successful post-sign layout must not repeat the call:\n%s", post)
+	}
+	if !strings.Contains(post, "Transfers") || !strings.Contains(post, "Events (3)") {
+		t.Fatalf("post-sign layout should keep transfers and events:\n%s", post)
+	}
+	if strings.Count(post, "✓ done") != 1 {
+		t.Fatalf("post-sign layout should not repeat the headline as footer:\n%s", post)
+	}
+}
+
+func TestPlainTransferIsHeadlineOnly(t *testing.T) {
+	r := jarviscommon.NewTxResult()
+	r.Status = "done"
+	r.TxType = "normal"
+	r.From = addr(meHex, "me")
+	r.To = addr(routerHex, "")
+	r.Value = "1.5"
+	r.GasCost = "0.00031500"
+	r.Nonce = "7"
+
+	out := render(t, r, util.LayoutInfo, hashHex)
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines for a plain transfer, got %d:\n%s", len(lines), out)
+	}
+	if lines[0] != "✓ done   transfer 1.5 ETH  →  0x7a25…488D (unknown)" {
+		t.Fatalf("unexpected headline %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "from me (0x9642…5D4E)   gas 0.00031500 ETH   nonce 7") {
+		t.Fatalf("unexpected details %q", lines[1])
+	}
+}
+
+func TestUnlimitedApprovalIsFlagged(t *testing.T) {
+	r := swapTxResult()
+	r.FunctionCall = nil
+	r.Logs = []jarviscommon.LogResult{{
+		Name:    "Approval",
+		Address: addr(usdcHex, "USDC token"),
+		Topics: []jarviscommon.TopicResult{
+			{Name: "owner", Value: addrValue(meHex, "me")},
+			{Name: "spender", Value: addrValue(routerHex, "")},
+		},
+		Data: []jarviscommon.ParamResult{scalar("value", "uint256", tokenValue(
+			"115792089237316195423570985008687907853269984665640564039457584007913129639935", "USDC", 6,
+		))},
+	}}
+
+	rec := ui.NewRecordingUI()
+	d := util.DisplayTxResult(rec, r, networks.EthereumMainnet, util.LayoutInfo, "")
+	if len(d.Transfers) != 1 || d.Transfers[0].Kind != "approval" || !d.Transfers[0].Unlimited {
+		t.Fatalf("expected one unlimited approval, got %+v", d.Transfers)
+	}
+	if !rec.HasMessage("approves UNLIMITED") {
+		t.Fatalf("expected UNLIMITED marker, got %v", rec.Entries())
+	}
+}
+
+func TestTxDisplayJSONIsAdditiveAndPlain(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	d := util.DisplayTxResult(rec, swapTxResult(), networks.EthereumMainnet, util.LayoutInfo, hashHex)
+	raw, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"hash", "status", "from", "to", "value", "tx_type", "function_call", "logs", "transfers", "block_number", "gas_cost"} {
+		if _, ok := m[k]; !ok {
+			t.Fatalf("missing json key %q in %s", k, raw)
+		}
+	}
+	if m["from"] != meHex+" (me)" {
+		t.Fatalf("json addresses must stay full: %v", m["from"])
+	}
+	transfers := m["transfers"].([]any)
+	first := transfers[0].(map[string]any)
+	if first["token"] != "USDC" || first["amount"] != "1000" {
+		t.Fatalf("unexpected transfer json: %v", first)
+	}
+}
+
+func TestUnknownCallTargetIsWarnButParamsAreNot(t *testing.T) {
+	r := swapTxResult()
+	r.To = addr(routerHex, "unknown")
+	r.FunctionCall.Destination = r.To
+	rec := ui.NewRecordingUI()
+	d := util.DisplayTxResult(rec, r, networks.EthereumMainnet, util.LayoutInfo, "")
+	if d.To.Severity != ui.SeverityWarn {
+		t.Fatalf("unknown call target should be Warn, got %v", d.To.Severity)
+	}
+	if d.From.Severity != ui.SeveritySuccess {
+		t.Fatalf("known sender should be green, got %v", d.From.Severity)
+	}
+	r.From = addr(meHex, "")
+	d = util.DisplayTxResult(rec, r, networks.EthereumMainnet, util.LayoutInfo, "")
+	if d.From.Severity != ui.SeverityInfo {
+		t.Fatalf("unknown sender should be plain, not yellow, got %v", d.From.Severity)
+	}
+	path := d.FunctionCall.Params[2]
+	if path.Values[0].Severity != ui.SeveritySuccess {
+		t.Fatalf("known param address should be green, got %v", path.Values[0].Severity)
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -275,7 +275,7 @@ func DisplayWaitAnalyze(
 	network networks.Network,
 	a *abi.ABI,
 	customABIs map[string]*abi.ABI,
-	degenMode bool,
+	layout TxLayout,
 ) {
 	DisplayBroadcastedTx(u, t, broadcasted, err, network)
 	if broadcasted {
@@ -295,7 +295,7 @@ func DisplayWaitAnalyze(
 			"",
 			a,
 			customABIs,
-			degenMode,
+			layout,
 		)
 	}
 }
@@ -325,7 +325,7 @@ func AnalyzeAndPrint(
 	customABI string,
 	a *abi.ABI,
 	customABIs map[string]*abi.ABI,
-	degenMode bool,
+	layout TxLayout,
 ) *TxDisplay {
 	if customABIs == nil {
 		customABIs = map[string]*abi.ABI{}
@@ -364,7 +364,7 @@ func AnalyzeAndPrint(
 		result = analyzer.AnalyzeOffline(&txinfo, GetABI, nil, false)
 	}
 
-	return DisplayTxResult(u, result, network, degenMode, tx)
+	return DisplayTxResult(u, result, network, layout, tx)
 }
 
 func EthTxMonitor(network networks.Network) (*monitor.TxMonitor, error) {

--- a/walletconnect/gateways/classic.go
+++ b/walletconnect/gateways/classic.go
@@ -254,7 +254,7 @@ func (g *ClassicGateway) waitAndAnalyze(
 	analyzer := txanalyzer.NewGenericAnalyzer(g.reader, g.network)
 	util.DisplayWaitAnalyze(
 		fullUI, g.reader, analyzer, signedTx, true, nil, g.network,
-		nil, nil, config.DegenMode,
+		nil, nil, util.InfoLayout(config.DegenMode),
 	)
 }
 

--- a/walletconnect/gateways/eoa.go
+++ b/walletconnect/gateways/eoa.go
@@ -302,7 +302,7 @@ func (g *EOAGateway) waitAndAnalyze(
 	}
 	jarvisutil.DisplayWaitAnalyze(
 		fullUI, rd, analyzer, signedTx, true, nil, net,
-		nil, customABIs, config.DegenMode,
+		nil, customABIs, jarvisutil.InfoLayout(config.DegenMode),
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 of `docs/improved-ui-plan.md`. Stacked on #109 (base branch `cursor/ui-phase-0-primitives-3023`); once that merges this can be retargeted to `improved-ui`.

`jarvis info <hash>` now prints in order of importance instead of data-model order, and without bordered tables in the default view:

```
✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)
         from me (0x9642…5D4E)   value 0 ETH   gas 0.00213000 ETH   nonce 412   block 19234567

Transfers
  1000 USDC     me (0x9642…5D4E)  →  USDC/WETH pair (0x0d4a…1852)
  0.3121 WETH   USDC/WETH pair (0x0d4a…1852)  →  me (0x9642…5D4E)

Call  swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)
  amountIn      1000000000 (1‸000￺000￺000)  uint256
  path          [2 items]  address[]
  ├─ USDC (0xA0b8…eB48)
  └─ WETH (0xC02a…6Cc2)
  to            me (0x9642…5D4E)  address
  ↳ transfer  →  USDC (0xA0b8…eB48)
    to      0x0d4a…1852 (unknown)  address

Events (3)
  1. Transfer  USDC token (0xA0b8…eB48)   from me (0x9642…5D4E)  to USDC/WETH pair (0x0d4a…1852)  value 1000000000 (1000 USDC)
  ...

✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)   0x3f9a…e1c2
```

### Changes

- `util.TxLayout` (`LayoutInfo`, `LayoutInfoFull`, `LayoutPostSign`) replaces the `fullDetail bool` on `DisplayTxResult`, `AnalyzeAndPrint` and `DisplayWaitAnalyze`. All callers updated via `util.InfoLayout(config.DegenMode)`; `LayoutPostSign` is wired up in Phase 4.
- The function call is now decoded and shown by default (previously only with `-x`). `-x` gives the full key/value card with gas, uncollapsed arrays, full addresses and the existing 3-column event table.
- New `Transfers` block derived from `Transfer` / `Approval` / `Deposit` / `Withdrawal` logs using the analyzer's ERC-20 hints; unlimited approvals render as `approves UNLIMITED` in yellow.
- Function call rendered as aligned `name  value  type` rows (type muted) with `├─ └─` trees for tuples/arrays and `↳` inner calls. Arrays over 4 elements and hex blobs over 32 bytes collapse in compact layouts with a `(-x to expand)` hint. Raw calldata still prints in full with `-x`.
- Yellow policy: unknown addresses are yellow only when they are the call target (`to` / inner-call destination). Params, event args and the sender are plain when unknown, green when known.
- Address shortening (`me (0x9642…5D4E)`) happens at print time via `compactAddressText`, so the view-model and `--json-output` keep full `0x… (Desc)` strings. Guarded against 40-hex runs inside hashes and calldata.
- Data: `TxResult.BlockNumber` and `LogResult.Address` (emitter, with ERC-20 symbol fallback) populated by the analyzer. JSON gains `transfers`, `block_number`, `logs[].address`; gas fields are now always present.
- `cmd/info.go`: the dashed separator is replaced by the headline footer.

Revert reasons are not fetched in this phase (would need an `eth_call` replay); the headline shows `✗ reverted` from the receipt status.

### Tests

`util/display_tx_test.go` (transcript assertions for compact, full, post-sign, plain transfer, unlimited approval, JSON shape, severity policy) and `util/display_tx_internal_test.go` (address/hex compaction edge cases). Existing display tests unchanged and passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

