### PR TITLE
UI phase 2: compact parameter entry

### DIFF
--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -89,48 +89,53 @@ func PromptParam(
 	prefill string,
 	network jarvisnetworks.Network,
 ) (any, error) {
-	t := input.Type
-	switch t.T {
-	case abi.SliceTy, abi.ArrayTy:
-		return PromptArray(u, input, prefill, network)
-	default:
-		return PromptNonArray(u, input, prefill, network)
+	raw := prefill
+	if raw == "" {
+		raw = u.Ask(nil)
 	}
+	return ConvertParamInput(input, raw, network)
 }
 
-// PromptArray prompts for an array-typed ABI parameter and delegates all
-// element parsing and typed-slice construction to ConvertParamStrToArray,
-// which uses abi.Type.GetType() via reflect to produce the exact slice type
-// go-ethereum's ABI encoder expects.
-func PromptArray(u ui.UI, input abi.Argument, prefill string, network jarvisnetworks.Network) (interface{}, error) {
-	var inpStr string
-	if prefill == "" {
-		inpStr = u.Ask(nil)
-	} else {
-		inpStr = prefill
-	}
-	inpStr = strings.TrimSpace(inpStr)
-	inpStr, err := util.InterpretInput(inpStr, network)
-	if err != nil {
-		return nil, err
-	}
-	return util.ConvertParamStrToArray(input.Name, input.Type, inpStr, network)
-}
-
-// PromptNonArray prompts for a scalar ABI parameter value.
-func PromptNonArray(u ui.UI, input abi.Argument, prefill string, network jarvisnetworks.Network) (interface{}, error) {
-	var inpStr string
-	if prefill == "" {
-		inpStr = u.Ask(nil)
-	} else {
-		inpStr = prefill
-	}
-	inpStr = strings.TrimSpace(inpStr)
-	inpStr, err := util.InterpretInput(inpStr, network)
+// ConvertParamInput turns one line of user input into the typed value the ABI
+// encoder expects for input. Arrays and tuples are entered as a single
+// bracketed line ("[a, b]", "(a, b)") and delegated to ConvertParamStrToArray,
+// which uses abi.Type.GetType() via reflect to build the exact slice type.
+func ConvertParamInput(input abi.Argument, raw string, network jarvisnetworks.Network) (any, error) {
+	inpStr, err := util.InterpretInput(strings.TrimSpace(raw), network)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't interpret input: %w", err)
 	}
-	return util.ConvertParamStrToType(input.Name, input.Type, inpStr, network)
+	switch input.Type.T {
+	case abi.SliceTy, abi.ArrayTy:
+		return util.ConvertParamStrToArray(input.Name, input.Type, inpStr, network)
+	default:
+		return util.ConvertParamStrToType(input.Name, input.Type, inpStr, network)
+	}
+}
+
+// foldableInputLen is the longest typed answer we fold into the "→" line on a
+// TTY. RewriteLastLine can only clear one physical row, so an answer that may
+// have wrapped is left in place rather than risk leaving fragments behind.
+const foldableInputLen = 60
+
+// echoParam shows what jarvis understood from the user's answer. The first
+// line replaces the raw "> answer" row on a TTY (when it is short enough to be
+// sure it occupied one row); nested values follow as an indented tree.
+func echoParam(u ui.UI, analyzer util.TxAnalyzer, input abi.Argument, value any, raw string, fold bool) {
+	d := util.NewParamDisplay(analyzer.ParamAsJarvisParamResult(input.Name, input.Type, value))
+	lines := util.ParamValueLines(u, d)
+	if len(lines) == 0 {
+		return
+	}
+	first := "  → " + lines[0]
+	if fold && len(raw) <= foldableInputLen {
+		u.RewriteLastLine(first)
+	} else {
+		u.Info("%s", first)
+	}
+	for _, l := range lines[1:] {
+		u.Info("    %s", l)
+	}
 }
 
 // PromptTxConfirmation displays a transaction summary and asks the user to
@@ -278,48 +283,43 @@ func PromptFunctionCallData(
 		return nil, nil, err
 	}
 
+	contract := util.StyledAddress(util.GetJarvisAddress(contractAddress, network))
 	if method.Type == abi.Constructor {
-		u.Info("Creating new contract at %s", contractAddress)
+		u.Info("%s  →  new contract at %s", u.Style(ui.StyledText{Text: methodName, Severity: ui.SeverityCritical}), contractAddress)
 	} else {
-		u.Info("Contract: %s", jarviscommon.VerboseAddress(util.GetJarvisAddress(contractAddress, network)))
+		u.Info("%s  →  %s", u.Style(ui.StyledText{Text: methodName, Severity: ui.SeverityCritical}), u.Style(contract))
 	}
-	u.Info("Method: %s", methodName)
 
 	inputs := method.Inputs
 	if prefillMode && len(inputs) != len(prefills) {
 		return nil, nil, fmt.Errorf("you must specify enough params in prefilled mode")
 	}
 
-	u.Info("Input:")
 	paramUI := u.Indent()
 	params = []any{}
-	pi := 0
-	for {
-		if pi >= len(inputs) {
-			break
-		}
+	for pi := 0; pi < len(inputs); {
 		input := inputs[pi]
+		paramUI.Info("%d. %s  %s", pi+1, input.Name,
+			paramUI.Style(ui.StyledText{Text: input.Type.String(), Severity: ui.SeverityMuted}))
 
-		paramUI.Info("%d. %s (%s)", pi+1, input.Name, input.Type.String())
-
-		var inputParam any
-		if !prefillMode || prefills[pi] == "?" {
-			inputParam, err = PromptParam(paramUI, true, input, "", network)
-			if err != nil {
-				paramUI.Error("your input is not valid: %s", err)
-				continue
-			}
+		interactive := !prefillMode || prefills[pi] == "?"
+		raw := ""
+		if interactive {
+			raw = paramUI.Ask(nil)
 		} else {
-			inputParam, err = PromptParam(paramUI, false, input, prefills[pi], network)
-			if err != nil {
-				paramUI.Error("your input is not valid: %s", err)
+			raw = prefills[pi]
+		}
+
+		inputParam, err := ConvertParamInput(input, raw, network)
+		if err != nil {
+			paramUI.Error("✗ %s", err)
+			if !interactive {
 				return nil, nil, fmt.Errorf("your input is not valid: %w", err)
 			}
+			continue
 		}
 
-		paramUI.Info("You entered:")
-		util.DisplayParam(paramUI.Indent(), analyzer.ParamAsJarvisParamResult(input.Name, input.Type, inputParam))
-
+		echoParam(paramUI, analyzer, input, inputParam, raw, interactive)
 		params = append(params, inputParam)
 		pi++
 	}

--- a/cmd/util/prompt_util_test.go
+++ b/cmd/util/prompt_util_test.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 
+	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/txanalyzer"
 	"github.com/tranvictor/jarvis/ui"
+	"github.com/tranvictor/jarvis/util/addrbook"
 )
 
 // SafeProxy verified ABI: constructor + fallback only. This is what
@@ -77,5 +80,115 @@ func TestPromptMethodPrefillIndex(t *testing.T) {
 	}
 	if name != "getOwners" || method.Name != "getOwners" {
 		t.Fatalf("got method %q, want getOwners", name)
+	}
+}
+
+const doStuffABIJSON = `[{"inputs":[
+	{"internalType":"address","name":"to","type":"address"},
+	{"internalType":"uint256","name":"amount","type":"uint256"},
+	{"internalType":"address[]","name":"spenders","type":"address[]"}
+],"name":"doStuff","outputs":[],"stateMutability":"nonpayable","type":"function"}]`
+
+func TestPromptFunctionCallDataEchoesCompactForm(t *testing.T) {
+	const (
+		contract = "0x1234567890123456789012345678901234567890"
+		vitalik  = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+		alice    = "0xaaaa000000000000000000000000000000001111"
+		bob      = "0xbbbb000000000000000000000000000000002222"
+	)
+	resolver := addrbook.Map{strings.ToLower(vitalik): "Vitalik Buterin", strings.ToLower(alice): "alice"}
+	analyzer := txanalyzer.NewGenericAnalyzerWithContext(
+		txanalyzer.NewAnalysisContextWithResolver(nil, networks.EthereumMainnet, resolver),
+	)
+
+	rec := ui.NewRecordingUI(
+		"1",                    // method index
+		"not-an-address",       // invalid answer for `to`
+		vitalik,                // valid answer for `to`
+		"1500",                 // amount
+		"["+alice+", "+bob+"]", // spenders
+	)
+	method, params, err := PromptFunctionCallData(
+		rec, analyzer, contract, 0, nil, false, "write",
+		mustABI(t, doStuffABIJSON), nil, networks.EthereumMainnet,
+	)
+	if err != nil {
+		t.Fatalf("PromptFunctionCallData: %v", err)
+	}
+	if method.Name != "doStuff" || len(params) != 3 {
+		t.Fatalf("got method %q with %d params", method.Name, len(params))
+	}
+
+	var got []string
+	for _, e := range rec.Entries() {
+		if e.Method == "Ask" || e.Method == "Choose" {
+			continue
+		}
+		got = append(got, e.Method+": "+e.Value)
+	}
+	want := []string{
+		"Info: write functions:",
+		"Info: 1. doStuff",
+		"Info: Please choose method index [1, 1]",
+		"Info: doStuff  →  0x1234567890123456789012345678901234567890",
+		"Info: 1. to  address",
+		"Error: ✗ ",
+		"Info: 1. to  address", // label repeats so the retry prompt is labelled
+		"Rewrite:   → Vitalik Buterin (0xd8dA…6045)",
+		"Info: 2. amount  uint256",
+		"Rewrite:   → 1500",
+		"Info: 3. spenders  address[]",
+		// The bracketed answer is longer than foldableInputLen, so it is not
+		// folded into the "> answer" row.
+		"Info:   → [2 items]",
+		"Info:     ├─ alice (0xaAaA…1111)",
+		"Info:     └─ 0xBbbb…2222 (unknown)",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("entry count %d != %d:\n%s", len(got), len(want), strings.Join(got, "\n"))
+	}
+	for i := range want {
+		if !strings.HasPrefix(got[i], want[i]) {
+			t.Fatalf("entry %d: got %q, want prefix %q\nall:\n%s", i, got[i], want[i], strings.Join(got, "\n"))
+		}
+	}
+	if rec.HasMessage("You entered") || rec.HasMessage("Parameter | Value") {
+		t.Fatalf("compact echo must replace the old table: %v", rec.Entries())
+	}
+}
+
+func TestPromptFunctionCallDataPrefillDoesNotFold(t *testing.T) {
+	const contract = "0x1234567890123456789012345678901234567890"
+	analyzer := txanalyzer.NewGenericAnalyzerWithContext(
+		txanalyzer.NewAnalysisContextWithResolver(nil, networks.EthereumMainnet, addrbook.Map{}),
+	)
+	rec := ui.NewRecordingUI("42")
+	_, params, err := PromptFunctionCallData(
+		rec, analyzer, contract, 1,
+		[]string{"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "?", "[]"}, true, "write",
+		mustABI(t, doStuffABIJSON), nil, networks.EthereumMainnet,
+	)
+	if err != nil {
+		t.Fatalf("PromptFunctionCallData: %v", err)
+	}
+	if len(params) != 3 {
+		t.Fatalf("expected 3 params, got %d", len(params))
+	}
+	var rewrites, infos []string
+	for _, e := range rec.Entries() {
+		switch e.Method {
+		case "Rewrite":
+			rewrites = append(rewrites, e.Value)
+		case "Info":
+			infos = append(infos, e.Value)
+		}
+	}
+	// Only the interactively answered slot ("?") had a "> answer" row to fold.
+	if len(rewrites) != 1 || rewrites[0] != "  → 42" {
+		t.Fatalf("expected exactly one folded echo for the prompted slot, got %v", rewrites)
+	}
+	joined := strings.Join(infos, "\n")
+	if !strings.Contains(joined, "  → 0xd8dA…6045 (unknown)") || !strings.Contains(joined, "  → [0 items]") {
+		t.Fatalf("prefilled slots should be echoed as plain lines:\n%s", joined)
 	}
 }

--- a/util/display_tx.go
+++ b/util/display_tx.go
@@ -58,6 +58,57 @@ type txPrinter struct {
 	u       ui.UI
 	layout  TxLayout
 	compact bool // shorten addresses / hex, collapse long arrays
+	// expandAll keeps every array element visible even in compact mode; used
+	// when echoing user input, where hiding elements would hide typos.
+	expandAll bool
+}
+
+// NewParamDisplay builds the view-model for one decoded parameter without
+// printing it.
+func NewParamDisplay(param jarviscommon.ParamResult) ParamDisplay {
+	return buildParamDisplay(param)
+}
+
+// ParamValueLines renders the value of a decoded parameter for echoing back
+// what jarvis understood from user input. The first line is the value itself
+// (or an item count for tuples/arrays); following lines expand the structure
+// as a tree. Addresses are shortened name-first, nothing is collapsed.
+func ParamValueLines(u ui.UI, d ParamDisplay) []string {
+	p := txPrinter{u: u, compact: true, expandAll: true}
+	return p.valueTree(d)
+}
+
+// valueTree is paramTree without the leading name/type: the caller has
+// already labelled the parameter.
+func (p txPrinter) valueTree(d ParamDisplay) []string {
+	switch {
+	case d.Values != nil && len(d.Values) == 1:
+		return []string{p.text(d.Values[0])}
+	case d.Values != nil:
+		var kids [][]string
+		for _, v := range d.Values {
+			kids = append(kids, []string{p.text(v)})
+		}
+		return append([]string{p.muted(fmt.Sprintf("[%d items]", len(d.Values)))}, children(kids)...)
+	case len(d.Tuples) == 1:
+		return append([]string{p.muted("tuple")}, children(p.fieldLines(d.Tuples[0].Fields))...)
+	case d.Tuples != nil:
+		var kids [][]string
+		for i, t := range d.Tuples {
+			kid := []string{p.muted(fmt.Sprintf("[%d]", i))}
+			kid = append(kid, children(p.fieldLines(t.Fields))...)
+			kids = append(kids, kid)
+		}
+		return append([]string{p.muted(fmt.Sprintf("[%d items]", len(d.Tuples)))}, children(kids)...)
+	case d.Arrays != nil:
+		var kids [][]string
+		for _, elem := range d.Arrays {
+			kids = append(kids, p.valueTree(elem))
+		}
+		return append([]string{p.muted(fmt.Sprintf("[%d items]", len(d.Arrays)))}, children(kids)...)
+	}
+	// An empty array/slice has no Values, Tuples or Arrays at all.
+	return []string{p.muted("[0 items]")}
 }
 
 func (p txPrinter) text(st ui.StyledText) string {
@@ -346,7 +397,7 @@ func children(lines [][]string) []string {
 }
 
 func (p txPrinter) paramTree(d ParamDisplay, nameWidth int) []string {
-	collapse := func(n int) bool { return p.compact && n > collapseAbove }
+	collapse := func(n int) bool { return p.compact && !p.expandAll && n > collapseAbove }
 	summary := func(n int) string {
 		s := p.muted(fmt.Sprintf("[%d items]", n))
 		if collapse(n) {
@@ -398,7 +449,7 @@ func (p txPrinter) paramTree(d ParamDisplay, nameWidth int) []string {
 		}
 		return append(lines, children(kids)...)
 	}
-	return nil
+	return []string{p.row(d.Name, nameWidth, p.muted("[0 items]"), d.Type)}
 }
 
 func (p txPrinter) fieldLines(fields []ParamDisplay) [][]string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 of `docs/improved-ui-plan.md`. Stacked on #110.

Interactive parameter entry (`jarvis contract tx`, `msig init`, Safe proposals, …) no longer prints `You entered:` plus a bordered table after every answer. The transcript becomes a compact form:

```
doStuff  →  SomeContract (0x1234…7890)
  1. to  address
    → Vitalik Buterin (0xd8dA…6045)
  2. amount  uint256
    → 1500
  3. spenders  address[]
  > [0xaaaa…, 0xbbbb…]
    → [2 items]
      ├─ alice (0xaAaA…1111)
      └─ 0xBbbb…2222 (unknown)
```

- Method header is `method  →  contract` (replaces `Contract:` / `Method:` / `Input:` lines); parameter labels are `N. name  type` with the type muted.
- Accepted answers echo as `→ value` through `util.ParamValueLines`, expanding tuples/arrays as a tree. On a TTY the echo replaces the `> answer` row when the answer is ≤ 60 chars (so it is certain to have occupied one physical row); longer answers and prefilled values are echoed as a plain line underneath.
- Invalid input prints `✗ reason` in red, re-shows the label and re-asks.
- `ConvertParamInput(input, raw, network)` extracted from `PromptArray` / `PromptNonArray` so the caller has the raw answer; `PromptParam` keeps its signature.
- Empty arrays render as `[0 items]` (previously nothing).

The signing screen is untouched in this phase; it still shows the full function call with full addresses.

## Tests

`cmd/util/prompt_util_test.go`: transcript test for address + uint + address[] entry with one invalid attempt, and a prefill test asserting only the interactively answered slot is folded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

