### PR TITLE
UI phase 4: live wait status and post-sign delta view

### DIFF
--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -949,7 +949,7 @@ Safe+Classic runs write both arrays into one file.`,
 				util.AnalyzeAndPrint(
 					appUI,
 					cm.Reader(network), cm.Analyzer(network),
-					minedTx.Hash().Hex(), network, false, "", a, nil, util.InfoLayout(config.DegenMode),
+					minedTx.Hash().Hex(), network, false, "", a, nil, util.PostSignLayout(config.DegenMode),
 				)
 			}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/networks"
 	"github.com/tranvictor/jarvis/ui"
+	"github.com/tranvictor/jarvis/util/account/ledgereum"
 )
 
 // appUI is the package-level UI used by all cmd/* files. It is initialised
@@ -115,6 +116,10 @@ func SupportedNetworkAndBlockExplorerVariableHelpString() string {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	// Hardware-wallet waits (Ledger not yet connected) report through the
+	// same status spinner as the rest of the app.
+	ledgereum.ProgressUI = appUI
+
 	rootCmd.PersistentFlags().StringVarP(
 		&config.NetworkString,
 		"network",

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -309,7 +309,7 @@ func SignAndBroadcast(
 		return false, err
 	}
 
-	u.Info("Unlock your wallet and sign now...")
+	u.Info("Unlock your wallet and sign now…")
 	account, err := accounts.UnlockAccount(fromAcc)
 	if err != nil {
 		return false, fmt.Errorf("%w: %s", ErrWalletUnlock, err)
@@ -392,7 +392,7 @@ func HandlePostSign(
 		}
 		util.DisplayWaitAnalyze(
 			u, reader, analyzer, signedTx, broadcasted, err, config.Network(),
-			a, nil, util.InfoLayout(config.DegenMode),
+			a, nil, util.PostSignLayout(config.DegenMode),
 		)
 		return broadcasted, err
 	}
@@ -426,7 +426,7 @@ func HandlePostSign(
 
 	util.DisplayWaitAnalyze(
 		u, reader, analyzer, signedTx, broadcasted, err, config.Network(),
-		a, nil, util.InfoLayout(config.DegenMode),
+		a, nil, util.PostSignLayout(config.DegenMode),
 	)
 	return broadcasted, err
 }

--- a/util/account/ledgereum/ledger_signer.go
+++ b/util/account/ledgereum/ledger_signer.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 
+	"github.com/tranvictor/jarvis/ui"
+
 	jarviscommon "github.com/tranvictor/jarvis/common"
 	kusb "github.com/tranvictor/jarvis/util/account/usb"
 )
@@ -22,8 +24,9 @@ import (
 // device in after the dApp already issued the request.
 const deviceWaitTimeout = 90 * time.Second
 
-// deviceWaitPoll is how often we retry enumeration while waiting.
-const deviceWaitPoll = 2 * time.Second
+// deviceWaitPoll is how often we retry enumeration while waiting. A
+// variable so tests can shorten it.
+var deviceWaitPoll = 2 * time.Second
 
 // minLedgerEthAppVersionForEIP712 is the lowest Ethereum app version known to
 // implement opcode 0x0C (SIGN_ETH_EIP_712 with precomputed hashes). For older
@@ -97,34 +100,47 @@ func (self *LedgerSigner) ensureUnlocked() error {
 	return unlockWithWait(self.unlockOnce, deviceWaitTimeout)
 }
 
+// ProgressUI, when set by the application, is used to show a live status
+// line while jarvis waits for a Ledger to be connected. It stays nil in
+// library use, where the wait falls back to plain printed lines.
+var ProgressUI ui.UI
+
 // unlockWithWait repeatedly calls unlock until it succeeds, a
-// non-"device not found" error happens, or timeout elapses. The
-// user sees progress roughly every 10s.
+// non-"device not found" error happens, or timeout elapses. The user sees a
+// single status line counting down the remaining time.
 func unlockWithWait(unlock func() error, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	attempt := 0
+	var progress ui.Progress
+	stop := func(final ui.StyledText) {
+		if progress != nil {
+			progress.Stop(final)
+		}
+	}
 	for {
-		attempt++
 		err := unlock()
 		if err == nil {
+			stop(ui.StyledText{Text: "✓ Ledger connected", Severity: ui.SeveritySuccess})
 			return nil
 		}
 		if !isLedgerNotConnected(err) {
+			stop(ui.StyledText{})
 			return err
 		}
 		if time.Now().After(deadline) {
+			stop(ui.StyledText{Text: "✗ Ledger not detected", Severity: ui.SeverityError})
 			return fmt.Errorf(
 				"ledger not connected after %s (last error: %w). Plug it in, unlock and open the Ethereum app, then try again",
 				timeout, err)
 		}
-		if attempt == 1 {
-			fmt.Printf(
-				"Ledger not detected. Please connect it, unlock and open the Ethereum app within %s...\n",
-				timeout,
-			)
-		} else if attempt%5 == 0 {
-			remaining := time.Until(deadline).Round(time.Second)
-			fmt.Printf("  ...still waiting for Ledger (~%s left)\n", remaining)
+		remaining := time.Until(deadline).Round(time.Second)
+		msg := fmt.Sprintf("Ledger not detected — connect it, unlock and open the Ethereum app (%s left)", remaining)
+		switch {
+		case progress != nil:
+			progress.Update(msg)
+		case ProgressUI != nil:
+			progress = ProgressUI.Spinner(msg)
+		default:
+			fmt.Println(msg)
 		}
 		time.Sleep(deviceWaitPoll)
 	}
@@ -159,7 +175,6 @@ func (self *LedgerSigner) SignTx(
 ) (common.Address, *types.Transaction, error) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
-	fmt.Printf("Going to proceed signing procedure\n")
 	if err := self.ensureUnlocked(); err != nil {
 		return common.Address{}, tx, err
 	}

--- a/util/account/ledgereum/wait_test.go
+++ b/util/account/ledgereum/wait_test.go
@@ -1,0 +1,73 @@
+package ledgereum
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tranvictor/jarvis/ui"
+)
+
+func TestUnlockWithWaitReportsThroughProgressUI(t *testing.T) {
+	origPoll, origUI := deviceWaitPoll, ProgressUI
+	deviceWaitPoll = time.Millisecond
+	rec := ui.NewRecordingUI()
+	ProgressUI = rec
+	defer func() { deviceWaitPoll, ProgressUI = origPoll, origUI }()
+
+	attempts := 0
+	err := unlockWithWait(func() error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("Ledger device is not found")
+		}
+		return nil
+	}, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var methods []string
+	for _, e := range rec.Entries() {
+		methods = append(methods, e.Method)
+	}
+	want := []string{"Spinner", "SpinnerUpdate", "SpinnerStop"}
+	if len(methods) != len(want) {
+		t.Fatalf("got %v, want %v", rec.Entries(), want)
+	}
+	for i := range want {
+		if methods[i] != want[i] {
+			t.Fatalf("entry %d: got %v, want %v", i, rec.Entries(), want)
+		}
+	}
+	if !rec.HasMessage("✓ Ledger connected") || !rec.HasMessage("left)") {
+		t.Fatalf("expected countdown and success line, got %v", rec.Entries())
+	}
+}
+
+func TestUnlockWithWaitTimesOut(t *testing.T) {
+	origPoll, origUI := deviceWaitPoll, ProgressUI
+	deviceWaitPoll = time.Millisecond
+	rec := ui.NewRecordingUI()
+	ProgressUI = rec
+	defer func() { deviceWaitPoll, ProgressUI = origPoll, origUI }()
+
+	err := unlockWithWait(func() error { return errors.New("no such device") }, 5*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !rec.HasMessage("✗ Ledger not detected") {
+		t.Fatalf("expected failure line, got %v", rec.Entries())
+	}
+}
+
+func TestUnlockWithWaitSurfacesOtherErrorsImmediately(t *testing.T) {
+	origUI := ProgressUI
+	ProgressUI = ui.NewRecordingUI()
+	defer func() { ProgressUI = origUI }()
+
+	err := unlockWithWait(func() error { return errors.New("user rejected") }, time.Second)
+	if err == nil || err.Error() != "user rejected" {
+		t.Fatalf("got %v", err)
+	}
+}

--- a/util/display.go
+++ b/util/display.go
@@ -461,3 +461,12 @@ func InfoLayout(degen bool) TxLayout {
 	}
 	return LayoutInfo
 }
+
+// PostSignLayout is the layout for a tx the user just signed: the delta view
+// by default, everything with --degen.
+func PostSignLayout(degen bool) TxLayout {
+	if degen {
+		return LayoutInfoFull
+	}
+	return LayoutPostSign
+}

--- a/util/monitor/monitor.go
+++ b/util/monitor/monitor.go
@@ -15,12 +15,26 @@ func NewGenericTxMonitor(r *reader.EthReader) *TxMonitor {
 	return &TxMonitor{r}
 }
 
-func (tm TxMonitor) periodicCheck(tx string, info chan common.TxInfo, interval time.Duration) {
+// periodicCheck polls the tx until it reaches a final state and sends that
+// state on info. When status is non-nil, every intermediate state change
+// ("pending" once the tx is seen in the mempool) is sent there too, and the
+// final state is sent on it as well before it is closed.
+func (tm TxMonitor) periodicCheck(tx string, info chan common.TxInfo, status chan string, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	startTime := time.Now()
 	isOnNode := false
 	var notFoundSince time.Time
+
+	finish := func(result common.TxInfo) {
+		if status != nil {
+			status <- result.Status
+			close(status)
+		}
+		if info != nil {
+			info <- result
+		}
+	}
 
 	for {
 		t := <-ticker.C
@@ -36,53 +50,49 @@ func (tm TxMonitor) periodicCheck(tx string, info chan common.TxInfo, interval t
 					notFoundSince = t
 				}
 				if t.Sub(notFoundSince) > 1*time.Minute {
-					info <- common.TxInfo{
-						Status:  "lost",
-						Tx:      tx,
-						Receipt: receipt,
-					}
+					finish(common.TxInfo{Status: "lost", Tx: tx, Receipt: receipt})
 					return
 				}
 			} else if t.Sub(startTime) > 3*time.Minute {
-				info <- common.TxInfo{
-					Status:  "lost",
-					Tx:      tx,
-					Receipt: receipt,
-				}
+				finish(common.TxInfo{Status: "lost", Tx: tx, Receipt: receipt})
 				return
 			}
 			continue
 		case "pending":
+			if !isOnNode && status != nil {
+				status <- "pending"
+			}
 			isOnNode = true
 			notFoundSince = time.Time{} // reset if tx reappears in mempool
 			continue
 		case "reverted":
-			info <- common.TxInfo{
-				Status:  "reverted",
-				Tx:      tx,
-				Receipt: receipt,
-			}
+			finish(common.TxInfo{Status: "reverted", Tx: tx, Receipt: receipt})
 			return
 		case "done":
-			info <- common.TxInfo{
-				Status:  "done",
-				Tx:      tx,
-				Receipt: receipt,
-			}
+			finish(common.TxInfo{Status: "done", Tx: tx, Receipt: receipt})
 			return
 		}
 	}
 }
 
+// MakeStatusChannel returns a channel that receives "pending" when the tx is
+// first seen in the mempool, then exactly one final status ("done",
+// "reverted" or "lost"), after which the channel is closed.
+func (tm TxMonitor) MakeStatusChannel(tx string) <-chan string {
+	status := make(chan string, 2)
+	go tm.periodicCheck(tx, nil, status, 5*time.Second)
+	return status
+}
+
 func (tm TxMonitor) MakeWaitChannel(tx string) <-chan common.TxInfo {
 	result := make(chan common.TxInfo)
-	go tm.periodicCheck(tx, result, 5*time.Second)
+	go tm.periodicCheck(tx, result, nil, 5*time.Second)
 	return result
 }
 
 func (tm TxMonitor) MakeWaitChannelWithInterval(tx string, interval time.Duration) <-chan common.TxInfo {
 	result := make(chan common.TxInfo)
-	go tm.periodicCheck(tx, result, interval)
+	go tm.periodicCheck(tx, result, nil, interval)
 	return result
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -261,10 +262,50 @@ func DisplayBroadcastedTx(u ui.UI, t *types.Transaction, broadcasted bool, err e
 		u.Error("%s", err)
 		u.Info("Check each URL with your chain id (e.g. cast chain-id --rpc-url <url>). Remove or fix nodes that return the wrong chain.")
 	} else {
-		u.Critical("BROADCASTED TX: %s:%s", network.GetName(), t.Hash().Hex())
+		u.Success("✓ broadcast  %s  %s", network.GetName(), t.Hash().Hex())
 	}
 }
 
+// WaitForTx blocks until the tx is mined, reverted or lost, showing a live
+// status line that tracks what the monitor sees (not yet in mempool → in
+// mempool → outcome). It returns the final status.
+func WaitForTx(u ui.UI, mo *monitor.TxMonitor, hash string) string {
+	return waitForStatuses(u, mo.MakeStatusChannel(hash))
+}
+
+// waitForStatuses drives the status line from a monitor status channel.
+func waitForStatuses(u ui.UI, statuses <-chan string) string {
+	progress := u.Spinner("waiting for the tx to show up in the mempool…")
+	for st := range statuses {
+		switch st {
+		case "pending":
+			progress.Update("in mempool, waiting to be mined…")
+		case "done":
+			progress.Stop(ui.StyledText{
+				Text:     fmt.Sprintf("✓ mined after %s", progress.Elapsed().Round(time.Second)),
+				Severity: ui.SeveritySuccess,
+			})
+			return st
+		case "reverted":
+			progress.Stop(ui.StyledText{
+				Text:     fmt.Sprintf("✗ reverted after %s", progress.Elapsed().Round(time.Second)),
+				Severity: ui.SeverityError,
+			})
+			return st
+		case "lost":
+			progress.Stop(ui.StyledText{
+				Text:     fmt.Sprintf("✗ dropped from the mempool after %s", progress.Elapsed().Round(time.Second)),
+				Severity: ui.SeverityError,
+			})
+			return st
+		}
+	}
+	progress.Stop(ui.StyledText{Text: "✗ stopped waiting", Severity: ui.SeverityError})
+	return "unknown"
+}
+
+// DisplayWaitAnalyze reports the broadcast result and, when it succeeded,
+// waits for the tx to be mined and prints the outcome using layout.
 func DisplayWaitAnalyze(
 	u ui.UI,
 	reader reader.Reader,
@@ -278,26 +319,20 @@ func DisplayWaitAnalyze(
 	layout TxLayout,
 ) {
 	DisplayBroadcastedTx(u, t, broadcasted, err, network)
-	if broadcasted {
-		mo, err := EthTxMonitor(network)
-		if err != nil {
-			u.Error("Couldn't monitor the tx: %s", err)
-			return
-		}
-		mo.BlockingWait(t.Hash().Hex())
-		AnalyzeAndPrint(
-			u,
-			reader,
-			analyzer,
-			t.Hash().Hex(),
-			network,
-			false,
-			"",
-			a,
-			customABIs,
-			layout,
-		)
+	if !broadcasted {
+		return
 	}
+	mo, err := EthTxMonitor(network)
+	if err != nil {
+		u.Error("Couldn't monitor the tx: %s", err)
+		return
+	}
+	hash := t.Hash().Hex()
+	if WaitForTx(u, mo, hash) == "lost" {
+		u.Info("Check the hash later with: jarvis info %s", hash)
+		return
+	}
+	AnalyzeAndPrint(u, reader, analyzer, hash, network, false, "", a, customABIs, layout)
 }
 
 func AnalyzeMethodCallAndPrint(

--- a/util/wait_test.go
+++ b/util/wait_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tranvictor/jarvis/ui"
+)
+
+func TestWaitForStatusesTracksMempoolThenOutcome(t *testing.T) {
+	cases := []struct {
+		statuses []string
+		final    string
+		stop     string
+	}{
+		{[]string{"pending", "done"}, "done", "✓ mined after"},
+		{[]string{"done"}, "done", "✓ mined after"},
+		{[]string{"pending", "reverted"}, "reverted", "✗ reverted after"},
+		{[]string{"pending", "lost"}, "lost", "✗ dropped from the mempool after"},
+	}
+	for _, c := range cases {
+		ch := make(chan string, len(c.statuses))
+		for _, s := range c.statuses {
+			ch <- s
+		}
+		close(ch)
+
+		rec := ui.NewRecordingUI()
+		got := waitForStatuses(rec, ch)
+		if got != c.final {
+			t.Errorf("%v: final %q, want %q", c.statuses, got, c.final)
+		}
+		var methods []string
+		for _, e := range rec.Entries() {
+			methods = append(methods, e.Method+": "+e.Value)
+		}
+		joined := strings.Join(methods, "\n")
+		if !strings.HasPrefix(joined, "Spinner: waiting for the tx to show up in the mempool…") {
+			t.Errorf("%v: spinner should start before the mempool check:\n%s", c.statuses, joined)
+		}
+		if c.statuses[0] == "pending" && !strings.Contains(joined, "SpinnerUpdate: in mempool, waiting to be mined…") {
+			t.Errorf("%v: expected mempool update:\n%s", c.statuses, joined)
+		}
+		if !strings.Contains(joined, "SpinnerStop: "+c.stop) {
+			t.Errorf("%v: expected final line %q:\n%s", c.statuses, c.stop, joined)
+		}
+	}
+}
+
+func TestWaitForStatusesClosedWithoutOutcome(t *testing.T) {
+	ch := make(chan string)
+	close(ch)
+	rec := ui.NewRecordingUI()
+	if got := waitForStatuses(rec, ch); got != "unknown" {
+		t.Fatalf("got %q", got)
+	}
+	if !rec.HasMessage("✗ stopped waiting") {
+		t.Fatalf("expected a stop line, got %v", rec.Entries())
+	}
+}

--- a/walletconnect/gateways/classic.go
+++ b/walletconnect/gateways/classic.go
@@ -254,7 +254,7 @@ func (g *ClassicGateway) waitAndAnalyze(
 	analyzer := txanalyzer.NewGenericAnalyzer(g.reader, g.network)
 	util.DisplayWaitAnalyze(
 		fullUI, g.reader, analyzer, signedTx, true, nil, g.network,
-		nil, nil, util.InfoLayout(config.DegenMode),
+		nil, nil, util.PostSignLayout(config.DegenMode),
 	)
 }
 

--- a/walletconnect/gateways/eoa.go
+++ b/walletconnect/gateways/eoa.go
@@ -302,7 +302,7 @@ func (g *EOAGateway) waitAndAnalyze(
 	}
 	jarvisutil.DisplayWaitAnalyze(
 		fullUI, rd, analyzer, signedTx, true, nil, net,
-		nil, customABIs, jarvisutil.InfoLayout(config.DegenMode),
+		nil, customABIs, jarvisutil.PostSignLayout(config.DegenMode),
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 4 of `docs/improved-ui-plan.md`. Stacked on #112.

After signing, the user now sees what is happening instead of a silent pause:

```
✓ broadcast  mainnet  0x3f9a1c2b…
⠹ in mempool, waiting to be mined…  0:14          ← spinner, elapsed time, TTY only
✓ mined after 19s
✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)
         from me (0x9642…5D4E)   gas 0.00213000 ETH (171203 / 185123)   nonce 412   block 19234567

Transfers
  1000 USDC     me (0x9642…5D4E)  →  USDC/WETH pair (0x0d4a…1852)
  0.3121 WETH   USDC/WETH pair (0x0d4a…1852)  →  me (0x9642…5D4E)

Events (3)
  ...
```

Off-TTY (piped/CI) the same states print as plain lines.

### Changes

- `monitor.TxMonitor.MakeStatusChannel(hash)`: emits `pending` when the tx is first seen in the mempool, then one final `done` / `reverted` / `lost`, then closes. `periodicCheck` gained an optional status channel; `MakeWaitChannel` / `BlockingWait` behave as before.
- `util.WaitForTx` drives a `ui.Progress` spinner from that channel: "waiting for the tx to show up in the mempool…" → "in mempool, waiting to be mined…" → `✓ mined after 19s` / `✗ reverted after …` / `✗ dropped from the mempool after …`. A dropped tx prints `Check the hash later with: jarvis info <hash>` and skips the analysis.
- `DisplayBroadcastedTx` success line becomes `✓ broadcast <network> <hash>` (green) instead of the bold `BROADCASTED TX:` shout.
- Post-sign callers (`HandlePostSign`, WalletConnect EOA/classic gateways, `msig` batch approve) use `util.PostSignLayout(degen)`: `LayoutPostSign` by default (status headline with gas used / limit, transfers, events; the call is repeated only when the tx reverted), `LayoutInfoFull` with `--degen`.
- Ledger connect wait (`ledgereum.unlockWithWait`) reports through `ui.Progress` with a countdown (`Ledger not detected — connect it, unlock and open the Ethereum app (1m28s left)`) when `ledgereum.ProgressUI` is set, which `cmd.Execute` does. Library use without a UI falls back to plain printed lines. The stray `Going to proceed signing procedure` print is removed.

## Tests

`util/wait_test.go` (status sequence → spinner entries and final status for all outcomes), `util/account/ledgereum/wait_test.go` (progress reporting, timeout, immediate surfacing of non-connection errors).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

