### PR TITLE
UI phase 6: cleanup, bapprove --continue-on-error / --confirm-once, README and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+## Unreleased — terminal output redesign
+
+Everything jarvis prints was reworked so that the information you act on
+comes first and reads the same way across `info`, signing and batch flows.
+No RPC, signing or storage behaviour changed. `--json-output` files are
+byte-for-byte compatible apart from the new `transfers`, `block_number` and
+per-log `address` fields.
+
+### `jarvis info <hash>`
+
+- Headline line: status glyph, method, destination; a muted second line
+  carries from / value / gas / nonce / block.
+- New **Transfers** section derived from `Transfer` and `Approval` logs, with
+  `UNLIMITED` marking max-uint approvals.
+- Function call shown as an indented tree; arrays longer than a few items and
+  long `bytes` values collapse. Events are one line each.
+- `--degen` expands collapsed values, shows full addresses and switches the
+  parameter list back to a bordered table.
+- Addresses are name-first (`me (0x9642…5D4E)`); only an *unknown call
+  target* is highlighted in yellow. Each tx ends with a one-line footer
+  (status, method, hash) so the outcome is visible even after a long event
+  list.
+
+### Interactive parameter entry
+
+- The "You entered" table after each parameter is replaced by one `→` line
+  (rewritten in place on a TTY); complex values expand as a small tree.
+- The method header now reads `method → contract`.
+
+### Signing screen
+
+- One signing card for EOA transactions, Safe proposals/approvals/executions
+  and WalletConnect requests: decoded call first, then Sign with / Send to /
+  Gas / nonce directly above the prompt.
+- Derived warnings printed as `!` lines right before the prompt: destination
+  not in the address book, native value into a contract, undecodable
+  calldata, unlimited ERC-20 approval, `setApprovalForAll`, approval to an
+  unknown spender, Safe `DELEGATECALL`.
+- Safe cards list the Safe, operation, nonce, `safeTxHash` and collected
+  signatures; the EOA card for a Safe execution collapses the inner call
+  since it was just shown.
+- Prompts say what will happen and what it costs, e.g.
+  `Sign and broadcast (≈ 0.0017 ETH)?` /
+  `Sign and submit this Safe proposal (off-chain, no gas)?`.
+
+### Waiting and results
+
+- Broadcasting prints `✓ broadcast` followed by a live status line
+  (not in mempool → in mempool → mined / reverted / dropped) with elapsed
+  time; off-TTY each state is printed once.
+- After mining, the post-sign view shows the headline, Transfers and Events
+  (gas used / limit in the details line) instead of the full `info` dump.
+- Waiting for a Ledger uses the same status line with a countdown.
+
+### Batch approvals (`jarvis msig bapprove`)
+
+- Plan printed before the first prompt; each item runs under a `[i/n]`
+  banner with everything indented; one-line result with a running tally.
+- After a failed item jarvis asks whether to continue; declining records the
+  rest as skipped.
+- Unified summary table for Safe and Classic items, totals line, and exit
+  status 1 when any item failed.
+- New flags:
+  - `--continue-on-error` — never ask after a failure, keep going.
+  - `--confirm-once` — Safe refs only: review every signing card first,
+    confirm once, then sign all of them. Broadcasts (on-chain `approveHash`,
+    threshold auto-execution, Classic confirmations) still confirm per item.
+
+### Internal
+
+- `ui.UI` gained `SeverityMuted`, `Subsection`, `RewriteLastLine`,
+  `KeyValueCells` and a `Progress` handle returned by `Spinner`;
+  `TableWithGroups` was removed (use `PrintTable` with `Table.Groups`).
+- `Subsection` no longer stacks a second blank line on top of one that is
+  already there.
+- Transaction rendering is split into a `TxDisplay` view-model
+  (`util/display_model.go`) and layout-driven renderers
+  (`util/display_tx.go`, `LayoutInfo` / `LayoutInfoFull` / `LayoutPostSign`).

--- a/README.md
+++ b/README.md
@@ -132,6 +132,138 @@ See help with
 ~/go/bin/jarvis -h
 ```
 
+## Reading the output
+
+Jarvis prints the things you have to decide on first and the things you
+might want to look up later further down. Colour is used sparingly: green
+for a confirmed outcome, red for a failure, yellow only for something you
+should read before signing. Addresses show their address-book name first
+and a shortened hex (`0x9642…5D4E`); the full hex is always shown on
+signing screens and with `--degen`. `--json-output` is unaffected by any of
+this and always carries full, untruncated values.
+
+### `jarvis info <hash>`
+
+```
+✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)
+         from me (0x9642…5D4E)   value 0 ETH   gas 0.00213000 ETH   nonce 412   block 19234567
+
+Transfers
+  1000 USDC     me (0x9642…5D4E)  →  USDC/WETH pair (0x0d4a…1852)
+  0.3121 WETH   USDC/WETH pair (0x0d4a…1852)  →  me (0x9642…5D4E)
+
+Call  swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)
+  amountIn      1000000000 (1‸000￺000￺000)  uint256
+  amountOutMin  311200000000000000 (311￺200￺000‸000￺000￺000)  uint256
+  path          [2 items]  address[]
+  ├─ USDC (0xA0b8…eB48)
+  └─ WETH (0xC02a…6Cc2)
+  to            me (0x9642…5D4E)  address
+  deadline      1725600000 (1‸725￺600￺000)  uint256
+
+Events (3)
+  1. Transfer  USDC token (0xA0b8…eB48)   from me (0x9642…5D4E)  to USDC/WETH pair (0x0d4a…1852)  value 1000000000 (1000 USDC)
+  2. Sync      USDC/WETH pair (0x0d4a…1852)   reserve0 5000000000000 (…)  reserve1 1500000000000000000000 (…)
+  3. Transfer  WETH token (0xC02a…6Cc2)   from USDC/WETH pair (0x0d4a…1852)  to me (0x9642…5D4E)  value 312100000000000000 (0.3121 WETH)
+
+✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)   0x3f9a…e1c2
+```
+
+- The headline is status + what was called + where. The muted second line
+  holds the numbers you rarely need (gas, nonce, block).
+- **Transfers** is derived from the `Transfer` / `Approval` logs so asset
+  movement is visible without reading the events. Unlimited approvals are
+  marked `UNLIMITED`.
+- Arrays longer than a few items and long `bytes` blobs are collapsed;
+  `--degen` expands everything, shows full addresses and switches the
+  parameter list to a table.
+- A reverted tx opens with `✗ reverted`; the revert reason, when known, is
+  the next line.
+
+### Signing screen
+
+Every `send`, `tx`, `msig init/approve/execute` and WalletConnect request
+ends in the same card. The decoded call comes first, the who/where/cost
+block sits directly above the prompt, and anything jarvis thinks you
+should double-check is listed as a `!` line right before you answer:
+
+```
+================ EOA transaction =================
+
+Call  approve  →  0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (USDC)
+  spender  0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D  address
+  amount   uint256.max (∞)  uint256
+
+Sign with  0x9642b23Ed1E01Df1092B92641051881a322F5D4E (me)   mainnet
+Send to    0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (USDC)
+Gas        max 20.0000 gwei, tip 1.5000 gwei · 85123 gas · ≈ 0.00170246 ETH   nonce 42
+
+! approves UNLIMITED USDC to 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D
+! spender 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D is not in your address book
+
+Sign and broadcast (≈ 0.00170246 ETH)? [y/N]
+>
+```
+
+Warnings are emitted for: a destination that is not in your address book,
+native value sent into a contract, calldata jarvis could not decode,
+unlimited ERC-20 approvals, `setApprovalForAll`, approvals to unknown
+spenders, and Safe `DELEGATECALL` operations. Safe cards add the Safe
+address, operation, nonce, `safeTxHash` and the list of collected
+signatures. `-Y` / `--yes` skips the prompt but still prints the card.
+
+After signing, a live status line replaces the silent wait
+(`⠋ in mempool, waiting to be mined…  0:12`), and once mined jarvis prints
+the same headline + Transfers + Events view as `info` so you can see what
+actually happened. The same status line is used while jarvis waits for a
+Ledger to be plugged in and unlocked.
+
+### Batch runs
+
+`jarvis msig bapprove` shows the plan before asking anything, then works
+through the list with one indented block per item and a one-line result
+that stays in the transcript:
+
+```
+=============== Batch approve: 3 transaction(s) ===============
+1. Safe     eth:0xSafe…:0xhash…
+2. Safe     bsc:0xSafe…:0xhash…
+3. Classic  mainnet:0xinit…
+
+[1/3] Safe  eth:0xSafe…:0xhash…
+  ... signing card, prompt, spinner ...
+✓ approved  safeTxHash 0x…   (1 ok · 2 left)
+
+[2/3] Safe  bsc:0xSafe…:0xhash…
+  ...
+✗ failed  unlock wallet: ledger not connected   (1 ok · 1 failed · 1 left)
+Continue with the remaining 1 transaction(s)? [Y/n]
+
+[3/3] Classic  mainnet:0xinit…
+  ...
+✓ approved  confirm tx 0x…   (2 ok · 1 failed)
+
+===================== Batch summary =====================
+┌───┬─────────┬─────────┬──────────┬──────────┬───────────────────────┐
+│ # │ Kind    │ Network │ Target   │ Result   │ Detail                │
+├───┼─────────┼─────────┼──────────┼──────────┼───────────────────────┤
+│ 1 │ Safe    │ mainnet │ 0xSafe…  │ approved │ safeTxHash 0x…        │
+│ 2 │ Safe    │ bsc     │ 0xSafe…  │ failed   │ unlock wallet: …      │
+│ 3 │ Classic │ mainnet │ msig #7  │ approved │ confirm tx 0x…        │
+└───┴─────────┴─────────┴──────────┴──────────┴───────────────────────┘
+
+3 transaction(s): 2 ok · 1 failed
+```
+
+- `--continue-on-error` skips the `Continue with the remaining…?` question.
+- `--confirm-once` (Safe refs only) reviews every signing card first, asks
+  one `Sign all N reviewed Safe approval(s)?` question and then signs each
+  without further prompts. Anything that broadcasts a transaction — on-chain
+  `approveHash`, auto-execution when the threshold is met, Classic
+  confirmations — still asks per item.
+- The process exits with status 1 when any item failed; skipped items alone
+  keep it at 0.
+
 ## Multisig: Gnosis Classic and Gnosis Safe
 
 Jarvis has first-class support for both Gnosis Classic (on-chain

--- a/cmd/batch_ui.go
+++ b/cmd/batch_ui.go
@@ -16,6 +16,14 @@ import (
 // exitFunc is os.Exit unless a test swaps it out.
 var exitFunc = os.Exit
 
+// batchContinueOnError (--continue-on-error) keeps a batch going after a
+// failed item without asking. batchConfirmOnce (--confirm-once) shows every
+// Safe signing card up front and asks once before signing them all.
+var (
+	batchContinueOnError bool
+	batchConfirmOnce     bool
+)
+
 // batchTally counts outcomes as items complete.
 type batchTally struct {
 	total, ok, skipped, failed int
@@ -90,9 +98,9 @@ func printBatchItemResult(status, detail string, tally batchTally) {
 }
 
 // continueBatchAfterFailure asks whether to keep going once an item failed.
-// --yes never stops; an empty answer continues.
+// --yes and --continue-on-error never stop; an empty answer continues.
 func continueBatchAfterFailure(left int) bool {
-	if config.YesToAllPrompt || left <= 0 {
+	if config.YesToAllPrompt || batchContinueOnError || left <= 0 {
 		return true
 	}
 	return appUI.Confirm(fmt.Sprintf("Continue with the remaining %d transaction(s)?", left), true)

--- a/cmd/batch_ui_test.go
+++ b/cmd/batch_ui_test.go
@@ -89,6 +89,161 @@ func TestContinueBatchAfterFailure(t *testing.T) {
 	if !rec.HasMessage("Continue with the remaining 2 transaction(s)?") {
 		t.Fatalf("prompt missing: %v", rec.Entries())
 	}
+
+	prevCont := batchContinueOnError
+	t.Cleanup(func() { batchContinueOnError = prevCont })
+	batchContinueOnError = true
+	rec = ui.NewRecordingUI()
+	swapAppUI(t, rec)
+	if !continueBatchAfterFailure(2) {
+		t.Fatal("--continue-on-error must never stop the batch")
+	}
+	if len(rec.Entries()) != 0 {
+		t.Fatalf("--continue-on-error must not prompt: %v", rec.Entries())
+	}
+}
+
+// fakeSafeRefs swaps reviewSafeRefFn/signSafeRefFn for stubs: refs whose
+// token contains "bad" fail review, everything else is signed successfully
+// unless its token contains "reject", which fails at signing time.
+func fakeSafeRefs(t *testing.T) *[]string {
+	t.Helper()
+	prevReview, prevSign := reviewSafeRefFn, signSafeRefFn
+	t.Cleanup(func() { reviewSafeRefFn, signSafeRefFn = prevReview, prevSign })
+
+	signed := &[]string{}
+	reviewSafeRefFn = func(in safeRefInput) (*preparedSafeRef, approveSafeRefResult) {
+		res := approveSafeRefResult{network: "mainnet", safeTxHash: "0x" + in.original}
+		if strings.Contains(in.original, "bad") {
+			res.status, res.reason = "failed", "fetch pending tx: 404"
+			appUI.Error("%s", res.reason)
+			return nil, res
+		}
+		appUI.Info("card for %s", in.original)
+		return &preparedSafeRef{in: in, res: res}, res
+	}
+	signSafeRefFn = func(p *preparedSafeRef, preConfirmed bool) approveSafeRefResult {
+		if !preConfirmed {
+			t.Fatalf("confirm-once must pre-confirm %s", p.in.original)
+		}
+		*signed = append(*signed, p.in.original)
+		res := p.res
+		if strings.Contains(p.in.original, "reject") {
+			res.status, res.reason = "failed", "sign safeTxHash: rejected on device"
+			return res
+		}
+		res.status, res.confirmType = "approved", "approve"
+		return res
+	}
+	return signed
+}
+
+func safeRefInputs(tokens ...string) []safeRefInput {
+	out := make([]safeRefInput, len(tokens))
+	for i, tok := range tokens {
+		out[i] = safeRefInput{original: tok}
+	}
+	return out
+}
+
+func TestApproveSafeRefsConfirmOnceReviewsThenSigns(t *testing.T) {
+	prevYes := config.YesToAllPrompt
+	t.Cleanup(func() { config.YesToAllPrompt = prevYes })
+	config.YesToAllPrompt = false
+
+	signed := fakeSafeRefs(t)
+	rec := ui.NewRecordingUI("y", "")
+	swapAppUI(t, rec)
+
+	tally := batchTally{total: 4}
+	results, item, aborted := approveSafeRefsConfirmOnce(safeRefInputs("a", "bad", "reject", "d"), &tally)
+	if item != 4 || aborted {
+		t.Fatalf("item=%d aborted=%v", item, aborted)
+	}
+	if got := strings.Join(*signed, ","); got != "a,reject,d" {
+		t.Fatalf("signed %q", got)
+	}
+	wantStatus := []string{"approved", "failed", "failed", "approved"}
+	for i, r := range results {
+		if r.status != wantStatus[i] {
+			t.Fatalf("result %d = %s, want %s (%+v)", i, r.status, wantStatus[i], r)
+		}
+	}
+	if tally.ok != 2 || tally.failed != 2 || tally.done() != 4 {
+		t.Fatalf("tally %+v", tally)
+	}
+
+	var transcript []string
+	for _, e := range rec.Entries() {
+		transcript = append(transcript, e.Method+": "+e.Value)
+	}
+	joined := strings.Join(transcript, "\n")
+	// Every card is shown before the single confirm, and the failed review
+	// is reported while still in the review pass.
+	confirmAt := strings.Index(joined, "Confirm: Sign all 3 reviewed Safe approval(s)")
+	if confirmAt < 0 {
+		t.Fatalf("single confirm missing:\n%s", joined)
+	}
+	for _, s := range []string{"card for a", "card for reject", "card for d", "fetch pending tx: 404", "✗ failed  fetch pending tx: 404"} {
+		at := strings.Index(joined, s)
+		if at < 0 || at > confirmAt {
+			t.Fatalf("%q should appear before the confirm:\n%s", s, joined)
+		}
+	}
+	if !rec.HasMessage("Continue with the remaining 1 transaction(s)?") {
+		t.Fatalf("failed signing should ask to continue:\n%s", joined)
+	}
+	if strings.Count(joined, "Confirm: Sign approval") != 0 {
+		t.Fatalf("per-item confirms must not appear:\n%s", joined)
+	}
+}
+
+func TestApproveSafeRefsConfirmOnceDeclineSkipsAll(t *testing.T) {
+	prevYes := config.YesToAllPrompt
+	t.Cleanup(func() { config.YesToAllPrompt = prevYes })
+	config.YesToAllPrompt = false
+
+	signed := fakeSafeRefs(t)
+	rec := ui.NewRecordingUI("n")
+	swapAppUI(t, rec)
+
+	tally := batchTally{total: 2}
+	results, _, aborted := approveSafeRefsConfirmOnce(safeRefInputs("a", "b"), &tally)
+	if aborted {
+		t.Fatal("declining is not an abort of later Classic items")
+	}
+	if len(*signed) != 0 {
+		t.Fatalf("nothing should be signed after n: %v", *signed)
+	}
+	for _, r := range results {
+		if r.status != "skipped" || r.reason != "user aborted" {
+			t.Fatalf("unexpected result %+v", r)
+		}
+	}
+	if tally.skipped != 2 {
+		t.Fatalf("tally %+v", tally)
+	}
+}
+
+func TestApproveSafeRefsConfirmOnceYesSkipsPrompt(t *testing.T) {
+	prevYes := config.YesToAllPrompt
+	t.Cleanup(func() { config.YesToAllPrompt = prevYes })
+	config.YesToAllPrompt = true
+
+	signed := fakeSafeRefs(t)
+	rec := ui.NewRecordingUI()
+	swapAppUI(t, rec)
+
+	tally := batchTally{total: 1}
+	approveSafeRefsConfirmOnce(safeRefInputs("a"), &tally)
+	if len(*signed) != 1 {
+		t.Fatalf("signed %v", *signed)
+	}
+	for _, e := range rec.Entries() {
+		if e.Method == "Confirm" {
+			t.Fatalf("--yes must not prompt: %v", e)
+		}
+	}
 }
 
 func TestPrintBatchApproveSummaryAndExitCode(t *testing.T) {

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -732,31 +732,28 @@ Safe+Classic runs write both arrays into one file.`,
 		// flow runs before we start touching Classic broadcasters that may
 		// share a wallet.
 		var safeResults []safeBatchResult
-		for _, ref := range safeRefs {
-			item++
-			r := safeBatchResult{ref: ref.original}
-			if aborted {
-				r.status, r.reason = "skipped", "aborted by user"
+		if batchConfirmOnce {
+			safeResults, item, aborted = approveSafeRefsConfirmOnce(safeRefs, &tally)
+		} else {
+			for _, ref := range safeRefs {
+				item++
+				r := safeBatchResult{ref: ref.original}
+				if aborted {
+					r.status, r.reason = "skipped", "aborted by user"
+					safeResults = append(safeResults, r)
+					tally.add(r.status)
+					continue
+				}
+				printBatchBanner(item, tally.total, "Safe", ref.original)
+				var res approveSafeRefResult
+				withIndentedUI(func() { res = approveSafeRef(ref) })
+				r.fill(res)
 				safeResults = append(safeResults, r)
 				tally.add(r.status)
-				continue
-			}
-			printBatchBanner(item, tally.total, "Safe", ref.original)
-			var res approveSafeRefResult
-			withIndentedUI(func() { res = approveSafeRef(ref) })
-			r.network = res.network
-			r.networkObj = res.networkObj
-			r.safeAddress = res.safeAddress
-			r.safeTxHash = res.safeTxHash
-			r.confirmType = res.confirmType
-			r.execTxHash = res.execTxHash
-			r.status = res.status
-			r.reason = res.reason
-			safeResults = append(safeResults, r)
-			tally.add(r.status)
-			printBatchItemResult(r.status, safeResultDetail(r), tally)
-			if r.status == "failed" && !continueBatchAfterFailure(tally.total-tally.done()) {
-				aborted = true
+				printBatchItemResult(r.status, safeResultDetail(r), tally)
+				if r.status == "failed" && !continueBatchAfterFailure(tally.total-tally.done()) {
+					aborted = true
+				}
 			}
 		}
 
@@ -1312,6 +1309,8 @@ func init() {
 	batchApproveMsigCmd.PersistentFlags().BoolVarP(&config.YesToAllPrompt, "auto-yes", "y", false, "Don't prompt Yes/No before signing.")
 	batchApproveMsigCmd.PersistentFlags().BoolVarP(&config.ForceLegacy, "legacy-tx", "L", false, "Force using legacy transaction")
 	batchApproveMsigCmd.PersistentFlags().StringVarP(&config.JSONOutputFile, "json-output", "o", "", "Write batch summary to a JSON file")
+	batchApproveMsigCmd.Flags().BoolVar(&batchContinueOnError, "continue-on-error", false, "Keep processing the remaining items after one fails instead of asking whether to continue.")
+	batchApproveMsigCmd.Flags().BoolVar(&batchConfirmOnce, "confirm-once", false, "Safe-only: review every Safe signing card first, confirm once, then sign them all. Broadcasts (approveHash, execTransaction) and Classic confirmations still confirm per item.")
 
 	msigCmd.AddCommand(approveMsigCmd)
 	msigCmd.AddCommand(batchApproveMsigCmd)

--- a/cmd/safe_batch.go
+++ b/cmd/safe_batch.go
@@ -17,6 +17,7 @@ import (
 	jarvisnetworks "github.com/tranvictor/jarvis/networks"
 	"github.com/tranvictor/jarvis/safe"
 	"github.com/tranvictor/jarvis/txanalyzer"
+	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util"
 )
 
@@ -31,6 +32,90 @@ type safeBatchResult struct {
 	execTxHash  string
 	status      string // "approved", "executed", "skipped", "failed"
 	reason      string
+}
+
+// fill copies the per-ref outcome into the summary row.
+func (r *safeBatchResult) fill(res approveSafeRefResult) {
+	r.network = res.network
+	r.networkObj = res.networkObj
+	r.safeAddress = res.safeAddress
+	r.safeTxHash = res.safeTxHash
+	r.confirmType = res.confirmType
+	r.execTxHash = res.execTxHash
+	r.status = res.status
+	r.reason = res.reason
+}
+
+// reviewSafeRefFn / signSafeRefFn are swapped out by tests of the
+// --confirm-once orchestration so no network or wallet is needed.
+var (
+	reviewSafeRefFn = reviewSafeRef
+	signSafeRefFn   = signSafeRef
+)
+
+// approveSafeRefsConfirmOnce is the --confirm-once variant of the Safe loop
+// in bapprove: every ref is reviewed (checks + signing card) first, one
+// prompt covers all the off-chain signatures, then each ref is signed under
+// its own banner. Refs that fail review are recorded immediately. Returns
+// the results in input order, the number of items consumed and whether the
+// user aborted the rest of the batch.
+func approveSafeRefsConfirmOnce(refs []safeRefInput, tally *batchTally) ([]safeBatchResult, int, bool) {
+	results := make([]safeBatchResult, len(refs))
+	prepared := make([]*preparedSafeRef, len(refs))
+	item := 0
+	ready := 0
+	for i, ref := range refs {
+		item++
+		results[i] = safeBatchResult{ref: ref.original}
+		printBatchBanner(item, tally.total, "Safe", ref.original)
+		var (
+			p   *preparedSafeRef
+			res approveSafeRefResult
+		)
+		withIndentedUI(func() { p, res = reviewSafeRefFn(ref) })
+		if p == nil {
+			results[i].fill(res)
+			tally.add(res.status)
+			printBatchItemResult(res.status, safeResultDetail(results[i]), *tally)
+			continue
+		}
+		prepared[i] = p
+		ready++
+		appUI.Info("%s", appUI.Style(ui.StyledText{Text: "reviewed, signing deferred", Severity: ui.SeverityMuted}))
+	}
+	if ready == 0 {
+		return results, item, false
+	}
+
+	appUI.Info("")
+	ok := config.YesToAllPrompt ||
+		appUI.Confirm(fmt.Sprintf("Sign all %d reviewed Safe approval(s) (off-chain, no gas)?", ready), true)
+
+	aborted := false
+	for i, p := range prepared {
+		if p == nil {
+			continue
+		}
+		var res approveSafeRefResult
+		switch {
+		case !ok:
+			res = p.res
+			res.status, res.reason = "skipped", "user aborted"
+		case aborted:
+			res = p.res
+			res.status, res.reason = "skipped", "aborted by user"
+		default:
+			printBatchBanner(i+1, tally.total, "Safe", p.in.original)
+			withIndentedUI(func() { res = signSafeRefFn(p, true) })
+		}
+		results[i].fill(res)
+		tally.add(res.status)
+		printBatchItemResult(res.status, safeResultDetail(results[i]), *tally)
+		if res.status == "failed" && !continueBatchAfterFailure(tally.total-tally.done()) {
+			aborted = true
+		}
+	}
+	return results, item, aborted
 }
 
 // safeRefInput pairs the canonical SafeAppRef with the original token
@@ -94,6 +179,20 @@ type approveSafeRefResult struct {
 	reason      string
 }
 
+// preparedSafeRef is a Safe approval that passed every check and has had
+// its signing card shown, but has not been signed yet. --confirm-once
+// collects these so one prompt can cover all of them.
+type preparedSafeRef struct {
+	in           safeRefInput
+	res          approveSafeRefResult
+	network      jarvisnetworks.Network
+	safeContract *safe.SafeContract
+	pending      *safe.PendingTx
+	domainSep    [32]byte
+	fromAcc      jtypes.AccDesc
+	tc           cmdutil.TxContext
+}
+
 // approveSafeRef performs the same logical steps as `jarvis msig approve`
 // for one ref: resolve the network + safe, find a local owner wallet,
 // sign the EIP-712 hash, submit to the Tx Service, and (when this approval
@@ -101,6 +200,17 @@ type approveSafeRefResult struct {
 // runSafeExecute. Errors are returned as `failed`/`skipped` results rather
 // than propagated, so the batch keeps going.
 func approveSafeRef(in safeRefInput) approveSafeRefResult {
+	prep, res := reviewSafeRef(in)
+	if prep == nil {
+		return res
+	}
+	return signSafeRef(prep, false)
+}
+
+// reviewSafeRef runs every read-only step of approveSafeRef and shows the
+// signing card. It returns a non-nil preparedSafeRef when the ref is ready
+// to sign; otherwise the returned result is final (skipped or failed).
+func reviewSafeRef(in safeRefInput) (*preparedSafeRef, approveSafeRefResult) {
 	ref := in.ref
 	res := approveSafeRefResult{
 		safeAddress: ref.SafeAddress.Hex(),
@@ -110,14 +220,14 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		res.status = "skipped"
 		res.reason = fmt.Sprintf("no chain hint in %q (use a URL or <chain>:<safe>:<hash>)", in.original)
 		appUI.Warn("%s", res.reason)
-		return res
+		return nil, res
 	}
 	network, err := jarvisnetworks.GetNetworkByID(ref.ChainID)
 	if err != nil {
 		res.status = "skipped"
 		res.reason = fmt.Sprintf("unsupported chain id %d", ref.ChainID)
 		appUI.Warn("%s", res.reason)
-		return res
+		return nil, res
 	}
 	res.network = network.GetName()
 	res.networkObj = network
@@ -128,14 +238,14 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("init safe reader: %s", err)
 		appUI.Error("%s", res.reason)
-		return res
+		return nil, res
 	}
 	owners, err := safeContract.Owners()
 	if err != nil {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("read safe owners: %s", err)
 		appUI.Error("%s", res.reason)
-		return res
+		return nil, res
 	}
 
 	var fromAcc jtypes.AccDesc
@@ -145,19 +255,19 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 			res.status = "skipped"
 			res.reason = "no local wallet is an owner of this safe"
 			appUI.Warn("%s", res.reason)
-			return res
+			return nil, res
 		}
 		if errors.Is(err, cmdutil.ErrMultipleLocalOwners) {
 			res.status = "skipped"
 			res.reason = "multiple local owner wallets; pass --from to disambiguate"
 			appUI.Warn("%s", res.reason)
-			return res
+			return nil, res
 		}
 		if err != nil {
 			res.status = "failed"
 			res.reason = err.Error()
 			appUI.Error("%s", res.reason)
-			return res
+			return nil, res
 		}
 		fromAcc = acc
 	} else {
@@ -166,13 +276,13 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 			res.status = "failed"
 			res.reason = fmt.Sprintf("--from %q: %s", config.From, err)
 			appUI.Error("%s", res.reason)
-			return res
+			return nil, res
 		}
 		if !cmdutil.IsAmongOwners(owners, acc.Address) {
 			res.status = "skipped"
 			res.reason = fmt.Sprintf("--from %s is not an owner of this safe", acc.Address)
 			appUI.Warn("%s", res.reason)
-			return res
+			return nil, res
 		}
 		fromAcc = acc
 	}
@@ -182,20 +292,20 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("init safe tx service: %s", err)
 		appUI.Error("%s", res.reason)
-		return res
+		return nil, res
 	}
 	pending, err := collector.Get(ref.SafeTxHash)
 	if err != nil {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("fetch pending tx: %s", err)
 		appUI.Error("%s", res.reason)
-		return res
+		return nil, res
 	}
 	if pending.IsExecuted {
 		res.status = "skipped"
 		res.reason = "already executed"
 		appUI.Warn("%s", res.reason)
-		return res
+		return nil, res
 	}
 
 	domainSep, err := safeContract.DomainSeparator()
@@ -203,13 +313,13 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("read domainSeparator: %s", err)
 		appUI.Error("%s", res.reason)
-		return res
+		return nil, res
 	}
 	if _, err := verifyPendingSafeTxHash(pending, domainSep); errors.Is(err, errPendingHashMismatch) {
 		res.status = "failed"
 		res.reason = "service safeTxHash doesn't match locally recomputed hash"
 		appUI.Error("%s", res.reason)
-		return res
+		return nil, res
 	}
 
 	// Merge on-chain approvals so the self-signed check and display
@@ -230,10 +340,10 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 			res.reason = fmt.Sprintf("%s already signed off-chain", me.Hex())
 		}
 		appUI.Warn("%s", res.reason)
-		return res
+		return nil, res
 	}
 
-	// Build a TxContext rich enough for showSafeTxToConfirm and (for the
+	// Build a TxContext rich enough for the signing card and (for the
 	// optional auto-execute step) for runSafeExecute. We deliberately do
 	// the gas/nonce/tx-type lookups here rather than relying on a global
 	// preprocess because this command runs across many networks.
@@ -242,7 +352,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		res.status = "failed"
 		res.reason = err.Error()
 		appUI.Error("%s", res.reason)
-		return res
+		return nil, res
 	}
 
 	threshold, _ := safeContract.Threshold()
@@ -252,6 +362,27 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		threshold: threshold,
 		signer:    fromAcc.Address,
 	}))
+
+	return &preparedSafeRef{
+		in:           in,
+		res:          res,
+		network:      network,
+		safeContract: safeContract,
+		pending:      pending,
+		domainSep:    domainSep,
+		fromAcc:      fromAcc,
+		tc:           tc,
+	}, res
+}
+
+// signSafeRef finishes a reviewed ref: confirm (unless preConfirmed or
+// --yes), sign, submit, and optionally chain into execution. Broadcasts
+// (approveHash, execTransaction) always confirm per item because they cost
+// gas; preConfirmed only covers the off-chain signature.
+func signSafeRef(p *preparedSafeRef, preConfirmed bool) approveSafeRefResult {
+	res := p.res
+	pending := p.pending
+	me := ethcommon.HexToAddress(p.fromAcc.Address)
 
 	if safeApproveOnChain {
 		// On-chain batch approval: broadcast approveHash and let
@@ -265,20 +396,20 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 			res.reason = "user aborted"
 			return res
 		}
-		runSafeApproveOnChain(tc, safeContract, pending, domainSep, me)
+		runSafeApproveOnChain(p.tc, p.safeContract, pending, p.domainSep, me)
 		res.status = "approved"
 		res.confirmType = "approve-onchain"
 		return res
 	}
 
-	if !config.YesToAllPrompt && !appUI.Confirm("Sign approval (off-chain, no gas)?", true) {
+	if !preConfirmed && !config.YesToAllPrompt && !appUI.Confirm("Sign approval (off-chain, no gas)?", true) {
 		res.status = "skipped"
 		res.reason = "user aborted"
 		return res
 	}
 
-	appUI.Info("Unlock %s and sign the EIP-712 safeTxHash now...", fromAcc.Address)
-	sig, err := signPendingSafeTx(fromAcc, pending, domainSep)
+	appUI.Info("Unlock %s and sign the EIP-712 safeTxHash now...", p.fromAcc.Address)
+	sig, err := signPendingSafeTx(p.fromAcc, pending, p.domainSep)
 	if errors.Is(err, errSignSafeHash) {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("sign safeTxHash: %s", signCause(err))
@@ -292,7 +423,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		return res
 	}
 
-	if err := persistApproval(tc, safeContract.Address, pending, me, sig, "", network.GetChainID()); err != nil {
+	if err := persistApproval(p.tc, p.safeContract.Address, pending, me, sig, "", p.network.GetChainID()); err != nil {
 		res.status = "failed"
 		res.reason = fmt.Sprintf("submit confirmation: %s", err)
 		appUI.Error("%s", res.reason)
@@ -302,7 +433,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 	res.confirmType = "approve"
 	appUI.Success("Confirmation submitted.")
 
-	threshold, err = safeContract.Threshold()
+	threshold, err := p.safeContract.Threshold()
 	if err != nil {
 		appUI.Warn("Couldn't read threshold post-approval: %s", err)
 		return res
@@ -317,7 +448,7 @@ func approveSafeRef(in safeRefInput) approveSafeRefResult {
 		return res
 	}
 
-	runSafeExecute(tc, safeContract, pendingWithNewSig(pending, me, sig), domainSep)
+	runSafeExecute(p.tc, p.safeContract, pendingWithNewSig(pending, me, sig), p.domainSep)
 	res.confirmType = "approve+execute"
 	res.status = "executed"
 	return res

--- a/docs/improved-ui-plan.md
+++ b/docs/improved-ui-plan.md
@@ -271,11 +271,14 @@ Tests: existing batch tests extended with transcript assertions for a
 
 ## Phase 6 — Cleanup and docs
 
-- Remove `ui.Table`/`TableWithGroups` if no callers remain; fix the stale
-  `PrintVerboseParamResultToWriter` reference in `ui.UI.Writer` docs.
-- README: replace the output examples with the new layouts (`info`, confirm
-  screen, batch summary).
-- Release notes entry listing the visible changes and the two new flags.
+- Remove `ui.TableWithGroups` (no callers; `ui.Table` stays for `clearsign`);
+  fix the stale `PrintVerboseParamResultToWriter` reference in `ui.UI.Writer`
+  docs.
+- Land the two `bapprove` flags deferred from Phase 5: `--continue-on-error`
+  and `--confirm-once` (review all Safe cards → one confirm → sign each).
+- README: new "Reading the output" section with the `info`, signing card and
+  batch examples.
+- `CHANGELOG.md` entry listing the visible changes and the two new flags.
 
 ---
 

--- a/ui/buffer.go
+++ b/ui/buffer.go
@@ -14,7 +14,7 @@ import (
 // os.Stdout. Useful for capturing colored output into a buffer.
 func NewTerminalUIWithWriter(w io.Writer, colorsEnabled bool) *TerminalUI {
 	return &TerminalUI{
-		out: w,
+		out: &blankTracker{w: w},
 		in:  bufio.NewReader(strings.NewReader("")),
 		au:  aurora.NewAurora(colorsEnabled),
 	}

--- a/ui/recording.go
+++ b/ui/recording.go
@@ -202,25 +202,9 @@ func (r *RecordingUI) Table(headers []string, rows [][]string) {
 	}
 }
 
-// TableWithGroups records each group's rows as pipe-separated "Table" entries
-// with a "---" separator entry between groups, mirroring the visual divider
-// that TerminalUI draws.
-func (r *RecordingUI) TableWithGroups(headers []string, groups [][][]string) {
-	if len(headers) > 0 {
-		r.record("Table", strings.Join(headers, " | "))
-	}
-	for gi, group := range groups {
-		if gi > 0 {
-			r.record("Table", "---")
-		}
-		for _, row := range group {
-			r.record("Table", strings.Join(row, " | "))
-		}
-	}
-}
-
 // PrintTable records the header and each row as pipe-separated "Table" entries,
-// consistent with how Table/TableWithGroups record their data.
+// consistent with how Table records its data. Groups are separated by a
+// "---" entry, mirroring the visual divider that TerminalUI draws.
 func (r *RecordingUI) PrintTable(t *Table) {
 	if len(t.Headers) > 0 {
 		r.record("Table", strings.Join(t.Headers, " | "))

--- a/ui/table.go
+++ b/ui/table.go
@@ -235,8 +235,8 @@ func wrapCell(s string, maxWidth int) []string {
 	return lines
 }
 
-// renderTable is the single table rendering engine used by PrintTable,
-// Table, and TableWithGroups.
+// renderTable is the single table rendering engine used by PrintTable and
+// Table.
 //
 // prefix is prepended to every output line — callers pass u.prefix() so
 // that nested UI indent levels are respected.

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -43,11 +43,42 @@ type TerminalUI struct {
 func NewTerminalUI() *TerminalUI {
 	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
 	return &TerminalUI{
-		out: os.Stdout,
+		out: &blankTracker{w: os.Stdout},
 		in:  bufio.NewReader(os.Stdin),
 		au:  aurora.NewAurora(isTTY),
 		tty: isTTY,
 	}
+}
+
+// blankTracker remembers whether the last bytes written ended with an empty
+// line so headings that want breathing room above them can avoid stacking a
+// second blank line on top of one that is already there.
+type blankTracker struct {
+	w         io.Writer
+	endsNL    bool // last write ended with '\n'
+	lastBlank bool // last write ended with an empty line
+}
+
+func (b *blankTracker) Write(p []byte) (int, error) {
+	if len(p) > 0 {
+		switch {
+		case bytes.HasSuffix(p, []byte("\n\n")):
+			b.lastBlank = true
+		case bytes.Equal(p, []byte("\n")):
+			b.lastBlank = b.endsNL
+		default:
+			b.lastBlank = false
+		}
+		b.endsNL = p[len(p)-1] == '\n'
+	}
+	return b.w.Write(p)
+}
+
+// endsWithBlankLine reports whether the last thing written to u.out was an
+// empty line. Always false for writers that are not tracked.
+func (u *TerminalUI) endsWithBlankLine() bool {
+	bt, ok := u.out.(*blankTracker)
+	return ok && bt.lastBlank
 }
 
 func (u *TerminalUI) child(indentLevel int, out io.Writer, tty bool) *TerminalUI {
@@ -133,7 +164,10 @@ func (u *TerminalUI) Section(title string) {
 
 // Subsection prints a bold heading after a blank line.
 func (u *TerminalUI) Subsection(title string) {
-	fmt.Fprintf(u.out, "\n%s%s\n", u.prefix(), u.au.Bold(title).String())
+	if !u.endsWithBlankLine() {
+		fmt.Fprint(u.out, "\n")
+	}
+	fmt.Fprintf(u.out, "%s%s\n", u.prefix(), u.au.Bold(title).String())
 }
 
 // RewriteLastLine moves the cursor up one line, clears it and writes line
@@ -261,31 +295,17 @@ func (u *TerminalUI) KeyValueCells(rows [][2]TableCell) {
 	}
 }
 
-// Table renders a full bordered table. Delegates to TableWithGroups.
+// Table renders a full bordered table of plain strings as one ungrouped
+// block. Converts the cells to TableCells and delegates to renderTable.
 func (u *TerminalUI) Table(headers []string, rows [][]string) {
-	u.TableWithGroups(headers, [][][]string{rows})
-}
-
-// TableWithGroups renders a bordered table where each group of rows is
-// separated from the next by a horizontal rule.
-// Converts plain strings to TableCells and delegates to renderTable in table.go.
-func (u *TerminalUI) TableWithGroups(headers []string, groups [][][]string) {
-	if len(groups) == 0 {
-		return
-	}
-	t := &Table{
-		Headers: headers,
-		Groups:  make([][][]TableCell, len(groups)),
-	}
-	for gi, group := range groups {
-		t.Groups[gi] = make([][]TableCell, len(group))
-		for ri, row := range group {
-			t.Groups[gi][ri] = make([]TableCell, len(row))
-			for ci, cell := range row {
-				t.Groups[gi][ri][ci] = TC(cell)
-			}
+	group := make([][]TableCell, len(rows))
+	for ri, row := range rows {
+		group[ri] = make([]TableCell, len(row))
+		for ci, cell := range row {
+			group[ri][ci] = TC(cell)
 		}
 	}
+	t := &Table{Headers: headers, Groups: [][][]TableCell{group}}
 	renderTable(u.out, u.prefix(), t, func(cell TableCell) string { return cell.Text })
 }
 

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -52,6 +52,23 @@ func TestSubsectionAndRewriteOffTTY(t *testing.T) {
 	}
 }
 
+func TestSubsectionDoesNotStackBlankLines(t *testing.T) {
+	var buf bytes.Buffer
+	u := NewTerminalUIWithWriter(&buf, false)
+	u.Section("Card")
+	u.Subsection("Call")
+	u.Info("row")
+	u.Info("")
+	u.Subsection("Next")
+	out := buf.String()
+	if strings.Contains(out, "\n\n\n") {
+		t.Fatalf("blank lines stacked:\n%q", out)
+	}
+	if !strings.Contains(out, "\n\nCall\n") || !strings.Contains(out, "row\n\nNext\n") {
+		t.Fatalf("headings should keep one blank line above them:\n%q", out)
+	}
+}
+
 func TestRewriteOnTTYMovesCursorUp(t *testing.T) {
 	var buf bytes.Buffer
 	u := NewTerminalUIWithWriter(&buf, false)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -168,15 +168,11 @@ type UI interface {
 	// (e.g. a decoded parameter list).
 	Table(headers []string, rows [][]string)
 
-	// TableWithGroups renders a bordered table where each group of rows is
-	// visually separated from the next by a horizontal divider line. Use when
-	// rows belong to distinct logical groups (e.g. one group per event log).
-	TableWithGroups(headers []string, groups [][][]string)
-
 	// PrintTable renders a bordered Table to the output, applying colour to
 	// each cell according to its Severity. Rows that share the same first-column
-	// value are visually grouped with a horizontal rule between groups.
-	// Use this instead of Table when cells need per-cell colour (e.g. node status).
+	// value are visually grouped with a horizontal rule between groups; set
+	// Table.Groups for explicit grouping. Use this instead of Table when cells
+	// need per-cell colour (e.g. node status) or grouping.
 	PrintTable(t *Table)
 
 	// Spinner starts a live status line with the given message and returns a
@@ -218,6 +214,6 @@ type UI interface {
 
 	// Writer returns an io.Writer that prepends the current indentation
 	// to every line. Use this when calling functions that take io.Writer
-	// directly (e.g. common.PrintVerboseParamResultToWriter).
+	// directly (e.g. capturing output into a buffer for a bordered box).
 	Writer() io.Writer
 }

--- a/util/display.go
+++ b/util/display.go
@@ -285,9 +285,9 @@ func flattenParamRows(d ParamDisplay, indent string) [][]ui.TableCell {
 	return nil
 }
 
-// printParamList renders a slice of ParamDisplays as a single unified
-// TableWithGroups. Consecutive scalar params share a group; each complex
-// param (tuple / array) gets its own group.
+// printParamList renders a slice of ParamDisplays as a single grouped
+// table. Consecutive scalar params share a group; each complex param
+// (tuple / array) gets its own group.
 func printParamList(u ui.UI, params []ParamDisplay) {
 	var groups [][][]ui.TableCell
 	var scalarGroup [][]ui.TableCell


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 6 (final) of `docs/improved-ui-plan.md`. Stacked on #114.

### Cleanup

- `ui.UI`: removed `TableWithGroups` (no callers; `Table` now builds a single-group `Table` and renders it directly). Fixed the stale `PrintVerboseParamResultToWriter` reference in the `Writer` doc and the `PrintTable` doc now mentions `Table.Groups`.
- `TerminalUI.Subsection` no longer stacks a second blank line when the previous output already ended with one (the signing card had a double gap between the `====` header and `Call`). Implemented with a small `blankTracker` writer wrapped around stdout / the injected writer.

### The two `bapprove` flags the plan promised in Phase 5

- `--continue-on-error`: never asks `Continue with the remaining N?` after a failure.
- `--confirm-once` (Safe refs only): `approveSafeRef` is split into `reviewSafeRef` (all read-only checks + the signing card) and `signSafeRef` (confirm, sign, submit, optional auto-execute). With the flag, every Safe ref is reviewed under its own `[i/n]` banner first, then one `Sign all N reviewed Safe approval(s) (off-chain, no gas)?` prompt, then each ref is signed under its banner with the usual one-line result and tally. Refs that fail review are recorded during the review pass; declining the single prompt records the rest as `skipped: user aborted`. Anything that broadcasts (on-chain `approveHash`, threshold auto-execution, Classic confirmations) still confirms per item.

### Docs

- README: new "Reading the output" section with the `info` layout, the signing card, the post-sign wait and the batch transcript, plus the two flags. Samples were rendered from the real code paths.
- `CHANGELOG.md` (new): Unreleased entry for the whole redesign, grouped by `info` / parameter entry / signing screen / waiting / batch / internal.
- Plan doc updated to reflect what Phase 6 actually covered.

## Tests

- `ui`: `TestSubsectionDoesNotStackBlankLines`.
- `cmd`: `--continue-on-error` case in `TestContinueBatchAfterFailure`; `TestApproveSafeRefsConfirmOnce{ReviewsThenSigns,DeclineSkipsAll,YesSkipsPrompt}` drive `approveSafeRefsConfirmOnce` through swappable `reviewSafeRefFn`/`signSafeRefFn` stubs and assert card order, the single prompt, per-item results, tally and that no per-item `Sign approval` prompt appears.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

