### PR TITLE
UI phase 5: batch approve plan, running tally, summary table and exit code

### DIFF
--- a/cmd/batch_ui.go
+++ b/cmd/batch_ui.go
@@ -1,0 +1,140 @@
+package cmd
+
+// Shared rendering for batch commands (`jarvis msig bapprove`): the plan
+// printed before any work starts, per-item banners and one-line results
+// with a running tally, the closing summary table and the exit code.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tranvictor/jarvis/config"
+	"github.com/tranvictor/jarvis/ui"
+)
+
+// exitFunc is os.Exit unless a test swaps it out.
+var exitFunc = os.Exit
+
+// batchTally counts outcomes as items complete.
+type batchTally struct {
+	total, ok, skipped, failed int
+}
+
+func (t *batchTally) add(status string) {
+	switch status {
+	case "approved", "executed", "broadcasted":
+		t.ok++
+	case "skipped":
+		t.skipped++
+	case "failed":
+		t.failed++
+	}
+}
+
+func (t batchTally) done() int { return t.ok + t.skipped + t.failed }
+
+// String renders "2 ok · 1 skipped · 0 failed · 3 left", dropping zero
+// counters except ok so the line stays short.
+func (t batchTally) String() string {
+	parts := []string{fmt.Sprintf("%d ok", t.ok)}
+	if t.skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d skipped", t.skipped))
+	}
+	if t.failed > 0 {
+		parts = append(parts, fmt.Sprintf("%d failed", t.failed))
+	}
+	if left := t.total - t.done(); left > 0 {
+		parts = append(parts, fmt.Sprintf("%d left", left))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// printBatchPlan lists every item before the first prompt so the user knows
+// how many confirmations are coming and can abort early.
+func printBatchPlan(title string, items []string) {
+	appUI.Section(fmt.Sprintf("%s: %d transaction(s)", title, len(items)))
+	for i, it := range items {
+		appUI.Info("%s %s", appUI.Style(ui.StyledText{Text: fmt.Sprintf("%d.", i+1), Severity: ui.SeverityMuted}), it)
+	}
+}
+
+// printBatchBanner opens one item: "[2/5] Safe  <ref>".
+func printBatchBanner(i, total int, kind, label string) {
+	appUI.Info("")
+	appUI.Info("%s %s  %s",
+		appUI.Style(ui.StyledText{Text: fmt.Sprintf("[%d/%d]", i, total), Severity: ui.SeverityCritical}),
+		appUI.Style(ui.StyledText{Text: kind, Severity: ui.SeverityCritical}),
+		label,
+	)
+}
+
+// printBatchItemResult closes one item with a single line whose colour
+// carries the outcome, followed by the running tally.
+func printBatchItemResult(status, detail string, tally batchTally) {
+	var st ui.StyledText
+	switch status {
+	case "approved", "executed", "broadcasted":
+		st = ui.StyledText{Text: "✓ " + status, Severity: ui.SeveritySuccess}
+	case "skipped":
+		st = ui.StyledText{Text: "⊘ skipped", Severity: ui.SeverityWarn}
+	default:
+		st = ui.StyledText{Text: "✗ failed", Severity: ui.SeverityError}
+	}
+	line := appUI.Style(st)
+	if detail != "" {
+		line += "  " + detail
+	}
+	line += "   " + appUI.Style(ui.StyledText{Text: "(" + tally.String() + ")", Severity: ui.SeverityMuted})
+	appUI.Info("%s", line)
+}
+
+// continueBatchAfterFailure asks whether to keep going once an item failed.
+// --yes never stops; an empty answer continues.
+func continueBatchAfterFailure(left int) bool {
+	if config.YesToAllPrompt || left <= 0 {
+		return true
+	}
+	return appUI.Confirm(fmt.Sprintf("Continue with the remaining %d transaction(s)?", left), true)
+}
+
+// resultCell colours a status word for the summary table.
+func resultCell(status string) ui.TableCell {
+	switch status {
+	case "approved", "executed", "broadcasted":
+		return ui.TCS(status, ui.SeveritySuccess)
+	case "skipped":
+		return ui.TCS(status, ui.SeverityWarn)
+	default:
+		return ui.TCS(status, ui.SeverityError)
+	}
+}
+
+// printBatchSummaryTable prints the closing table and the totals line.
+func printBatchSummaryTable(rows [][]ui.TableCell, tally batchTally) {
+	appUI.Section("Batch summary")
+	appUI.PrintTable(&ui.Table{
+		Headers: []string{"#", "Kind", "Network", "Target", "Result", "Detail"},
+		Rows:    rows,
+	})
+	appUI.Info("")
+	appUI.Info("%d transaction(s): %s", tally.total, strings.TrimSuffix(tally.String(), " · 0 left"))
+}
+
+// withIndentedUI runs fn with appUI one level deeper so an item's output is
+// visually nested under its banner. The cmd package addresses the UI through
+// the package variable, hence the swap.
+func withIndentedUI(fn func()) {
+	prev := appUI
+	appUI = appUI.Indent()
+	defer func() { appUI = prev }()
+	fn()
+}
+
+// exitForBatch ends the process with status 1 when anything failed so CI can
+// tell a partial batch from a clean one.
+func exitForBatch(tally batchTally) {
+	if tally.failed > 0 {
+		exitFunc(1)
+	}
+}

--- a/cmd/batch_ui_test.go
+++ b/cmd/batch_ui_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tranvictor/jarvis/config"
+	"github.com/tranvictor/jarvis/ui"
+)
+
+func swapAppUI(t *testing.T, rec *ui.RecordingUI) {
+	t.Helper()
+	prev := appUI
+	appUI = rec
+	t.Cleanup(func() { appUI = prev })
+}
+
+func TestBatchTallyString(t *testing.T) {
+	tl := batchTally{total: 4}
+	if tl.String() != "0 ok · 4 left" {
+		t.Fatalf("empty: %q", tl.String())
+	}
+	tl.add("approved")
+	tl.add("executed")
+	tl.add("skipped")
+	if tl.String() != "2 ok · 1 skipped · 1 left" {
+		t.Fatalf("partial: %q", tl.String())
+	}
+	tl.add("failed")
+	if tl.String() != "2 ok · 1 skipped · 1 failed" {
+		t.Fatalf("complete: %q", tl.String())
+	}
+	if tl.done() != 4 {
+		t.Fatalf("done = %d", tl.done())
+	}
+}
+
+func TestBatchPlanBannerAndResultLines(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	swapAppUI(t, rec)
+
+	printBatchPlan("Batch approve", []string{"Safe     eth:0xsafe:0xhash", "Classic  mainnet:0xinit"})
+	tally := batchTally{total: 2}
+	printBatchBanner(1, 2, "Safe", "eth:0xsafe:0xhash")
+	withIndentedUI(func() { appUI.Info("inner") })
+	tally.add("approved")
+	printBatchItemResult("approved", "safeTxHash 0xhash", tally)
+	tally.add("failed")
+	printBatchItemResult("failed", "sign safeTxHash: rejected", tally)
+
+	var got []string
+	for _, e := range rec.Entries() {
+		got = append(got, e.Method+": "+e.Value)
+	}
+	want := []string{
+		"Section: Batch approve: 2 transaction(s)",
+		"Info: 1. Safe     eth:0xsafe:0xhash",
+		"Info: 2. Classic  mainnet:0xinit",
+		"Info: ",
+		"Info: [1/2] Safe  eth:0xsafe:0xhash",
+		"Info: inner",
+		"Info: ✓ approved  safeTxHash 0xhash   (1 ok · 1 left)",
+		"Info: ✗ failed  sign safeTxHash: rejected   (1 ok · 1 failed)",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("got:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestContinueBatchAfterFailure(t *testing.T) {
+	prevYes := config.YesToAllPrompt
+	t.Cleanup(func() { config.YesToAllPrompt = prevYes })
+
+	config.YesToAllPrompt = true
+	swapAppUI(t, ui.NewRecordingUI())
+	if !continueBatchAfterFailure(3) {
+		t.Fatal("--yes must never stop the batch")
+	}
+
+	config.YesToAllPrompt = false
+	if !continueBatchAfterFailure(0) {
+		t.Fatal("nothing left to do must not prompt")
+	}
+	rec := ui.NewRecordingUI("n")
+	swapAppUI(t, rec)
+	if continueBatchAfterFailure(2) {
+		t.Fatal("answering n must stop the batch")
+	}
+	if !rec.HasMessage("Continue with the remaining 2 transaction(s)?") {
+		t.Fatalf("prompt missing: %v", rec.Entries())
+	}
+}
+
+func TestPrintBatchApproveSummaryAndExitCode(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	swapAppUI(t, rec)
+	prevDegen := config.DegenMode
+	config.DegenMode = false
+	t.Cleanup(func() { config.DegenMode = prevDegen })
+
+	safeResults := []safeBatchResult{
+		{network: "mainnet", safeAddress: "0xsafe", safeTxHash: "0xhash", status: "approved"},
+		{network: "bsc", safeAddress: "0xsafe2", status: "failed", reason: "unlock wallet: nope"},
+	}
+	classic := []batchResult{
+		{network: "matic", initTxHash: "0xinit", msigTxID: "7", status: "skipped", reason: "already executed"},
+	}
+	tally := batchTally{total: 3}
+	for _, r := range safeResults {
+		tally.add(r.status)
+	}
+	tally.add(classic[0].status)
+	printBatchApproveSummary(safeResults, classic, tally)
+
+	for _, w := range []string{
+		"Section: Batch summary",
+		"Table: # | Kind | Network | Target | Result | Detail",
+		"Table: 1 | Safe | mainnet | 0xsafe | approved | safeTxHash 0xhash",
+		"Table: 2 | Safe | bsc | 0xsafe2 | failed | unlock wallet: nope",
+		"Table: 3 | Classic | matic | msig #7 | skipped | already executed",
+		"Info: 3 transaction(s): 1 ok · 1 skipped · 1 failed",
+	} {
+		found := false
+		for _, e := range rec.Entries() {
+			if e.Method+": "+e.Value == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing %q in %v", w, rec.Entries())
+		}
+	}
+
+	code := -1
+	prevExit := exitFunc
+	exitFunc = func(c int) { code = c }
+	t.Cleanup(func() { exitFunc = prevExit })
+	exitForBatch(tally)
+	if code != 1 {
+		t.Fatalf("a failed item must exit 1, got %d", code)
+	}
+	code = -1
+	exitForBatch(batchTally{total: 2, ok: 1, skipped: 1})
+	if code != -1 {
+		t.Fatalf("skips alone must not change the exit code, got %d", code)
+	}
+}

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/msig"
 	jarvisnetworks "github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util"
 	"github.com/tranvictor/jarvis/util/reader"
 )
@@ -467,82 +468,68 @@ type batchResult struct {
 	history       *msigTxHistory
 }
 
-func printBatchSummary(results []batchResult) {
-	appUI.Section("Batch Approve Summary")
-	approved, broadcasted, skipped, failed := 0, 0, 0, 0
-	for i, r := range results {
-		msigLabel := ""
+// classicResultDetail is the one-line detail shown next to a Classic
+// outcome: the reason for skips/failures, the confirm tx hash otherwise.
+func classicResultDetail(r batchResult) string {
+	if r.reason != "" {
+		return r.reason
+	}
+	if r.confirmTxHash != "" {
+		return "confirm tx " + r.confirmTxHash
+	}
+	return ""
+}
+
+// printBatchApproveSummary renders the closing table for a bapprove run:
+// one row per item in plan order (Safe first, then Classic) and the totals.
+// With --degen the Classic confirmation history is listed under the table.
+func printBatchApproveSummary(safeResults []safeBatchResult, classic []batchResult, tally batchTally) {
+	rows := make([][]ui.TableCell, 0, len(safeResults)+len(classic))
+	n := 0
+	for _, r := range safeResults {
+		n++
+		rows = append(rows, []ui.TableCell{
+			ui.TC(fmt.Sprintf("%d", n)), ui.TC("Safe"), ui.TC(r.network), ui.TC(r.safeAddress),
+			resultCell(r.status), ui.TC(safeResultDetail(r)),
+		})
+	}
+	for _, r := range classic {
+		n++
+		target := r.initTxHash
 		if r.msigTxID != "" {
-			msigLabel = fmt.Sprintf(" (msig #%s)", r.msigTxID)
+			target = "msig #" + r.msigTxID
 		}
+		rows = append(rows, []ui.TableCell{
+			ui.TC(fmt.Sprintf("%d", n)), ui.TC("Classic"), ui.TC(r.network), ui.TC(target),
+			resultCell(r.status), ui.TC(classicResultDetail(r)),
+		})
+	}
+	printBatchSummaryTable(rows, tally)
 
-		switch r.status {
-		case "approved":
-			approved++
-			appUI.Success("  %d. [%s]%s — approved", i+1, r.network, msigLabel)
-		case "broadcasted":
-			broadcasted++
-			appUI.Success("  %d. [%s]%s — broadcasted (not waiting for mining)", i+1, r.network, msigLabel)
-		case "skipped":
-			skipped++
-			appUI.Warn("  %d. [%s]%s — skipped: %s", i+1, r.network, msigLabel, r.reason)
-		case "failed":
-			failed++
-			appUI.Error("  %d. [%s]%s — failed: %s", i+1, r.network, msigLabel, r.reason)
+	if !config.DegenMode {
+		return
+	}
+	for i, r := range classic {
+		if r.history == nil || len(r.history.confirmations) == 0 {
+			continue
 		}
-
-		if r.history != nil && len(r.history.confirmations) > 0 {
-			for j, c := range r.history.confirmations {
-				tag := "confirm"
-				if j == 0 {
-					tag = "init   "
-				}
-				senderName := c.sender
-				if r.networkObj != nil {
-					addr := util.GetJarvisAddress(c.sender, r.networkObj)
-					senderName = appUI.Style(util.StyledAddress(addr))
-				}
-				appUI.Info("       %s tx: %s (by %s)", tag, c.txHash, senderName)
+		appUI.Info("")
+		appUI.Info("%d. %s msig #%s confirmations:", len(safeResults)+i+1, r.network, r.msigTxID)
+		for j, c := range r.history.confirmations {
+			tag := "confirm"
+			if j == 0 {
+				tag = "init   "
 			}
-			if r.confirmTxHash != "" {
-				found := false
-				for _, c := range r.history.confirmations {
-					if strings.EqualFold(c.txHash, r.confirmTxHash) {
-						found = true
-						break
-					}
-				}
-				if !found {
-					appUI.Info("       confirm tx: %s (pending)", r.confirmTxHash)
-				}
+			senderName := c.sender
+			if r.networkObj != nil {
+				senderName = appUI.Style(util.StyledAddress(util.GetJarvisAddress(c.sender, r.networkObj)))
 			}
-			if r.history.executionTxHash != "" {
-				appUI.Info("       exec    tx: %s", r.history.executionTxHash)
-			}
-		} else {
-			if r.initTxHash != "" {
-				appUI.Info("       init tx: %s", r.initTxHash)
-			}
-			if r.confirmTxHash != "" {
-				appUI.Info("       approve tx: %s", r.confirmTxHash)
-			}
+			appUI.Info("   %s tx: %s (by %s)", tag, c.txHash, senderName)
+		}
+		if r.history.executionTxHash != "" {
+			appUI.Info("   exec    tx: %s", r.history.executionTxHash)
 		}
 	}
-	appUI.Info("")
-	parts := []string{}
-	if approved > 0 {
-		parts = append(parts, fmt.Sprintf("%d approved", approved))
-	}
-	if broadcasted > 0 {
-		parts = append(parts, fmt.Sprintf("%d broadcasted", broadcasted))
-	}
-	if skipped > 0 {
-		parts = append(parts, fmt.Sprintf("%d skipped", skipped))
-	}
-	if failed > 0 {
-		parts = append(parts, fmt.Sprintf("%d failed", failed))
-	}
-	appUI.Info("Total: %d transactions (%s)", len(results), strings.Join(parts, ", "))
 }
 
 type jsonConfirmation struct {
@@ -719,248 +706,254 @@ Safe+Classic runs write both arrays into one file.`,
 		for _, sr := range safeRefs {
 			residual = strings.ReplaceAll(residual, sr.original, " ")
 		}
+		networkNames, txs := cmdutil.ScanForTxs(residual)
+		if len(networkNames) == 0 || len(txs) == 0 {
+			networkNames, txs = nil, nil
+		}
+		if len(safeRefs) == 0 && len(txs) == 0 {
+			appUI.Error("No txs passed to the first param. Did nothing.")
+			return
+		}
+
+		plan := make([]string, 0, len(safeRefs)+len(txs))
+		for _, ref := range safeRefs {
+			plan = append(plan, "Safe     "+ref.original)
+		}
+		for i, n := range networkNames {
+			plan = append(plan, fmt.Sprintf("Classic  %s:%s", n, txs[i]))
+		}
+		printBatchPlan("Batch approve", plan)
+
+		tally := batchTally{total: len(plan)}
+		item := 0
+		aborted := false
 
 		// Process the Safe portion of the input first so any auto-execute
 		// flow runs before we start touching Classic broadcasters that may
 		// share a wallet.
 		var safeResults []safeBatchResult
-		if len(safeRefs) > 0 {
-			total := len(safeRefs)
-			safeResults = make([]safeBatchResult, 0, total)
-			appUI.Section(fmt.Sprintf("Batch Approve (Safe): %d transactions", total))
-			for i, ref := range safeRefs {
-				r := safeBatchResult{ref: ref.original}
-				appUI.Info("")
-				appUI.Critical("━━━ Safe [%d/%d] %s ━━━", i+1, total, ref.original)
-				res := approveSafeRef(ref)
-				r.network = res.network
-				r.networkObj = res.networkObj
-				r.safeAddress = res.safeAddress
-				r.safeTxHash = res.safeTxHash
-				r.confirmType = res.confirmType
-				r.execTxHash = res.execTxHash
-				r.status = res.status
-				r.reason = res.reason
+		for _, ref := range safeRefs {
+			item++
+			r := safeBatchResult{ref: ref.original}
+			if aborted {
+				r.status, r.reason = "skipped", "aborted by user"
 				safeResults = append(safeResults, r)
+				tally.add(r.status)
+				continue
 			}
-			printSafeBatchSummary(safeResults)
+			printBatchBanner(item, tally.total, "Safe", ref.original)
+			var res approveSafeRefResult
+			withIndentedUI(func() { res = approveSafeRef(ref) })
+			r.network = res.network
+			r.networkObj = res.networkObj
+			r.safeAddress = res.safeAddress
+			r.safeTxHash = res.safeTxHash
+			r.confirmType = res.confirmType
+			r.execTxHash = res.execTxHash
+			r.status = res.status
+			r.reason = res.reason
+			safeResults = append(safeResults, r)
+			tally.add(r.status)
+			printBatchItemResult(r.status, safeResultDetail(r), tally)
+			if r.status == "failed" && !continueBatchAfterFailure(tally.total-tally.done()) {
+				aborted = true
+			}
 		}
 
-		networkNames, txs := cmdutil.ScanForTxs(residual)
-		if len(networkNames) == 0 || len(txs) == 0 {
-			if len(safeRefs) == 0 {
-				appUI.Error("No txs passed to the first param. Did nothing.")
-			} else {
-				writeBatchApproveJSONIfRequested(safeResults, nil)
-			}
-			return
-		}
-
-		cm := walletarmy.NewWalletManager()
-		a := util.GetGnosisMsigABI()
-
-		total := len(networkNames)
-		results := make([]batchResult, 0, total)
-
-		appUI.Section(fmt.Sprintf("Batch Approve (Classic): %d transactions", total))
-
-		for i, n := range networkNames {
-			txHash := txs[i]
-			r := batchResult{network: n, initTxHash: txHash}
-
-			appUI.Info("")
-			appUI.Critical("━━━ Classic [%d/%d] %s: %s ━━━", i+1, total, n, txHash)
-
-			network, err := jarvisnetworks.GetNetwork(n)
-			if err != nil {
-				appUI.Error("%s network is not supported. Skip.", n)
-				r.status = "skipped"
-				r.reason = "unsupported network"
-				results = append(results, r)
-				continue
-			}
-			r.networkObj = network
-			txinfo, err := cm.Reader(network).TxInfoFromHash(txHash)
-			if err != nil {
-				appUI.Error("Couldn't get tx info from hash: %s. Skip.", err)
-				r.status = "failed"
-				r.reason = fmt.Sprintf("tx info: %s", err)
-				results = append(results, r)
-				continue
-			}
-			if txinfo.Receipt == nil {
-				appUI.Warn("This tx is still pending. Skip.")
-				r.status = "skipped"
-				r.reason = "tx still pending"
-				results = append(results, r)
-				continue
-			}
-			msigHex := txinfo.Tx.To().Hex()
-			txid := util.GnosisMsigTxIDFromLogs(txinfo.Receipt.Logs, msigHex)
-			if txid == nil && txinfo.Tx != nil {
-				txid = util.GnosisMsigTxIDFromCalldata(txinfo.Tx.Data())
-			}
-			if txid == nil {
-				appUI.Warn("This tx is not a Classic Gnosis submit/confirm/revoke/execute tx. Skip.")
-				r.status = "skipped"
-				r.reason = "not a gnosis classic msig tx"
-				results = append(results, r)
-				continue
-			}
-
-			r.msigTxID = txid.String()
-			initBlock := txinfo.Receipt.BlockNumber.Int64()
-
-			multisigContract, err := msig.NewMultisigContract(msigHex, network)
-			if err != nil {
-				appUI.Error("Couldn't interact with the contract: %s. Skip.", err)
-				r.status = "failed"
-				r.reason = fmt.Sprintf("contract: %s", err)
-				results = append(results, r)
-				continue
-			}
-
-			from, err := GetApproverAccountFromMsig(multisigContract)
-			if err != nil {
-				appUI.Error("Couldn't read and get wallet to approve this msig. You might not have any approver wallets.")
-				r.status = "failed"
-				r.reason = "no approver wallet"
-				results = append(results, r)
-				continue
-			}
-
-			_, numConf, confirmed, executed := cmdutil.AnalyzeAndShowMsigTxInfo(appUI, multisigContract, txid, network, cmdutil.DefaultABIResolver{}, cm.Analyzer(network))
-			if executed {
-				appUI.Warn("Already executed. Skip.")
-				r.history = queryMsigTxHistory(cm.Reader(network), a, msigHex, txid, initBlock, network, true, numConf)
-				r.status = "skipped"
-				r.reason = "already executed"
-				results = append(results, r)
-				continue
-			}
-			if confirmed {
-				appUI.Warn("Already confirmed but not executed. Consider executing instead. Skip.")
-				r.history = queryMsigTxHistory(cm.Reader(network), a, msigHex, txid, initBlock, network, false, numConf)
-				r.status = "skipped"
-				r.reason = "already confirmed"
-				results = append(results, r)
-				continue
-			}
-
-			data, err := a.Pack("confirmTransaction", txid)
-			if err != nil {
-				appUI.Error("Couldn't pack data: %s. Skip.", err)
-				r.status = "failed"
-				r.reason = fmt.Sprintf("pack data: %s", err)
-				results = append(results, r)
-				continue
-			}
-
-			customABIs := map[string]*abi.ABI{
-				strings.ToLower(msigHex): a,
-			}
-
-			txType, err := cmdutil.ValidTxType(cm.Reader(network), network)
-			if err != nil {
-				appUI.Error("Couldn't determine proper tx type: %s. Aborting.", err)
-				r.status = "failed"
-				r.reason = fmt.Sprintf("tx type: %s", err)
-				results = append(results, r)
-				printBatchSummary(results)
-				writeBatchApproveJSONIfRequested(safeResults, results)
-				return
-			}
-
-			if txType == types.LegacyTxType && config.TipGas > 0 {
-				appUI.Warn("Legacy tx — ignoring tip gas parameter.")
-			}
-
-			var confirmHash string
-			minedTx, err := cm.EnsureTxWithHooks(
-				10,
-				5*time.Second,
-				5*time.Second,
-				txType,
-				jarviscommon.HexToAddress(from), jarviscommon.HexToAddress(msigHex),
-				nil,
-				0,
-				2000000,
-				0,
-				0,
-				0,
-				0,
-				data,
-				network,
-				func(tx *types.Transaction, buildError error) error {
-					if buildError != nil {
-						appUI.Error("Couldn't build tx: %s", buildError)
-						return buildError
-					}
-					err = cmdutil.PromptTxConfirmation(
-						appUI,
-						cm.Analyzer(network),
-						util.GetJarvisAddress(from, network),
-						tx,
-						customABIs,
-						network,
-					)
-					if err != nil {
-						appUI.Warn("User skipped. Continue with next tx.")
-						return fmt.Errorf("%w: %w", ErrUserAborted, err)
-					}
-					return nil
-				},
-				func(broadcastedTx *types.Transaction, signError error) error {
-					if signError != nil {
-						return signError
-					}
-					if broadcastedTx != nil {
-						confirmHash = broadcastedTx.Hash().Hex()
-						util.DisplayBroadcastedTx(appUI, broadcastedTx, true, signError, network)
-					}
-					if config.DontWaitToBeMined {
-						return fmt.Errorf("%w: %w", ErrNotWaitingForMining, signError)
-					}
-					return nil
-				},
-				nil,
-				nil,
-			)
-
-			r.confirmTxHash = confirmHash
-			if err != nil {
-				if errors.Is(err, ErrUserAborted) {
-					r.status = "skipped"
-					r.reason = "user aborted"
-				} else if errors.Is(err, ErrNotWaitingForMining) {
-					r.status = "broadcasted"
-					r.history = queryMsigTxHistory(cm.Reader(network), a, msigHex, txid, initBlock, network, false, numConf)
-				} else {
-					appUI.Error("Failed to broadcast the tx after retries: %s.", err)
-					r.status = "failed"
-					r.reason = fmt.Sprintf("broadcast: %s", err)
+		var results []batchResult
+		if len(txs) > 0 {
+			cm := walletarmy.NewWalletManager()
+			a := util.GetGnosisMsigABI()
+			results = make([]batchResult, 0, len(txs))
+			for i, n := range networkNames {
+				item++
+				r := batchResult{network: n, initTxHash: txs[i]}
+				if aborted {
+					r.status, r.reason = "skipped", "aborted by user"
+					results = append(results, r)
+					tally.add(r.status)
+					continue
 				}
+				printBatchBanner(item, tally.total, "Classic", n+":"+txs[i])
+				withIndentedUI(func() { approveClassicRef(cm, a, &r) })
 				results = append(results, r)
-				continue
+				tally.add(r.status)
+				printBatchItemResult(r.status, classicResultDetail(r), tally)
+				if r.status == "failed" && !continueBatchAfterFailure(tally.total-tally.done()) {
+					aborted = true
+				}
 			}
-
-			r.confirmTxHash = minedTx.Hash().Hex()
-			if !config.DontWaitToBeMined {
-				util.AnalyzeAndPrint(
-					appUI,
-					cm.Reader(network), cm.Analyzer(network),
-					minedTx.Hash().Hex(), network, false, "", a, nil, util.PostSignLayout(config.DegenMode),
-				)
-			}
-
-			r.history = queryMsigTxHistory(cm.Reader(network), a, msigHex, txid, initBlock, network, true, numConf+1)
-			r.status = "approved"
-			results = append(results, r)
 		}
 
-		printBatchSummary(results)
+		printBatchApproveSummary(safeResults, results, tally)
 		writeBatchApproveJSONIfRequested(safeResults, results)
+		exitForBatch(tally)
 	},
+}
+
+// approveClassicRef runs the approve flow for one Gnosis Classic init tx and
+// fills r with the outcome. It never returns early without setting r.status.
+func approveClassicRef(cm *walletarmy.WalletManager, a *abi.ABI, r *batchResult) {
+	network, err := jarvisnetworks.GetNetwork(r.network)
+	if err != nil {
+		appUI.Error("%s network is not supported. Skip.", r.network)
+		r.status, r.reason = "skipped", "unsupported network"
+		return
+	}
+	r.networkObj = network
+	txHash := r.initTxHash
+	txinfo, err := cm.Reader(network).TxInfoFromHash(txHash)
+	if err != nil {
+		appUI.Error("Couldn't get tx info from hash: %s. Skip.", err)
+		r.status, r.reason = "failed", fmt.Sprintf("tx info: %s", err)
+		return
+	}
+	if txinfo.Receipt == nil {
+		appUI.Warn("This tx is still pending. Skip.")
+		r.status, r.reason = "skipped", "tx still pending"
+		return
+	}
+	msigHex := txinfo.Tx.To().Hex()
+	txid := util.GnosisMsigTxIDFromLogs(txinfo.Receipt.Logs, msigHex)
+	if txid == nil && txinfo.Tx != nil {
+		txid = util.GnosisMsigTxIDFromCalldata(txinfo.Tx.Data())
+	}
+	if txid == nil {
+		appUI.Warn("This tx is not a Classic Gnosis submit/confirm/revoke/execute tx. Skip.")
+		r.status, r.reason = "skipped", "not a gnosis classic msig tx"
+		return
+	}
+
+	r.msigTxID = txid.String()
+	initBlock := txinfo.Receipt.BlockNumber.Int64()
+
+	multisigContract, err := msig.NewMultisigContract(msigHex, network)
+	if err != nil {
+		appUI.Error("Couldn't interact with the contract: %s. Skip.", err)
+		r.status, r.reason = "failed", fmt.Sprintf("contract: %s", err)
+		return
+	}
+
+	from, err := GetApproverAccountFromMsig(multisigContract)
+	if err != nil {
+		appUI.Error("Couldn't read and get wallet to approve this msig. You might not have any approver wallets.")
+		r.status, r.reason = "failed", "no approver wallet"
+		return
+	}
+
+	_, numConf, confirmed, executed := cmdutil.AnalyzeAndShowMsigTxInfo(appUI, multisigContract, txid, network, cmdutil.DefaultABIResolver{}, cm.Analyzer(network))
+	if executed {
+		appUI.Warn("Already executed. Skip.")
+		r.history = queryMsigTxHistory(cm.Reader(network), a, msigHex, txid, initBlock, network, true, numConf)
+		r.status, r.reason = "skipped", "already executed"
+		return
+	}
+	if confirmed {
+		appUI.Warn("Already confirmed but not executed. Consider executing instead. Skip.")
+		r.history = queryMsigTxHistory(cm.Reader(network), a, msigHex, txid, initBlock, network, false, numConf)
+		r.status, r.reason = "skipped", "already confirmed"
+		return
+	}
+
+	data, err := a.Pack("confirmTransaction", txid)
+	if err != nil {
+		appUI.Error("Couldn't pack data: %s. Skip.", err)
+		r.status, r.reason = "failed", fmt.Sprintf("pack data: %s", err)
+		return
+	}
+
+	customABIs := map[string]*abi.ABI{
+		strings.ToLower(msigHex): a,
+	}
+
+	txType, err := cmdutil.ValidTxType(cm.Reader(network), network)
+	if err != nil {
+		appUI.Error("Couldn't determine proper tx type: %s.", err)
+		r.status, r.reason = "failed", fmt.Sprintf("tx type: %s", err)
+		return
+	}
+
+	if txType == types.LegacyTxType && config.TipGas > 0 {
+		appUI.Warn("Legacy tx — ignoring tip gas parameter.")
+	}
+
+	var confirmHash string
+	minedTx, err := cm.EnsureTxWithHooks(
+		10,
+		5*time.Second,
+		5*time.Second,
+		txType,
+		jarviscommon.HexToAddress(from), jarviscommon.HexToAddress(msigHex),
+		nil,
+		0,
+		2000000,
+		0,
+		0,
+		0,
+		0,
+		data,
+		network,
+		func(tx *types.Transaction, buildError error) error {
+			if buildError != nil {
+				appUI.Error("Couldn't build tx: %s", buildError)
+				return buildError
+			}
+			err = cmdutil.PromptTxConfirmation(
+				appUI,
+				cm.Analyzer(network),
+				util.GetJarvisAddress(from, network),
+				tx,
+				customABIs,
+				network,
+			)
+			if err != nil {
+				return fmt.Errorf("%w: %w", ErrUserAborted, err)
+			}
+			return nil
+		},
+		func(broadcastedTx *types.Transaction, signError error) error {
+			if signError != nil {
+				return signError
+			}
+			if broadcastedTx != nil {
+				confirmHash = broadcastedTx.Hash().Hex()
+				util.DisplayBroadcastedTx(appUI, broadcastedTx, true, signError, network)
+			}
+			if config.DontWaitToBeMined {
+				return fmt.Errorf("%w: %w", ErrNotWaitingForMining, signError)
+			}
+			return nil
+		},
+		nil,
+		nil,
+	)
+
+	r.confirmTxHash = confirmHash
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrUserAborted):
+			r.status, r.reason = "skipped", "user aborted"
+		case errors.Is(err, ErrNotWaitingForMining):
+			r.status = "broadcasted"
+			r.history = queryMsigTxHistory(cm.Reader(network), a, msigHex, txid, initBlock, network, false, numConf)
+		default:
+			appUI.Error("Failed to broadcast the tx after retries: %s.", err)
+			r.status, r.reason = "failed", fmt.Sprintf("broadcast: %s", err)
+		}
+		return
+	}
+
+	r.confirmTxHash = minedTx.Hash().Hex()
+	if !config.DontWaitToBeMined {
+		util.AnalyzeAndPrint(
+			appUI,
+			cm.Reader(network), cm.Analyzer(network),
+			minedTx.Hash().Hex(), network, false, "", a, nil, util.PostSignLayout(config.DegenMode),
+		)
+	}
+
+	r.history = queryMsigTxHistory(cm.Reader(network), a, msigHex, txid, initBlock, network, true, numConf+1)
+	r.status = "approved"
 }
 
 var newMsigCmd = &cobra.Command{

--- a/cmd/safe_batch.go
+++ b/cmd/safe_batch.go
@@ -356,52 +356,19 @@ func buildTxContextForBatch(
 	return tc, nil
 }
 
-// printSafeBatchSummary renders a per-ref outcome list followed by a
-// totals line, mirroring printBatchSummary for classic msig.
-func printSafeBatchSummary(results []safeBatchResult) {
-	appUI.Section("Batch Approve Summary")
-	approved, executed, skipped, failed := 0, 0, 0, 0
-	for i, r := range results {
-		safeLabel := ""
-		if r.safeAddress != "" {
-			safeLabel = fmt.Sprintf(" safe %s", r.safeAddress)
-		}
-		switch r.status {
-		case "approved":
-			approved++
-			appUI.Success("  %d. [%s]%s — approved", i+1, r.network, safeLabel)
-		case "executed":
-			executed++
-			appUI.Success("  %d. [%s]%s — approved + executed", i+1, r.network, safeLabel)
-		case "skipped":
-			skipped++
-			appUI.Warn("  %d. [%s]%s — skipped: %s", i+1, r.network, safeLabel, r.reason)
-		case "failed":
-			failed++
-			appUI.Error("  %d. [%s]%s — failed: %s", i+1, r.network, safeLabel, r.reason)
-		}
-		if r.safeTxHash != "" {
-			appUI.Info("       safeTxHash %s", r.safeTxHash)
-		}
-		if r.execTxHash != "" {
-			appUI.Info("       exec tx    %s", r.execTxHash)
-		}
+// safeResultDetail is the one-line detail shown next to a Safe outcome: the
+// reason for skips/failures, the exec tx hash when it executed, otherwise the
+// safeTxHash that was approved.
+func safeResultDetail(r safeBatchResult) string {
+	switch {
+	case r.reason != "":
+		return r.reason
+	case r.execTxHash != "":
+		return "exec tx " + r.execTxHash
+	case r.safeTxHash != "":
+		return "safeTxHash " + r.safeTxHash
 	}
-	parts := []string{}
-	if approved > 0 {
-		parts = append(parts, fmt.Sprintf("%d approved", approved))
-	}
-	if executed > 0 {
-		parts = append(parts, fmt.Sprintf("%d executed", executed))
-	}
-	if skipped > 0 {
-		parts = append(parts, fmt.Sprintf("%d skipped", skipped))
-	}
-	if failed > 0 {
-		parts = append(parts, fmt.Sprintf("%d failed", failed))
-	}
-	appUI.Info("")
-	appUI.Info("Total: %d transactions (%s)", len(results), strings.Join(parts, ", "))
+	return ""
 }
 
 // jsonSafeBatchResult and jsonSafeBatchSummary mirror the classic-msig


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 5 of `docs/improved-ui-plan.md`. Stacked on #113.

`jarvis msig bapprove` now reads as one run instead of N independent commands:

```
=============== Batch approve: 3 transaction(s) ===============
1. Safe     eth:0xSafe…:0xhash…
2. Safe     bsc:0xSafe…:0xhash…
3. Classic  mainnet:0xinit…

[1/3] Safe  eth:0xSafe…:0xhash…
  ... signing card, prompt, spinner ...
✓ approved  safeTxHash 0x…   (1 ok · 2 left)

[2/3] Safe  bsc:0xSafe…:0xhash…
  ...
✗ failed  unlock wallet: ledger not connected   (1 ok · 1 failed · 1 left)
Continue with the remaining 1 transaction(s)? [Y/n]

[3/3] Classic  mainnet:0xinit…
  ...
✓ approved  confirm tx 0x…   (2 ok · 1 failed)

===================== Batch summary =====================
┌───┬─────────┬─────────┬──────────┬──────────┬───────────────────────┐
│ # │ Kind    │ Network │ Target   │ Result   │ Detail                │
├───┼─────────┼─────────┼──────────┼──────────┼───────────────────────┤
│ 1 │ Safe    │ mainnet │ 0xSafe…  │ approved │ safeTxHash 0x…        │
│ 2 │ Safe    │ bsc     │ 0xSafe…  │ failed   │ unlock wallet: …      │
│ 3 │ Classic │ mainnet │ msig #7  │ approved │ confirm tx 0x…        │
└───┴─────────┴─────────┴──────────┴──────────┴───────────────────────┘

3 transaction(s): 2 ok · 1 failed
```

### Changes

- `cmd/batch_ui.go`: `batchTally`, `printBatchPlan`, `printBatchBanner`, `printBatchItemResult`, `continueBatchAfterFailure`, `printBatchSummaryTable`, `withIndentedUI`, `exitForBatch` (via swappable `exitFunc`).
- The plan lists every item (Safe first, then Classic) before the first prompt, so the user knows how many confirmations are coming.
- Each item runs under an indented UI and closes with a colour-coded one-liner plus the running tally. After a `failed` item the user is asked whether to continue; declining records the remaining items as `skipped: aborted by user`. `--yes` never stops.
- One summary table covers Safe and Classic items in plan order, followed by a totals line. The Classic confirmation history (init/confirm/exec tx hashes by sender) is still available under `--degen`.
- Exit status is 1 when any item failed; skips alone keep 0.
- The Classic per-item flow is extracted into `approveClassicRef(cm, a, *batchResult)`; a tx-type lookup failure now fails that item instead of aborting the whole batch. JSON output (`--json-output`) is unchanged.

## Tests

`cmd/batch_ui_test.go`: tally formatting, plan/banner/result transcript, continue-after-failure behaviour under `--yes` / `n` / nothing left, summary table rows and exit code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

