### PR TITLE
UI phase 3: unified signing card with derived warnings

### DIFF
--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -175,8 +175,13 @@ approve' and any owner can finalise via 'jarvis msig execute'.`,
 		if batchLabel != "" {
 			appUI.Info("MultiSend   : %s", batchLabel)
 		}
-		showSafeTxToConfirmWithABIs(stx, hash, &tc, batchABIs)
-		if !config.YesToAllPrompt && !appUI.Confirm("Sign and submit this Safe transaction?", true) {
+		card := buildSafeSigningCard(stx, hash, &tc, safeCardOptions{
+			kind:      "Safe proposal",
+			extraABIs: batchABIs,
+			signer:    tc.From,
+			prompt:    "Sign and submit this Safe proposal (off-chain, no gas)?",
+		})
+		if !cmdutil.ConfirmSigningCard(appUI, card) {
 			appUI.Warn("Aborted by user.")
 			return
 		}
@@ -329,12 +334,18 @@ over an off-chain signature store. Other owners' off-chain signatures
 			appUI.Warn("Couldn't merge on-chain approvals: %s", err)
 		}
 
+		threshold, _ := safeContract.Threshold()
 		if pending.SafeTx != nil {
-			showSafeTxToConfirm(pending.SafeTx, pending.SafeTxHash, &tc)
+			cmdutil.ShowSigningCard(appUI, buildSafeSigningCard(pending.SafeTx, pending.SafeTxHash, &tc, safeCardOptions{
+				kind:      "Safe approval",
+				sigs:      pending.Sigs,
+				threshold: threshold,
+				signer:    tc.From,
+			}))
 		} else {
 			appUI.Info("safeTxHash: 0x%s (no SafeTx body available; only approving the hash on-chain)", ethcommon.Bytes2Hex(pending.SafeTxHash[:]))
+			showSafeSigners("Existing signatures", pending.Sigs)
 		}
-		showSafeSigners("Existing signatures", pending.Sigs)
 
 		me := ethcommon.HexToAddress(tc.From)
 		if onChain, found := ownerAlreadySigned(pending, me); found {
@@ -356,7 +367,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 			return
 		}
 
-		if !config.YesToAllPrompt && !appUI.Confirm("Sign and submit your approval?", true) {
+		if !config.YesToAllPrompt && !appUI.Confirm("Sign approval (off-chain, no gas)?", true) {
 			appUI.Warn("Aborted by user.")
 			return
 		}
@@ -391,7 +402,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 		totalSigs := len(pending.Sigs) + 1
 		appUI.Info("Total signatures now: %d", totalSigs)
 
-		threshold, err := safeContract.Threshold()
+		threshold, err = safeContract.Threshold()
 		if err != nil {
 			appUI.Warn("Couldn't read safe threshold post-approval: %s", err)
 			return
@@ -742,12 +753,12 @@ Equivalent to ` + "`jarvis msig info`" + ` for Gnosis Classic.`,
 			appUI.Warn("Couldn't merge on-chain approvals: %s", err)
 		}
 
-		showSafeTxToConfirm(pending.SafeTx, pending.SafeTxHash, &tc)
 		threshold, _ := safeContract.Threshold()
-		showSafeSigners(
-			fmt.Sprintf("Signatures (%d of %d required)", len(pending.Sigs), threshold),
-			pending.Sigs,
-		)
+		cmdutil.ShowSigningCard(appUI, buildSafeSigningCard(pending.SafeTx, pending.SafeTxHash, &tc, safeCardOptions{
+			kind:      "Safe transaction",
+			sigs:      pending.Sigs,
+			threshold: threshold,
+		}))
 		switch {
 		case pending.IsExecuted:
 			appUI.Success("Status: executed.")
@@ -1041,8 +1052,12 @@ func runSafeExecute(
 		return
 	}
 
-	showSafeTxToConfirm(pending.SafeTx, pending.SafeTxHash, &tc)
-	showSafeSigners("Signatures (sorted by owner asc)", pending.Sigs)
+	cmdutil.ShowSigningCard(appUI, buildSafeSigningCard(pending.SafeTx, pending.SafeTxHash, &tc, safeCardOptions{
+		kind:      "Safe execution",
+		sigs:      pending.Sigs,
+		threshold: threshold,
+		signer:    tc.From,
+	}))
 
 	txData, err := safeContract.Abi.Pack(
 		"execTransaction",
@@ -1087,6 +1102,11 @@ func runSafeExecute(
 		strings.ToLower(safeContract.Address): safeContract.Abi,
 	}
 
+	// The EOA card that follows would otherwise re-decode execTransaction in
+	// full; link it to the Safe card just shown instead.
+	cmdutil.SetNextSigningNote(cmdutil.SigningNote{
+		ExecutesSafeTxHash: "0x" + ethcommon.Bytes2Hex(pending.SafeTxHash[:]),
+	})
 	if broadcasted, err := cmdutil.SignAndBroadcast(
 		appUI, tc.FromAcc, tx, customABIs,
 		tc.Reader, tc.Analyzer, safeContract.Abi, tc.Broadcaster,

--- a/cmd/safe_batch.go
+++ b/cmd/safe_batch.go
@@ -245,8 +245,13 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		return res
 	}
 
-	showSafeTxToConfirm(pending.SafeTx, pending.SafeTxHash, &tc)
-	showSafeSigners("Existing signatures", pending.Sigs)
+	threshold, _ := safeContract.Threshold()
+	cmdutil.ShowSigningCard(appUI, buildSafeSigningCard(pending.SafeTx, pending.SafeTxHash, &tc, safeCardOptions{
+		kind:      "Safe approval",
+		sigs:      pending.Sigs,
+		threshold: threshold,
+		signer:    fromAcc.Address,
+	}))
 
 	if safeApproveOnChain {
 		// On-chain batch approval: broadcast approveHash and let
@@ -266,7 +271,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		return res
 	}
 
-	if !config.YesToAllPrompt && !appUI.Confirm("Sign and submit your approval?", true) {
+	if !config.YesToAllPrompt && !appUI.Confirm("Sign approval (off-chain, no gas)?", true) {
 		res.status = "skipped"
 		res.reason = "user aborted"
 		return res
@@ -297,7 +302,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 	res.confirmType = "approve"
 	appUI.Success("Confirmation submitted.")
 
-	threshold, err := safeContract.Threshold()
+	threshold, err = safeContract.Threshold()
 	if err != nil {
 		appUI.Warn("Couldn't read threshold post-approval: %s", err)
 		return res

--- a/cmd/safe_display.go
+++ b/cmd/safe_display.go
@@ -13,6 +13,7 @@ import (
 	jarviscommon "github.com/tranvictor/jarvis/common"
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/safe"
+	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util"
 )
 
@@ -39,79 +40,111 @@ func showSafeInfo(s *safe.SafeContract) {
 	}
 }
 
-// showSafeTxToConfirm displays the parameters of a SafeTx in a way that
-// matches Safe wallet UIs (so users can sanity-check side-by-side) AND
-// decodes the calldata into a human-readable function call using jarvis's
-// standard analyzer pipeline — exactly the way `jarvis msig` shows pending
-// classic-multisig transactions. Pass tc so we can reach the network reader,
-// analyzer, and ABI resolver; pass nil to fall back to a raw-hex display.
-func showSafeTxToConfirm(stx *safe.SafeTx, hash [32]byte, tc *cmdutil.TxContext) {
-	showSafeTxToConfirmWithABIs(stx, hash, tc, nil)
+// safeCardOptions are the per-flow choices when building a Safe signing card.
+type safeCardOptions struct {
+	kind      string // "Safe proposal", "Safe approval", "Safe execution", "Safe transaction"
+	extraABIs map[string]*abi.ABI
+	sigs      []safe.OwnerSig // owners that already signed; rendered under the card
+	threshold uint64          // 0 = unknown; otherwise "n of m required"
+	signer    string          // EOA that will sign, if any
+	prompt    string
 }
 
-// showSafeTxToConfirmWithABIs is showSafeTxToConfirm plus a set of extra ABIs
-// keyed by lowercased address. Batch proposals need it: the calls inside a
+// showSafeTxToConfirm displays a SafeTx as a read-only card (no prompt).
+// Pass tc so we can reach the network reader, analyzer, and ABI resolver;
+// pass nil to fall back to a raw-hex display.
+func showSafeTxToConfirm(stx *safe.SafeTx, hash [32]byte, tc *cmdutil.TxContext) {
+	cmdutil.ShowSigningCard(appUI, buildSafeSigningCard(stx, hash, tc, safeCardOptions{kind: "Safe transaction"}))
+}
+
+// buildSafeSigningCard assembles the SigningCard for a SafeTx: the SafeTx
+// parameters in the order Safe wallet UIs show them (so users can sanity-check
+// side by side), the calldata decoded through jarvis's analyzer pipeline, and
+// the derived warnings. extraABIs matter for batches: the calls inside a
 // MultiSend payload frequently target contracts the block explorer can't give
 // an ABI for, and jarvis already knows their signatures because it just
 // encoded them from the tx builder batch.
-func showSafeTxToConfirmWithABIs(
+func buildSafeSigningCard(
 	stx *safe.SafeTx,
 	hash [32]byte,
 	tc *cmdutil.TxContext,
-	extraABIs map[string]*abi.ABI,
-) {
-	appUI.Section("Safe transaction details")
-
+	opt safeCardOptions,
+) *cmdutil.SigningCard {
+	network := config.Network()
 	// util.GetJarvisAddress runs through util.NewEnrichedResolver, which
-	// transparently fetches verified contract names (and follows
-	// proxies) from the block explorer on first miss — no manual
-	// PrefetchContractName plumbing required here or in the analyzer
-	// pipeline below.
-	toJarvis := util.GetJarvisAddress(stx.To.Hex(), config.Network())
-	appUI.Critical("To             : %s", appUI.Style(util.StyledAddress(toJarvis)))
+	// transparently fetches verified contract names (and follows proxies)
+	// from the block explorer on first miss.
+	toJarvis := util.GetJarvisAddress(stx.To.Hex(), network)
+	isMultiSend := jarviscommon.IsMultiSendCallData(stx.Data)
 
+	card := &cmdutil.SigningCard{
+		Kind:    opt.kind,
+		Network: network.GetName(),
+		To:      util.StyledAddress(toJarvis),
+		Prompt:  opt.prompt,
+		Safe: &cmdutil.SafeCardFields{
+			Operation:      operationLabel(stx.Operation),
+			DelegateCall:   stx.Operation == safe.OpDelegateCall,
+			MultiSend:      isMultiSend,
+			SafeNonce:      stx.Nonce.String(),
+			SafeTxHash:     "0x" + ethcommon.Bytes2Hex(hash[:]),
+			SafeTxGas:      stx.SafeTxGas.String(),
+			BaseGas:        stx.BaseGas.String(),
+			GasPrice:       stx.GasPrice.String(),
+			GasToken:       stx.GasToken.Hex(),
+			RefundReceiver: stx.RefundReceiver.Hex(),
+			Threshold:      opt.threshold,
+		},
+	}
+	if opt.signer != "" {
+		card.Signer = util.StyledAddress(util.GetJarvisAddress(opt.signer, network))
+	}
 	if stx.Value != nil && stx.Value.Sign() > 0 {
-		appUI.Critical("Value          : %f %s (%s wei)",
-			jarviscommon.BigToFloat(stx.Value, config.Network().GetNativeTokenDecimal()),
-			config.Network().GetNativeTokenSymbol(),
-			stx.Value.String(),
-		)
-	} else {
-		appUI.Critical("Value          : 0")
+		card.Value = fmt.Sprintf("%s %s (%s wei)",
+			jarviscommon.BigToFloatString(stx.Value, network.GetNativeTokenDecimal()),
+			network.GetNativeTokenSymbol(), stx.Value.String())
 	}
-	appUI.Critical("Operation      : %s", operationLabel(stx.Operation))
-	if stx.Operation == safe.OpDelegateCall && jarviscommon.IsMultiSendCallData(stx.Data) {
-		// The DANGEROUS label above stays: a delegatecall really does run
-		// foreign code in the Safe's context. This adds the missing why, so a
-		// reviewing owner can tell a routine batch from an actual red flag.
-		appUI.Critical("                 ^ this is a MultiSend batch; every call it makes is listed below")
-	}
-	appUI.Critical("Nonce (Safe)   : %s", stx.Nonce.String())
-	appUI.Critical("safeTxGas      : %s", stx.SafeTxGas.String())
-	appUI.Critical("baseGas        : %s", stx.BaseGas.String())
-	appUI.Critical("gasPrice       : %s", stx.GasPrice.String())
-	appUI.Critical("gasToken       : %s", stx.GasToken.Hex())
-	appUI.Critical("refundReceiver : %s", stx.RefundReceiver.Hex())
-	appUI.Critical("safeTxHash     : 0x%s", ethcommon.Bytes2Hex(hash[:]))
-
-	if len(stx.Data) == 0 {
-		appUI.Critical("Data           : (empty)")
-		return
+	for _, sig := range opt.sigs {
+		card.Safe.Signatures = append(card.Safe.Signatures, signerLine(sig))
 	}
 
-	// Decoded calldata block. We mirror cmd/util.AnalyzeAndShowMsigTxInfo:
-	// fetch the destination ABI through the resolver (honoring --custom-abi
-	// and --erc20), then hand off to util.AnalyzeMethodCallAndPrint which
-	// prints the function name + decoded params with token-aware formatting.
+	warn := cmdutil.WarningInput{
+		To:           toJarvis,
+		Value:        stx.Value,
+		NativeSymbol: network.GetNativeTokenSymbol(),
+		HasData:      len(stx.Data) > 0,
+		DelegateCall: stx.Operation == safe.OpDelegateCall,
+		MultiSend:    isMultiSend,
+	}
+	if len(stx.Data) > 0 {
+		if isContract, err := util.IsContract(stx.To.Hex(), network); err == nil {
+			warn.ToIsContract = isContract
+		}
+		fc := decodeSafeCalldata(stx, tc, opt.extraABIs)
+		if fc != nil {
+			warn.Call = fc
+			card.Call = util.NewFunctionCallDisplay(fc)
+		} else {
+			card.RawData = "0x" + ethcommon.Bytes2Hex(stx.Data)
+		}
+	}
+	card.Warnings = cmdutil.SigningWarnings(warn)
+	return card
+}
+
+// decodeSafeCalldata runs the analyzer over the SafeTx payload. It mirrors
+// cmd/util.AnalyzeAndShowMsigTxInfo: fetch the destination ABI through the
+// resolver (honoring --custom-abi and --erc20) and let the analyzer decode
+// recursively. Returns nil when no analyzer is available or no ABI could be
+// found for a non-MultiSend destination.
+func decodeSafeCalldata(stx *safe.SafeTx, tc *cmdutil.TxContext, extraABIs map[string]*abi.ABI) *jarviscommon.FunctionCall {
 	if tc == nil || tc.Resolver == nil || tc.Analyzer == nil {
-		appUI.Critical("Data (%d bytes): 0x%s", len(stx.Data), ethcommon.Bytes2Hex(stx.Data))
-		return
+		return nil
 	}
 	customABIs := map[string]*abi.ABI{}
 	for addr, a := range extraABIs {
 		customABIs[strings.ToLower(addr)] = a
 	}
-
 	destAbi, err := tc.Resolver.ConfigToABI(
 		stx.To.Hex(), config.ForceERC20ABI, config.CustomABI, config.Network(),
 	)
@@ -119,24 +152,28 @@ func showSafeTxToConfirmWithABIs(
 		// MultiSend / MultiSendCallOnly is unverified on many explorers, so a
 		// failure here is expected for batches and must not abort the decode:
 		// the analyzer has a built-in multiSend ABI to fall back on.
-		appUI.Warn("Couldn't resolve ABI of destination %s: %s", stx.To.Hex(), err)
 		if len(customABIs) == 0 && !jarviscommon.IsMultiSendCallData(stx.Data) {
-			appUI.Critical("Data (%d bytes): 0x%s", len(stx.Data), ethcommon.Bytes2Hex(stx.Data))
-			return
+			return nil
 		}
 	} else if _, taken := customABIs[strings.ToLower(stx.To.Hex())]; !taken {
 		customABIs[strings.ToLower(stx.To.Hex())] = destAbi
 	}
-
-	util.AnalyzeMethodCallAndPrint(
-		appUI,
-		tc.Analyzer,
-		stx.Value,
-		stx.To.Hex(),
-		stx.Data,
-		customABIs,
-		config.Network(),
+	return tc.Analyzer.AnalyzeFunctionCallRecursively(
+		util.GetABI, stx.Value, stx.To.Hex(), stx.Data, customABIs,
 	)
+}
+
+// signerLine renders one owner signature, tagged "[on-chain]" when it was an
+// approveHash rather than an off-chain signature.
+func signerLine(s safe.OwnerSig) ui.StyledText {
+	jarvisAddr := util.GetJarvisAddress(s.Owner.Hex(), config.Network())
+	tag := "[off-chain]"
+	if safe.IsOnChainApproval(s.Sig) {
+		tag = "[on-chain] "
+	}
+	st := util.StyledAddress(jarvisAddr)
+	st.Text = tag + " " + st.Text
+	return st
 }
 
 // showSafeSigners renders the list of owners that have already signed,
@@ -165,7 +202,7 @@ func operationLabel(op safe.Operation) string {
 	case safe.OpCall:
 		return "CALL (0)"
 	case safe.OpDelegateCall:
-		return "DELEGATECALL (1) — DANGEROUS"
+		return "DELEGATECALL (1)"
 	default:
 		return fmt.Sprintf("UNKNOWN (%d)", op)
 	}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -691,9 +691,11 @@ func sendFromSafe(
 		Analyzer: analyzer,
 		Resolver: resolver,
 	}
-	showSafeTxToConfirm(stx, hash, &tcView)
-
-	if !config.YesToAllPrompt && !appUI.Confirm("Sign and submit this Safe transaction?", true) {
+	card := buildSafeSigningCard(stx, hash, &tcView, safeCardOptions{
+		kind:   "Safe proposal",
+		prompt: "Sign and submit this Safe proposal (off-chain, no gas)?",
+	})
+	if !cmdutil.ConfirmSigningCard(appUI, card) {
 		appUI.Warn("Aborted by user.")
 		return
 	}

--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -3,17 +3,16 @@ package util
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
 	jarviscommon "github.com/tranvictor/jarvis/common"
-	"github.com/tranvictor/jarvis/config"
 	jarvisnetworks "github.com/tranvictor/jarvis/networks"
 	"github.com/tranvictor/jarvis/txanalyzer/erc7730"
 	"github.com/tranvictor/jarvis/ui"
@@ -138,7 +137,22 @@ func echoParam(u ui.UI, analyzer util.TxAnalyzer, input abi.Argument, value any,
 	}
 }
 
-// PromptTxConfirmation displays a transaction summary and asks the user to
+// nextSigningNote carries context from a caller that knows what the next EOA
+// transaction is for (e.g. runSafeExecute) into PromptTxConfirmation, which
+// only sees the raw transaction. It is consumed by the next confirmation.
+var nextSigningNote *SigningNote
+
+// SigningNote annotates the next EOA signing card.
+type SigningNote struct {
+	// ExecutesSafeTxHash marks the tx as the execTransaction of a Safe tx the
+	// user has just reviewed, so the card links to it and collapses the call.
+	ExecutesSafeTxHash string
+}
+
+// SetNextSigningNote attaches a note to the next PromptTxConfirmation call.
+func SetNextSigningNote(n SigningNote) { nextSigningNote = &n }
+
+// PromptTxConfirmation displays the signing card for tx and asks the user to
 // confirm before signing. Returns an error if the user aborts.
 func PromptTxConfirmation(
 	u ui.UI,
@@ -148,15 +162,110 @@ func PromptTxConfirmation(
 	customABIs map[string]*abi.ABI,
 	network jarvisnetworks.Network,
 ) error {
-	u.Section("Confirm tx data before signing")
-	if err := showTxInfoToConfirm(u, analyzer, from, tx, customABIs, network); err != nil {
+	note := nextSigningNote
+	nextSigningNote = nil
+	card, err := buildEOASigningCard(u, analyzer, from, tx, customABIs, network, note)
+	if err != nil {
 		u.Error("%s", err)
 		return err
 	}
-	if !config.YesToAllPrompt && !u.Confirm("Confirm?", true) {
+	if !ConfirmSigningCard(u, card) {
 		return fmt.Errorf("user aborted")
 	}
 	return nil
+}
+
+// buildEOASigningCard assembles the SigningCard for a raw EOA transaction:
+// resolves the destination, decodes the calldata when it targets a contract,
+// and derives the warnings.
+func buildEOASigningCard(
+	u ui.UI,
+	analyzer util.TxAnalyzer,
+	from jarviscommon.Address,
+	tx *types.Transaction,
+	customABIs map[string]*abi.ABI,
+	network jarvisnetworks.Network,
+	note *SigningNote,
+) (*SigningCard, error) {
+	symbol := network.GetNativeTokenSymbol()
+	card := &SigningCard{
+		Kind:    "EOA transaction",
+		Network: network.GetName(),
+		Signer:  util.StyledAddress(from),
+		Nonce:   fmt.Sprintf("%d", tx.Nonce()),
+		Gas: FormatGasLine(tx.Type() == types.LegacyTxType,
+			tx.GasPrice(), tx.GasFeeCap(), tx.GasTipCap(), tx.Gas(), symbol),
+	}
+	if tx.Value().Sign() > 0 {
+		card.Value = jarviscommon.BigToFloatString(tx.Value(), network.GetNativeTokenDecimal()) + " " + symbol
+	}
+
+	if tx.To() == nil {
+		card.CreateAddress = crypto.CreateAddress(jarviscommon.HexToAddress(from.Address), tx.Nonce()).Hex()
+		if len(tx.Data()) > 0 {
+			card.RawData = "0x" + ethcommon.Bytes2Hex(tx.Data())
+		}
+		card.Prompt = fmt.Sprintf("Sign and broadcast contract creation (%s)?", gasCostOnly(card.Gas))
+		return card, nil
+	}
+
+	toHex := tx.To().Hex()
+	if isERC20, _ := util.IsERC20(toHex, network); isERC20 {
+		// Warm the caches so the analyzer below annotates token amounts.
+		util.GetERC20Symbol(toHex, network)
+		util.GetERC20Decimal(toHex, network)
+	}
+	to := util.GetJarvisAddress(toHex, network)
+	card.To = util.StyledAddress(to)
+
+	isContract, err := util.IsContract(toHex, network)
+	if err != nil {
+		return nil, err
+	}
+	warn := WarningInput{
+		To: to, ToIsContract: isContract, Value: tx.Value(), NativeSymbol: symbol,
+		HasData: len(tx.Data()) > 0,
+	}
+
+	var fc *jarviscommon.FunctionCall
+	if isContract && len(tx.Data()) > 0 {
+		fc = analyzer.AnalyzeFunctionCallRecursively(util.GetABI, tx.Value(), toHex, tx.Data(), customABIs)
+		warn.Call = fc
+		if fc != nil {
+			card.Call = util.NewFunctionCallDisplay(fc)
+		}
+		// ERC-7730 clear-signing layer: when a descriptor matches the
+		// destination contract, the curated view is rendered above the raw
+		// ABI decode so the operator can scan the intent at a glance and
+		// still cross-check against the full breakdown. Failures fall through
+		// silently — we never make the review worse than today.
+		if fc != nil && fc.Method != "" {
+			card.ClearSign = func(cu ui.UI) { renderContractClearSign(cu, tx, fc, network, customABIs) }
+		}
+	} else if len(tx.Data()) > 0 {
+		card.RawData = "0x" + ethcommon.Bytes2Hex(tx.Data())
+	}
+
+	if note != nil && note.ExecutesSafeTxHash != "" {
+		card.Kind = "Safe execution"
+		card.CollapseCall = card.Call != nil && card.Call.Method == "execTransaction"
+		card.Safe = &SafeCardFields{Executes: note.ExecutesSafeTxHash}
+		// Safe params were already shown on the Safe card; only the EOA facts
+		// remain on this one.
+		card.Safe.Operation, card.Safe.SafeNonce, card.Safe.SafeTxHash = "", "", ""
+	}
+
+	card.Warnings = SigningWarnings(warn)
+	card.Prompt = fmt.Sprintf("Sign and broadcast (%s)?", gasCostOnly(card.Gas))
+	return card, nil
+}
+
+// gasCostOnly extracts the "≈ 0.0017 ETH" tail of a FormatGasLine string.
+func gasCostOnly(gas string) string {
+	if i := strings.LastIndex(gas, "≈"); i >= 0 {
+		return gas[i:]
+	}
+	return gas
 }
 
 // PromptTxData guides the user through selecting a method and filling its
@@ -324,96 +433,6 @@ func PromptFunctionCallData(
 		pi++
 	}
 	return method, params, nil
-}
-
-// showTxInfoToConfirm writes the transaction summary (from, to, value, gas,
-// decoded function call) to the UI for the user to review before signing.
-func showTxInfoToConfirm(
-	u ui.UI,
-	analyzer util.TxAnalyzer,
-	from jarviscommon.Address,
-	tx *types.Transaction,
-	customABIs map[string]*abi.ABI,
-	network jarvisnetworks.Network,
-) error {
-	fromStyled := util.StyledAddress(from)
-	u.Critical("From  : %s", u.Style(fromStyled))
-
-	if tx.To() != nil {
-		toHex := tx.To().Hex()
-		if isERC20, _ := util.IsERC20(toHex, network); isERC20 {
-			util.GetERC20Symbol(toHex, network)
-			util.GetERC20Decimal(toHex, network)
-		}
-		toStyled := util.StyledAddress(util.GetJarvisAddress(toHex, network))
-		u.Critical("To    : %s", u.Style(toStyled))
-	} else {
-		cAddr := crypto.CreateAddress(
-			jarviscommon.HexToAddress(from.Address),
-			tx.Nonce(),
-		).Hex()
-		u.Critical("To    : create contract at %s", cAddr)
-	}
-
-	if tx.Value().Sign() > 0 {
-		sendingETH := jarviscommon.BigToFloatString(tx.Value(), network.GetNativeTokenDecimal())
-		u.Critical("Value : %s %s", sendingETH, network.GetNativeTokenSymbol())
-	}
-
-	gasCost := jarviscommon.BigToFloat(
-		big.NewInt(0).Mul(big.NewInt(int64(tx.Gas())), tx.GasPrice()),
-		18,
-	)
-	switch tx.Type() {
-	case types.LegacyTxType:
-		u.Critical("Nonce : %d", tx.Nonce())
-		u.Critical("Gas   : %.4f gwei (%d gas = %.8f %s)",
-			jarviscommon.BigToFloat(tx.GasPrice(), 9),
-			tx.Gas(), gasCost, network.GetNativeTokenSymbol(),
-		)
-	case types.DynamicFeeTxType:
-		u.Critical("Nonce : %d", tx.Nonce())
-		u.Critical("Gas   : Max %.4f gwei, Tip %.4f gwei (%d gas = %.8f %s)",
-			jarviscommon.BigToFloat(tx.GasFeeCap(), 9),
-			jarviscommon.BigToFloat(tx.GasTipCap(), 9),
-			tx.Gas(), gasCost, network.GetNativeTokenSymbol(),
-		)
-	}
-
-	if tx.To() == nil {
-		return nil
-	}
-
-	isContract, err := util.IsContract(tx.To().Hex(), network)
-	if err != nil {
-		return err
-	}
-	if !isContract {
-		return nil
-	}
-
-	fc := analyzer.AnalyzeFunctionCallRecursively(
-		util.GetABI,
-		tx.Value(),
-		tx.To().Hex(),
-		tx.Data(),
-		customABIs,
-	)
-
-	// ERC-7730 clear-signing layer: when a descriptor matches the
-	// destination contract, render the curated green-bordered view
-	// above the raw ABI decode so the operator can scan the intent
-	// at a glance and still cross-check against the full breakdown.
-	// Failures (descriptor not found, registry miss, formatter
-	// error) silently fall through to the existing display — we
-	// never make the review worse than today.
-	if fc != nil && fc.Method != "" {
-		renderContractClearSign(u, tx, fc, network, customABIs)
-	}
-
-	util.DisplayFunctionCall(u, fc)
-	u.Info("")
-	return nil
 }
 
 // renderContractClearSign asks the shared ERC-7730 engine for a

--- a/cmd/util/signing_card.go
+++ b/cmd/util/signing_card.go
@@ -1,0 +1,312 @@
+package util
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/config"
+	"github.com/tranvictor/jarvis/ui"
+	"github.com/tranvictor/jarvis/util"
+)
+
+// SigningCard is everything shown to the user right before they sign. The
+// same renderer serves plain EOA transactions and the Safe flows so the
+// screen has one shape wherever a signature is requested.
+//
+// Addresses on this screen are always complete: the card is the last place a
+// lookalike address can be caught.
+type SigningCard struct {
+	Kind    string // "EOA transaction", "Safe proposal", "Safe approval", "Safe execution"
+	Network string
+
+	Signer ui.StyledText
+	To     ui.StyledText // empty Text for contract creation; see CreateAddress
+	// CreateAddress is the predicted address when the tx deploys a contract.
+	CreateAddress string
+	Value         string // "1.5 ETH"; empty hides the row
+	Gas           string // "max 20.0 gwei, tip 1.5 gwei · 85,123 gas · ≈ 0.0017 ETH"; empty hides
+	Nonce         string
+
+	Safe *SafeCardFields
+
+	// Call is the decoded calldata. Nil when there is none or it could not be
+	// analyzed; RawData is shown instead when set.
+	Call    *util.FunctionCallDisplay
+	RawData string
+	// CollapseCall prints the call as a single header line. Used when the
+	// same call was fully displayed moments ago (Safe approve → execute).
+	CollapseCall bool
+
+	// ClearSign renders the ERC-7730 view when a descriptor matched. It is
+	// a callback so this package does not depend on the erc7730 engine.
+	ClearSign func(ui.UI)
+
+	Warnings []string
+	Prompt   string
+}
+
+// SafeCardFields are the SafeTx parameters that have no EOA equivalent.
+type SafeCardFields struct {
+	Operation      string // "CALL" or "DELEGATECALL"
+	DelegateCall   bool
+	MultiSend      bool
+	SafeNonce      string
+	SafeTxHash     string
+	SafeTxGas      string
+	BaseGas        string
+	GasPrice       string
+	GasToken       string
+	RefundReceiver string
+	// Signatures lists owners that already signed, one rendered line each;
+	// Threshold (when known) is shown next to the count.
+	Signatures []ui.StyledText
+	Threshold  uint64
+	// Executes is the safeTxHash an EOA execTransaction carries out.
+	Executes string
+}
+
+// ShowSigningCard prints the card. Order is chosen so that what the reader
+// must verify sits directly above the prompt: the call first, then the
+// summary block, then the warnings.
+func ShowSigningCard(u ui.UI, c *SigningCard) {
+	u.Section(c.Kind)
+
+	if c.ClearSign != nil {
+		c.ClearSign(u)
+	}
+
+	switch {
+	case c.Call != nil && c.CollapseCall:
+		u.Subsection(fmt.Sprintf("Call  %s  →  %s   %s",
+			c.Call.Method, u.Style(c.Call.Destination),
+			u.Style(ui.StyledText{Text: "(Safe transaction shown above)", Severity: ui.SeverityMuted})))
+	case c.Call != nil:
+		util.PrintFunctionCall(u, c.Call)
+	case c.RawData != "":
+		u.Subsection("Calldata  " + u.Style(ui.StyledText{Text: "(could not be decoded)", Severity: ui.SeverityWarn}))
+		printHexBlock(u.Indent(), c.RawData)
+	}
+
+	label := func(s string) ui.TableCell { return ui.TCS(s, ui.SeverityMuted) }
+	rows := [][2]ui.TableCell{}
+	signer := c.Signer.Text
+	if c.Network != "" {
+		signer += "   " + c.Network
+	}
+	if c.Signer.Text != "" {
+		rows = append(rows, [2]ui.TableCell{label("Sign with"), ui.TCS(signer, c.Signer.Severity)})
+	}
+	if c.CreateAddress != "" {
+		rows = append(rows, [2]ui.TableCell{label("Creates"), ui.TC(c.CreateAddress)})
+	} else if c.To.Text != "" {
+		toLabel := "Send to"
+		if c.Safe != nil {
+			toLabel = "Safe calls"
+		}
+		rows = append(rows, [2]ui.TableCell{label(toLabel), ui.TCS(c.To.Text, c.To.Severity)})
+	}
+	if c.Value != "" {
+		rows = append(rows, [2]ui.TableCell{label("Value"), ui.TC(c.Value)})
+	}
+	if c.Gas != "" {
+		gas := c.Gas
+		if c.Nonce != "" {
+			gas += "   nonce " + c.Nonce
+		}
+		rows = append(rows, [2]ui.TableCell{label("Gas"), ui.TC(gas)})
+	} else if c.Nonce != "" {
+		rows = append(rows, [2]ui.TableCell{label("Nonce"), ui.TC(c.Nonce)})
+	}
+	if s := c.Safe; s != nil {
+		op := ui.TC(s.Operation)
+		if s.DelegateCall {
+			op = ui.TCS(s.Operation, ui.SeverityWarn)
+		}
+		if s.Operation != "" {
+			rows = append(rows,
+				[2]ui.TableCell{label("Operation"), op},
+				[2]ui.TableCell{label("Safe nonce"), ui.TC(s.SafeNonce)},
+				[2]ui.TableCell{label("safeTxHash"), ui.TC(s.SafeTxHash)},
+			)
+		}
+		if s.Executes != "" {
+			rows = append(rows, [2]ui.TableCell{label("Executes"), ui.TC(s.Executes)})
+		}
+		if s.SafeTxGas != "" {
+			rows = append(rows, [2]ui.TableCell{label("Refund"), ui.TCS(fmt.Sprintf(
+				"safeTxGas %s · baseGas %s · gasPrice %s · gasToken %s · refundReceiver %s",
+				s.SafeTxGas, s.BaseGas, s.GasPrice, s.GasToken, s.RefundReceiver,
+			), ui.SeverityMuted)})
+		}
+	}
+	u.Info("")
+	u.KeyValueCells(rows)
+
+	if c.Safe != nil && (len(c.Safe.Signatures) > 0 || c.Safe.Threshold > 0) {
+		heading := fmt.Sprintf("Signed by (%d)", len(c.Safe.Signatures))
+		if c.Safe.Threshold > 0 {
+			heading = fmt.Sprintf("Signed by (%d of %d required)", len(c.Safe.Signatures), c.Safe.Threshold)
+		}
+		u.Info("")
+		u.Info("%s", u.Style(ui.StyledText{Text: heading, Severity: ui.SeverityMuted}))
+		for i, s := range c.Safe.Signatures {
+			u.Indent().Info("%d. %s", i+1, u.Style(s))
+		}
+	}
+
+	if len(c.Warnings) > 0 {
+		u.Info("")
+		for _, w := range c.Warnings {
+			u.Warn("! %s", w)
+		}
+	}
+	u.Info("")
+}
+
+// ConfirmSigningCard prints the card and asks the card's prompt. It returns
+// true when the user accepted (or --yes is set).
+func ConfirmSigningCard(u ui.UI, c *SigningCard) bool {
+	ShowSigningCard(u, c)
+	if config.YesToAllPrompt {
+		return true
+	}
+	return u.Confirm(c.Prompt, true)
+}
+
+// printHexBlock writes hex data wrapped to 32-byte words with the byte count
+// first, never truncating.
+func printHexBlock(u ui.UI, data string) {
+	body := strings.TrimPrefix(data, "0x")
+	u.Info("%d bytes", len(body)/2)
+	const width = 64
+	for i := 0; i < len(body); i += width {
+		end := i + width
+		if end > len(body) {
+			end = len(body)
+		}
+		prefix := "  "
+		if i == 0 {
+			prefix = "0x"
+		}
+		u.Info("%s%s", prefix, body[i:end])
+	}
+}
+
+// WarningInput is what SigningWarnings looks at. It is deliberately a plain
+// struct so the derivation can be unit-tested without a chain.
+type WarningInput struct {
+	To           jarviscommon.Address
+	ToIsContract bool
+	Value        *big.Int
+	NativeSymbol string
+	HasData      bool
+	Call         *jarviscommon.FunctionCall
+	DelegateCall bool
+	MultiSend    bool
+}
+
+// approvalMethods maps ERC-20/721/1155 approval selectors to the parameter
+// names that carry the spender/operator and the amount.
+var approvalMethods = map[string]struct{ spender, amount string }{
+	"approve":           {"spender", "amount"},
+	"increaseAllowance": {"spender", "addedValue"},
+	"setApprovalForAll": {"operator", "approved"},
+	"permit":            {"spender", "value"},
+}
+
+// SigningWarnings derives the yellow "!" lines from a transaction. Each
+// warning is one sentence stating a fact the reader may not have noticed in
+// the decoded call; the list is empty for a routine transaction.
+func SigningWarnings(in WarningInput) []string {
+	var out []string
+
+	if in.To.Address != "" && !jarviscommon.IsKnownAddress(in.To) {
+		out = append(out, fmt.Sprintf("%s is not in your address book", in.To.Address))
+	}
+	if in.Value != nil && in.Value.Sign() > 0 && in.ToIsContract {
+		out = append(out, fmt.Sprintf("sends %s %s into a contract",
+			jarviscommon.BigToFloatString(in.Value, 18), in.NativeSymbol))
+	}
+	if in.DelegateCall {
+		if in.MultiSend {
+			out = append(out, "DELEGATECALL into MultiSend: every inner call below runs with the Safe's full authority")
+		} else {
+			out = append(out, "DELEGATECALL: the target's code runs in the Safe's own context")
+		}
+	}
+	if in.HasData && (in.Call == nil || in.Call.Method == "") {
+		dest := in.To.Address
+		if in.Call != nil && in.Call.Destination.Address != "" {
+			dest = in.Call.Destination.Address
+		}
+		out = append(out, fmt.Sprintf("calldata could not be decoded (no ABI for %s); review the raw bytes", dest))
+	}
+	if in.Call != nil {
+		out = append(out, approvalWarnings(in.Call)...)
+	}
+	return out
+}
+
+func approvalWarnings(fc *jarviscommon.FunctionCall) []string {
+	var out []string
+	if spec, ok := approvalMethods[fc.Method]; ok {
+		var spender *jarviscommon.Address
+		var amount *jarviscommon.Value
+		for i := range fc.Params {
+			p := &fc.Params[i]
+			if len(p.Values) != 1 {
+				continue
+			}
+			switch {
+			case p.Values[0].Kind == jarviscommon.DisplayAddress && (strings.EqualFold(p.Name, spec.spender) || spender == nil && strings.Contains(strings.ToLower(p.Name), "spender")):
+				spender = p.Values[0].Address
+			case strings.EqualFold(p.Name, spec.amount) || (amount == nil && p.Values[0].Kind != jarviscommon.DisplayAddress):
+				amount = &p.Values[0]
+			}
+		}
+		target := fc.Destination.Address
+		if jarviscommon.IsKnownAddress(fc.Destination) {
+			target = fc.Destination.Desc
+		}
+		spenderText := "an unspecified spender"
+		if spender != nil {
+			spenderText = jarviscommon.PlainAddress(*spender)
+		}
+		switch {
+		case fc.Method == "setApprovalForAll" && amount != nil && amount.Raw == "true":
+			out = append(out, fmt.Sprintf("grants %s control over ALL %s tokens", spenderText, target))
+		case amount != nil && isMaxUint(amount.Raw):
+			out = append(out, fmt.Sprintf("approves UNLIMITED %s to %s", target, spenderText))
+		}
+		if spender != nil && !jarviscommon.IsKnownAddress(*spender) {
+			out = append(out, fmt.Sprintf("spender %s is not in your address book", spender.Address))
+		}
+	}
+	for _, inner := range fc.DecodedFunctionCalls {
+		out = append(out, approvalWarnings(inner)...)
+	}
+	return out
+}
+
+func isMaxUint(raw string) bool {
+	_, ok := jarviscommon.MaxUintLabel(raw)
+	return ok
+}
+
+// FormatGasLine renders the fee parameters of a tx in one line:
+// "max 20.0000 gwei, tip 1.5000 gwei · 85123 gas · ≈ 0.00170246 ETH".
+func FormatGasLine(legacy bool, gasPrice, feeCap, tipCap *big.Int, gasLimit uint64, symbol string) string {
+	price := feeCap
+	if legacy {
+		price = gasPrice
+	}
+	cost := jarviscommon.BigToFloat(new(big.Int).Mul(new(big.Int).SetUint64(gasLimit), price), 18)
+	if legacy {
+		return fmt.Sprintf("%.4f gwei · %d gas · ≈ %.8f %s",
+			jarviscommon.BigToFloat(gasPrice, 9), gasLimit, cost, symbol)
+	}
+	return fmt.Sprintf("max %.4f gwei, tip %.4f gwei · %d gas · ≈ %.8f %s",
+		jarviscommon.BigToFloat(feeCap, 9), jarviscommon.BigToFloat(tipCap, 9), gasLimit, cost, symbol)
+}

--- a/cmd/util/signing_card_test.go
+++ b/cmd/util/signing_card_test.go
@@ -1,0 +1,240 @@
+package util
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/ui"
+	"github.com/tranvictor/jarvis/util"
+)
+
+const (
+	cardMe     = "0x9642b23Ed1E01Df1092B92641051881a322F5D4E"
+	cardRouter = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"
+	cardUSDC   = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+	maxUint    = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+)
+
+func cardAddr(hex, desc string) jarviscommon.Address {
+	return jarviscommon.Address{Address: hex, Desc: desc}
+}
+
+func addrParam(name, hex, desc string) jarviscommon.ParamResult {
+	a := cardAddr(hex, desc)
+	return jarviscommon.ParamResult{Name: name, Type: "address", Values: []jarviscommon.Value{
+		{Raw: hex, Kind: jarviscommon.DisplayAddress, Address: &a},
+	}}
+}
+
+func uintParam(name, raw string) jarviscommon.ParamResult {
+	return jarviscommon.ParamResult{Name: name, Type: "uint256", Values: []jarviscommon.Value{
+		{Raw: raw, Kind: jarviscommon.DisplayInteger},
+	}}
+}
+
+func TestSigningWarningsRoutineTxHasNone(t *testing.T) {
+	got := SigningWarnings(WarningInput{
+		To: cardAddr(cardRouter, "Uniswap V2 Router"), ToIsContract: true, Value: big.NewInt(0),
+		HasData: true,
+		Call: &jarviscommon.FunctionCall{
+			Destination: cardAddr(cardRouter, "Uniswap V2 Router"), Method: "swapExactTokensForTokens",
+		},
+	})
+	if len(got) != 0 {
+		t.Fatalf("expected no warnings, got %v", got)
+	}
+}
+
+func TestSigningWarningsCoverTheRiskyCases(t *testing.T) {
+	cases := []struct {
+		name string
+		in   WarningInput
+		want []string
+	}{
+		{
+			name: "unknown destination",
+			in:   WarningInput{To: cardAddr(cardRouter, "unknown")},
+			want: []string{cardRouter + " is not in your address book"},
+		},
+		{
+			name: "value into a contract",
+			in: WarningInput{
+				To: cardAddr(cardRouter, "Router"), ToIsContract: true,
+				Value: big.NewInt(1500000000000000000), NativeSymbol: "ETH",
+			},
+			want: []string{"sends 1.5 ETH into a contract"},
+		},
+		{
+			name: "delegatecall multisend",
+			in:   WarningInput{To: cardAddr(cardRouter, "MultiSendCallOnly"), DelegateCall: true, MultiSend: true},
+			want: []string{"DELEGATECALL into MultiSend"},
+		},
+		{
+			name: "undecoded calldata",
+			in:   WarningInput{To: cardAddr(cardRouter, "Router"), HasData: true, Call: &jarviscommon.FunctionCall{Destination: cardAddr(cardRouter, "Router")}},
+			want: []string{"calldata could not be decoded (no ABI for " + cardRouter + ")"},
+		},
+		{
+			name: "unlimited approve",
+			in: WarningInput{To: cardAddr(cardUSDC, "USDC"), Call: &jarviscommon.FunctionCall{
+				Destination: cardAddr(cardUSDC, "USDC"), Method: "approve",
+				Params: []jarviscommon.ParamResult{addrParam("spender", cardRouter, "Uniswap V2 Router"), uintParam("amount", maxUint)},
+			}},
+			want: []string{"approves UNLIMITED USDC to " + cardRouter + " (Uniswap V2 Router)"},
+		},
+		{
+			name: "approve to unknown spender",
+			in: WarningInput{To: cardAddr(cardUSDC, "USDC"), Call: &jarviscommon.FunctionCall{
+				Destination: cardAddr(cardUSDC, "USDC"), Method: "approve",
+				Params: []jarviscommon.ParamResult{addrParam("spender", cardRouter, ""), uintParam("amount", "1000")},
+			}},
+			want: []string{"spender " + cardRouter + " is not in your address book"},
+		},
+		{
+			name: "setApprovalForAll inside a multisend",
+			in: WarningInput{To: cardAddr(cardRouter, "MultiSend"), Call: &jarviscommon.FunctionCall{
+				Destination: cardAddr(cardRouter, "MultiSend"), Method: "multiSend",
+				DecodedFunctionCalls: []*jarviscommon.FunctionCall{{
+					Destination: cardAddr(cardUSDC, "CoolNFT"), Method: "setApprovalForAll",
+					Params: []jarviscommon.ParamResult{
+						addrParam("operator", cardMe, "me"),
+						{Name: "approved", Type: "bool", Values: []jarviscommon.Value{{Raw: "true", Kind: jarviscommon.DisplayRaw}}},
+					},
+				}},
+			}},
+			want: []string{"grants " + cardMe + " (me) control over ALL CoolNFT tokens"},
+		},
+	}
+	for _, c := range cases {
+		got := SigningWarnings(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("%s: got %d warnings %v, want %d", c.name, len(got), got, len(c.want))
+			continue
+		}
+		for i := range c.want {
+			if !strings.Contains(got[i], c.want[i]) {
+				t.Errorf("%s: warning %d = %q, want to contain %q", c.name, i, got[i], c.want[i])
+			}
+		}
+	}
+}
+
+func TestShowSigningCardOrderAndFullAddresses(t *testing.T) {
+	rec := ui.NewRecordingUI("y")
+	fc := &jarviscommon.FunctionCall{
+		Destination: cardAddr(cardUSDC, "USDC"), Method: "approve",
+		Params: []jarviscommon.ParamResult{addrParam("spender", cardRouter, ""), uintParam("amount", maxUint)},
+	}
+	card := &SigningCard{
+		Kind:     "EOA transaction",
+		Network:  "mainnet",
+		Signer:   util.StyledAddress(cardAddr(cardMe, "me")),
+		To:       util.StyledAddress(cardAddr(cardUSDC, "USDC")),
+		Gas:      "max 20.0000 gwei, tip 1.5000 gwei · 85123 gas · ≈ 0.00170246 ETH",
+		Nonce:    "42",
+		Call:     util.NewFunctionCallDisplay(fc),
+		Warnings: SigningWarnings(WarningInput{To: cardAddr(cardUSDC, "USDC"), HasData: true, Call: fc}),
+		Prompt:   "Sign and broadcast (≈ 0.00170246 ETH)?",
+	}
+	if !ConfirmSigningCard(rec, card) {
+		t.Fatal("scripted 'y' should confirm")
+	}
+
+	var got []string
+	for _, e := range rec.Entries() {
+		got = append(got, e.Method+": "+e.Value)
+	}
+	joined := strings.Join(got, "\n")
+
+	// Order: title, call, summary, warnings, prompt.
+	order := []string{
+		"Section: EOA transaction",
+		"Subsection: Call  approve  →  " + cardUSDC + " (USDC)",
+		"Info: spender  " + cardRouter + "  address",
+		"KeyValue: Sign with: " + cardMe + " (me)   mainnet",
+		"KeyValue: Send to: " + cardUSDC + " (USDC)",
+		"KeyValue: Gas: max 20.0000 gwei, tip 1.5000 gwei · 85123 gas · ≈ 0.00170246 ETH   nonce 42",
+		"Warn: ! approves UNLIMITED USDC to " + cardRouter,
+		"Confirm: Sign and broadcast (≈ 0.00170246 ETH)?",
+	}
+	pos := -1
+	for _, w := range order {
+		idx := strings.Index(joined, w)
+		if idx < 0 {
+			t.Fatalf("missing %q in:\n%s", w, joined)
+		}
+		if idx < pos {
+			t.Fatalf("%q out of order in:\n%s", w, joined)
+		}
+		pos = idx
+	}
+	if strings.Contains(joined, "…") {
+		t.Fatalf("signing card must never shorten addresses:\n%s", joined)
+	}
+}
+
+func TestShowSigningCardSafeFieldsAndCollapse(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	card := &SigningCard{
+		Kind:   "Safe approval",
+		Signer: util.StyledAddress(cardAddr(cardMe, "me")),
+		To:     util.StyledAddress(cardAddr(cardRouter, "MultiSendCallOnly")),
+		Safe: &SafeCardFields{
+			Operation: "DELEGATECALL (1)", DelegateCall: true, MultiSend: true,
+			SafeNonce: "17", SafeTxHash: "0xabc",
+			SafeTxGas: "0", BaseGas: "0", GasPrice: "0", GasToken: "0x0", RefundReceiver: "0x0",
+			Signatures: []ui.StyledText{{Text: "[off-chain] " + cardMe + " (me)"}},
+			Threshold:  2,
+		},
+		Warnings: SigningWarnings(WarningInput{To: cardAddr(cardRouter, "MultiSendCallOnly"), DelegateCall: true, MultiSend: true}),
+	}
+	ShowSigningCard(rec, card)
+	for _, w := range []string{
+		"Safe calls: " + cardRouter + " (MultiSendCallOnly)",
+		"Operation: DELEGATECALL (1)",
+		"Safe nonce: 17",
+		"safeTxHash: 0xabc",
+		"Signed by (1 of 2 required)",
+		"1. [off-chain] " + cardMe + " (me)",
+		"! DELEGATECALL into MultiSend",
+	} {
+		if !rec.HasMessage(w) {
+			t.Fatalf("missing %q in %v", w, rec.Entries())
+		}
+	}
+
+	rec = ui.NewRecordingUI()
+	exec := &SigningCard{
+		Kind:         "Safe execution",
+		Call:         util.NewFunctionCallDisplay(&jarviscommon.FunctionCall{Destination: cardAddr(cardRouter, "Safe"), Method: "execTransaction", Params: []jarviscommon.ParamResult{uintParam("value", "0")}}),
+		CollapseCall: true,
+		Safe:         &SafeCardFields{Executes: "0xabc"},
+	}
+	ShowSigningCard(rec, exec)
+	if !rec.HasMessage("Call  execTransaction  →  " + cardRouter + " (Safe)   (Safe transaction shown above)") {
+		t.Fatalf("collapsed call header missing: %v", rec.Entries())
+	}
+	if rec.HasMessage("value  0") {
+		t.Fatalf("collapsed call must not print params: %v", rec.Entries())
+	}
+	if !rec.HasMessage("Executes: 0xabc") || rec.HasMessage("Operation:") {
+		t.Fatalf("execution card should link the safeTxHash without repeating Safe params: %v", rec.Entries())
+	}
+}
+
+func TestFormatGasLine(t *testing.T) {
+	gwei := big.NewInt(1_000_000_000)
+	legacy := FormatGasLine(true, new(big.Int).Mul(big.NewInt(20), gwei), nil, nil, 21000, "ETH")
+	if legacy != "20.0000 gwei · 21000 gas · ≈ 0.00042000 ETH" {
+		t.Fatalf("legacy: %q", legacy)
+	}
+	dyn := FormatGasLine(false, nil, new(big.Int).Mul(big.NewInt(20), gwei), new(big.Int).Mul(big.NewInt(2), gwei), 21000, "ETH")
+	if dyn != "max 20.0000 gwei, tip 2.0000 gwei · 21000 gas · ≈ 0.00042000 ETH" {
+		t.Fatalf("dynamic: %q", dyn)
+	}
+	if gasCostOnly(dyn) != "≈ 0.00042000 ETH" {
+		t.Fatalf("gasCostOnly: %q", gasCostOnly(dyn))
+	}
+}

--- a/util/display.go
+++ b/util/display.go
@@ -350,97 +350,6 @@ func printRawCalldata(u ui.UI, data string) {
 	}
 }
 
-// printUndecodedCall renders a call jarvis couldn't decode. Showing the
-// destination, the selector and the raw calldata is what lets an operator tell
-// *which* contract is missing an ABI (and inspect the payload by hand) instead
-// of staring at a bare decode error — which matters most for one entry of a
-// multisig batch, where the failing contract is otherwise invisible.
-func printUndecodedCall(u ui.UI, d *FunctionCallDisplay, nested bool) {
-	var rows [][]ui.TableCell
-	if nested {
-		// The arrow label already carries the destination; don't repeat it.
-		u.Error("↳ <undecoded call>  [%s]", u.Style(d.Destination))
-		u = u.Indent()
-	} else {
-		u.Section("Function call: <undecoded>")
-		rows = append(rows, []ui.TableCell{ui.TC("Contract"), tableCell(d.Destination)})
-	}
-
-	if d.Value != "" {
-		rows = append(rows, []ui.TableCell{ui.TC("Value"), ui.TC(d.Value)})
-	}
-	if len(d.Data) >= 10 {
-		rows = append(rows, []ui.TableCell{ui.TC("Method ID"), ui.TC(d.Data[:10])})
-	}
-	if d.Error != "" {
-		rows = append(
-			rows,
-			[]ui.TableCell{ui.TC("Error"), ui.TCS(d.Error, ui.SeverityError)},
-		)
-	}
-	if len(rows) > 0 {
-		u.PrintTable(&ui.Table{Groups: [][][]ui.TableCell{rows}})
-	}
-	if d.Data != "" {
-		printRawCalldata(u, d.Data)
-	}
-
-	for _, inner := range d.InnerCalls {
-		printFunctionCallDisplay(u.Indent(), inner, true)
-	}
-}
-
-func printFunctionCallDisplay(u ui.UI, d *FunctionCallDisplay, nested bool) {
-	if d.Method == "" {
-		printUndecodedCall(u, d, nested)
-		return
-	}
-
-	if nested {
-		// Inner calls are visually subordinate — a simple arrow label, no Section.
-		u.Info("↳ %s  [%s]", d.Method, u.Style(d.Destination))
-		if d.Error != "" {
-			u.Indent().Error("%s", d.Error)
-		}
-		printParamList(u.Indent(), d.Params)
-		for _, inner := range d.InnerCalls {
-			printFunctionCallDisplay(u.Indent(), inner, true)
-		}
-		return
-	}
-
-	u.Section(fmt.Sprintf("Function call: %s", d.Method))
-
-	// Build a single TableWithGroups: contract metadata (group 0) + params (group 1).
-	metaGroup := [][]ui.TableCell{{ui.TC("Contract"), tableCell(d.Destination)}}
-	if d.Value != "" {
-		metaGroup = append(metaGroup, []ui.TableCell{ui.TC("Value"), ui.TC(d.Value)})
-	}
-	// A method can resolve while its arguments fail to unpack; say so instead of
-	// showing a name over an empty parameter list.
-	if d.Error != "" {
-		metaGroup = append(
-			metaGroup,
-			[]ui.TableCell{ui.TC("Error"), ui.TCS(d.Error, ui.SeverityError)},
-		)
-	}
-
-	var paramGroup [][]ui.TableCell
-	for _, p := range d.Params {
-		paramGroup = append(paramGroup, flattenParamRows(p, "")...)
-	}
-
-	if len(paramGroup) > 0 {
-		u.PrintTable(&ui.Table{Groups: [][][]ui.TableCell{metaGroup, paramGroup}})
-	} else {
-		u.PrintTable(&ui.Table{Groups: [][][]ui.TableCell{metaGroup}})
-	}
-
-	for _, inner := range d.InnerCalls {
-		printFunctionCallDisplay(u.Indent(), inner, true)
-	}
-}
-
 // logSimpleRows returns all simple [param, value] rows for a single log,
 // used when building the combined all-logs table.
 func logSimpleRows(d LogDisplay) [][]ui.TableCell {
@@ -511,11 +420,24 @@ func DisplayParams(u ui.UI, params []jarviscommon.ParamResult) []ParamDisplay {
 }
 
 // DisplayFunctionCall builds the human-readable view-model for a decoded
-// function call (and any recursively decoded inner calls) and writes it to u.
+// function call (and any recursively decoded inner calls) and writes it to u
+// as an indented tree with full addresses and nothing collapsed — the form
+// used wherever the reader is about to sign what they see.
 func DisplayFunctionCall(u ui.UI, fc *jarviscommon.FunctionCall) *FunctionCallDisplay {
 	d := buildFunctionCallDisplay(fc, false)
-	printFunctionCallDisplay(u, d, false)
+	PrintFunctionCall(u, d)
 	return d
+}
+
+// NewFunctionCallDisplay builds the view-model for a decoded call without
+// printing it.
+func NewFunctionCallDisplay(fc *jarviscommon.FunctionCall) *FunctionCallDisplay {
+	return buildFunctionCallDisplay(fc, false)
+}
+
+// PrintFunctionCall renders an already-built call view-model in full detail.
+func PrintFunctionCall(u ui.UI, d *FunctionCallDisplay) {
+	txPrinter{u: u, layout: LayoutInfoFull, compact: false}.printCall(d)
 }
 
 // DisplayTxResult builds the human-readable view-model for an analyzed

--- a/util/display_test.go
+++ b/util/display_test.go
@@ -321,8 +321,8 @@ func TestUndecodedCallShowsContractAndData(t *testing.T) {
 	joined := strings.Join(all, "\n")
 
 	for _, want := range []string{
-		"0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97",
-		"Method ID | 0xdeadbeef",
+		"↳ <undecoded>  →  0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97",
+		"selector 0xdeadbeef   36 bytes",
 		"Raw calldata (36 bytes):",
 		"0xdeadbeef00000000000000000000000000000000000000000000000000000000",
 		"no method with id: 0xdeadbeef",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 3 of `docs/improved-ui-plan.md`. Stacked on #111. This is the only phase that changes what is shown at signing time, so it is kept separate for review.

Every pre-sign screen (EOA `SignAndBroadcast`, Safe proposal / approval / execution, `send` via Safe, batch approvals, WalletConnect) now goes through one renderer, `cmdutil.SigningCard`, laid out so the facts to verify sit directly above the prompt:

```
================ EOA transaction =================

Call  approve  →  0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (USDC)
  spender  0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D  address
  amount   uint256.max (∞)  uint256

Sign with  0x9642b23Ed1E01Df1092B92641051881a322F5D4E (me)   mainnet
Send to    0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (USDC)
Gas        max 20.0000 gwei, tip 1.5000 gwei · 85123 gas · ≈ 0.00170246 ETH   nonce 42

! approves UNLIMITED USDC to 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D
! spender 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D is not in your address book

Sign and broadcast (≈ 0.00170246 ETH)? [Y/n]
```

### Changes

- `cmd/util/signing_card.go`: `SigningCard`, `SafeCardFields`, `ShowSigningCard`, `ConfirmSigningCard`, `SigningWarnings`, `FormatGasLine`. Order: title → ERC-7730 box (callback) → call tree (full detail, full addresses) → key/value summary → `Signed by (n of m required)` for Safe → yellow `!` warnings → prompt.
- `SigningWarnings` is a pure function over `WarningInput` and covers: destination not in address book, native value sent into a contract, `DELEGATECALL` (with a MultiSend-specific message), calldata that could not be decoded, unlimited approvals, `setApprovalForAll(true)`, approvals to unknown spenders. It recurses into inner calls so a MultiSend batch is checked call by call.
- `PromptTxConfirmation` builds the EOA card (`buildEOASigningCard`); `showTxInfoToConfirm` is gone. Contract creation shows `Creates <predicted address>`.
- `cmd/safe_display.go`: `buildSafeSigningCard(stx, hash, tc, safeCardOptions{kind, extraABIs, sigs, threshold, signer, prompt})` replaces `showSafeTxToConfirmWithABIs`; `showSafeTxToConfirm` remains as a read-only wrapper. Call sites in `safe.go`, `safe_batch.go`, `send.go` updated with kind-specific titles and prompts.
- Safe approve → execute: `runSafeExecute` shows the `Safe execution` card once, then `cmdutil.SetNextSigningNote` makes the following EOA card link `Executes 0x<safeTxHash>` and collapse the `execTransaction` call to a single header line instead of re-decoding the batch.
- Prompt wording states consequence and cost: `Sign and broadcast (≈ X ETH)?`, `Sign approval (off-chain, no gas)?`, `Sign and submit this Safe proposal (off-chain, no gas)?`. `Broadcast approveHash on-chain?` / `Broadcast execTransaction now?` unchanged.
- `util.DisplayFunctionCall` now renders the tree/full-address form everywhere (classic msig, `AnalyzeMethodCallAndPrint`); the bordered-table call renderer is removed. `util.NewFunctionCallDisplay` / `util.PrintFunctionCall` exported.
- `operationLabel` drops the `— DANGEROUS` suffix; the delegatecall risk is now a warning line with the reason.

Addresses are never shortened on a signing card (test-enforced).

## Tests

`cmd/util/signing_card_test.go`: warning derivation table (7 cases + routine tx), card ordering/full-address transcript, Safe fields + collapsed execution card, gas line formatting. Existing `TestUndecodedCallShowsContractAndData` updated for the tree output.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

