### PR TITLE
info: correctness fixes found while testing the new layout on mainnet

### DIFF
--- a/common/eth_util.go
+++ b/common/eth_util.go
@@ -17,6 +17,18 @@ func GetMultiSendABI() *abi.ABI {
 	return &result
 }
 
+// GetWellKnownEventsABI returns the ABI used to decode standard token events
+// when the emitting contract's own ABI is unavailable. erc721 selects the
+// ERC-721 variant (three indexed arguments) of Transfer/Approval.
+func GetWellKnownEventsABI(erc721 bool) *abi.ABI {
+	src := wellKnownEventsABI
+	if erc721 {
+		src = erc721EventsABI
+	}
+	result, _ := abi.JSON(strings.NewReader(src))
+	return &result
+}
+
 func GetEIP1967BeaconABI() *abi.ABI {
 	result, _ := abi.JSON(strings.NewReader(eip1967beacon))
 	return &result

--- a/common/ethereum_data.go
+++ b/common/ethereum_data.go
@@ -131,6 +131,9 @@ type TxResult struct {
 	BlockNumber string
 	Timestamp   string
 	TxType      string
+	// RevertReason is the decoded revert payload of a reverted tx, recovered
+	// by replaying the call; empty when unknown.
+	RevertReason string
 
 	FunctionCall *FunctionCall
 	Logs         []LogResult

--- a/common/hardcode_abis.go
+++ b/common/hardcode_abis.go
@@ -9,3 +9,22 @@ var erc20abi = `[ { "constant": true, "inputs": [], "name": "name", "outputs": [
 var multisendabi = `[{"inputs":[{"internalType":"bytes","name":"transactions","type":"bytes"}],"name":"multiSend","outputs":[],"stateMutability":"payable","type":"function"}]`
 
 var eip1967beacon = `[{"inputs":[{"internalType":"address","name":"implementation_","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"implementation","type":"address"}],"name":"Upgraded","type":"event"},{"inputs":[],"name":"implementation","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newImplementation","type":"address"}],"name":"upgradeTo","outputs":[],"stateMutability":"nonpayable","type":"function"}]`
+
+// wellKnownEventsABI covers the token events every wallet knows how to read
+// so that Transfers can be derived even when the emitting contract's ABI is
+// not available from a block explorer: ERC-20 Transfer/Approval, WETH
+// Deposit/Withdrawal and ERC-721/1155 ApprovalForAll.
+var wellKnownEventsABI = `[
+{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},
+{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":true,"name":"spender","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Approval","type":"event"},
+{"anonymous":false,"inputs":[{"indexed":true,"name":"dst","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Deposit","type":"event"},
+{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Withdrawal","type":"event"},
+{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":true,"name":"operator","type":"address"},{"indexed":false,"name":"approved","type":"bool"}],"name":"ApprovalForAll","type":"event"}
+]`
+
+// erc721EventsABI is the ERC-721 flavour of Transfer/Approval: same topic0 as
+// ERC-20 but with the token id as a third indexed argument.
+var erc721EventsABI = `[
+{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":true,"name":"tokenId","type":"uint256"}],"name":"Transfer","type":"event"},
+{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":true,"name":"approved","type":"address"},{"indexed":true,"name":"tokenId","type":"uint256"}],"name":"Approval","type":"event"}
+]`

--- a/common/math.go
+++ b/common/math.go
@@ -69,17 +69,20 @@ func GweiToWei(n float64) *big.Int {
 	return FloatToBigInt(n, 9)
 }
 
+// FloatStringToBig converts a human decimal string such as "0.001" into the
+// integer amount with the given number of decimals. Arithmetic is exact
+// (big.Rat), so "0.001" with 6 decimals is 1000, never 999. Digits beyond the
+// token's precision are truncated; "_" and "," are accepted as digit
+// separators.
 func FloatStringToBig(value string, decimal uint64) (*big.Int, error) {
-	f, success := new(big.Float).SetString(value)
-	if !success {
-		return nil, fmt.Errorf("couldn't parse string to big int")
+	cleaned := strings.NewReplacer("_", "", ",", "").Replace(strings.TrimSpace(value))
+	r, ok := new(big.Rat).SetString(cleaned)
+	if !ok || cleaned == "" {
+		return nil, fmt.Errorf("couldn't parse %q as a decimal number", value)
 	}
-	power := new(big.Float).SetInt(new(big.Int).Exp(
-		big.NewInt(10), big.NewInt(int64(decimal)), nil,
-	))
-	f.Mul(f, power)
-	res, _ := f.Int(nil)
-	return res, nil
+	power := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimal)), nil)
+	r.Mul(r, new(big.Rat).SetInt(power))
+	return new(big.Int).Quo(r.Num(), r.Denom()), nil
 }
 
 func BigToFloatString(value *big.Int, decimal uint64) string {

--- a/common/math_test.go
+++ b/common/math_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestGweiToWeiTypicalGasPrice(t *testing.T) {
 	// 37.500044782 Gwei is a normal Ethereum gas price. Converting to wei
-		// yields 37500044782, which overflows 32-bit int (strconv.Atoi) but fits
-		// in int64.
+	// yields 37500044782, which overflows 32-bit int (strconv.Atoi) but fits
+	// in int64.
 	got := GweiToWei(37.500044782)
 	want := big.NewInt(37500044782)
 	if got.Cmp(want) != 0 {
@@ -21,5 +21,36 @@ func TestFloatToIntBeyondInt32(t *testing.T) {
 	const want int64 = 37500044782
 	if got != want {
 		t.Errorf("FloatToInt(37500044782) = %d, want %d", got, want)
+	}
+}
+
+func TestFloatStringToBigIsExact(t *testing.T) {
+	cases := []struct {
+		in       string
+		decimals uint64
+		want     string
+	}{
+		{"0.001", 6, "1000"},
+		{"0.1", 18, "100000000000000000"},
+		{"1", 18, "1000000000000000000"},
+		{"1,000.5", 6, "1000500000"},
+		{"1_000", 0, "1000"},
+		{"1e6", 0, "1000000"},
+		{"0.0000001", 6, "0"}, // below precision truncates, never rounds up
+		{"123456789.123456789", 9, "123456789123456789"},
+	}
+	for _, c := range cases {
+		got, err := FloatStringToBig(c.in, c.decimals)
+		if err != nil {
+			t.Fatalf("%s: %s", c.in, err)
+		}
+		if got.String() != c.want {
+			t.Errorf("%s with %d decimals = %s, want %s", c.in, c.decimals, got, c.want)
+		}
+	}
+	for _, bad := range []string{"", "abc", "1.2.3"} {
+		if _, err := FloatStringToBig(bad, 18); err == nil {
+			t.Errorf("%q should not parse", bad)
+		}
 	}
 }

--- a/txanalyzer/analyzer.go
+++ b/txanalyzer/analyzer.go
@@ -27,7 +27,12 @@ type TxAnalyzer struct {
 func (self *TxAnalyzer) setBasicTxInfo(txinfo TxInfo, result *TxResult) {
 	result.From = self.ctx.GetJarvisAddress(txinfo.Tx.Extra.From.Hex())
 	result.Value = BigToFloatString(txinfo.Tx.Value(), self.ctx.Network.GetNativeTokenDecimal())
-	result.To = self.ctx.GetJarvisAddress(txinfo.Tx.To().Hex())
+	if to := txinfo.Tx.To(); to != nil {
+		result.To = self.ctx.GetJarvisAddress(to.Hex())
+	} else if txinfo.Receipt != nil {
+		// Contract creation: the receipt carries the deployed address.
+		result.To = self.ctx.GetJarvisAddress(txinfo.Receipt.ContractAddress.Hex())
+	}
 	result.Nonce = fmt.Sprintf("%d", txinfo.Tx.Nonce())
 	result.GasPrice = fmt.Sprintf("%.4f", BigToFloat(txinfo.Tx.GasPrice(), 9))
 	result.GasLimit = fmt.Sprintf("%d", txinfo.Tx.Gas())
@@ -170,6 +175,19 @@ func (ta *TxAnalyzer) ParamAsJarvisParamResult(name string, t abi.Type, value in
 	return ta.paramAsJarvisParamResult(name, t, value, nil)
 }
 
+// rawTopics turns a log's topics into unnamed TopicResults, topic0 first, for
+// logs that no available ABI describes.
+func rawTopics(l *types.Log) []TopicResult {
+	out := make([]TopicResult, 0, len(l.Topics))
+	for i, t := range l.Topics {
+		out = append(out, TopicResult{
+			Name:  fmt.Sprintf("topic%d", i),
+			Value: Value{Raw: t.Hex(), Kind: DisplayRaw},
+		})
+	}
+	return out
+}
+
 func findEventById(a *abi.ABI, topic []byte) (*abi.Event, error) {
 	for _, event := range a.Events {
 		if bytes.Equal(event.ID.Bytes(), topic) {
@@ -279,6 +297,11 @@ func (self *TxAnalyzer) analyzeFunctionCallRecursively(
 		fc.Destination.Decimal = int64(hint.Decimal)
 	}
 
+	if len(data) == 0 {
+		// A plain value transfer into a contract (receive/fallback): there is
+		// no calldata to decode and nothing to report as an error.
+		return fc
+	}
 	fc.Method, fc.Params, err = self.analyzeMethodCall(a, data, hint)
 	if err != nil {
 		// Keep the underlying reason: "no method with id: 0x..." tells the
@@ -491,12 +514,31 @@ func (self *TxAnalyzer) AnalyzeLog(
 		}
 		a, err = lookupABI(l.Address.Hex(), self.ctx.Network)
 		if err != nil {
-			return logResult, fmt.Errorf("getting abi for %s failed: %s", l.Address.Hex(), err)
+			a = nil
 		}
 	}
-	event, err := findEventById(a, l.Topics[0].Bytes())
-	if err != nil {
-		return logResult, err
+	var event *abi.Event
+	if a != nil {
+		event, _ = findEventById(a, l.Topics[0].Bytes())
+	}
+	// Standard token events decode the same on every contract, so an
+	// unverified token still contributes to Transfers. The ERC-721 variant is
+	// picked by topic count (token id is a third indexed argument).
+	if event == nil {
+		event, _ = findEventById(GetWellKnownEventsABI(len(l.Topics) == 4), l.Topics[0].Bytes())
+	}
+	if event == nil {
+		// Keep the log in the result so the event count stays honest; the
+		// display layer renders it from the raw topics.
+		logResult.Topics = rawTopics(l)
+		if len(l.Data) > 0 {
+			logResult.Data = append(logResult.Data, ParamResult{
+				Name:   "data",
+				Type:   "bytes",
+				Values: []Value{{Raw: hexutil.Encode(l.Data), Kind: DisplayRaw}},
+			})
+		}
+		return logResult, nil
 	}
 	logResult.Name = event.Name
 
@@ -557,7 +599,18 @@ func (self *TxAnalyzer) analyzeContractTx(
 		txinfo.Tx.To().Hex(),
 		txinfo.Tx.Data(),
 		customABIs)
+	self.analyzeLogs(txinfo, lookupABI, customABIs, result)
+}
 
+func (self *TxAnalyzer) analyzeLogs(
+	txinfo TxInfo,
+	lookupABI ABIDatabase,
+	customABIs map[string]*abi.ABI,
+	result *TxResult,
+) {
+	if txinfo.Receipt == nil {
+		return
+	}
 	for _, l := range txinfo.Receipt.Logs {
 		logResult, err := self.AnalyzeLog(lookupABI, customABIs, l)
 		if err != nil {
@@ -583,9 +636,16 @@ func (self *TxAnalyzer) AnalyzeOffline(
 	result.Status = txinfo.Status
 	if txinfo.Status == "done" || txinfo.Status == "reverted" {
 		self.setBasicTxInfo(*txinfo, result)
-		if !isContract {
+		if txinfo.Status == "reverted" {
+			result.RevertReason = self.revertReason(txinfo, lookupABI, customABIs)
+		}
+		switch {
+		case txinfo.Tx.To() == nil:
+			result.TxType = "contract creation"
+			self.analyzeLogs(*txinfo, lookupABI, customABIs, result)
+		case !isContract:
 			result.TxType = "normal"
-		} else {
+		default:
 			result.TxType = "contract call"
 			self.analyzeContractTx(*txinfo, lookupABI, customABIs, result)
 
@@ -617,4 +677,96 @@ func NewGenericAnalyzer(r reader.Reader, network Network) *TxAnalyzer {
 //	analyzer := txanalyzer.NewGenericAnalyzerWithContext(ctx)
 func NewGenericAnalyzerWithContext(ctx *AnalysisContext) *TxAnalyzer {
 	return &TxAnalyzer{ctx: ctx}
+}
+
+// revertReplayer is implemented by readers that can replay a mined tx to
+// recover its revert payload (see reader.EthReader.RevertData).
+type revertReplayer interface {
+	RevertData(txinfo TxInfo) ([]byte, error)
+}
+
+// revertReason replays a reverted tx and decodes the payload. Any failure
+// yields "" — the reason is a convenience, never a requirement.
+func (self *TxAnalyzer) revertReason(txinfo *TxInfo, lookupABI ABIDatabase, customABIs map[string]*abi.ABI) string {
+	rp, ok := self.ctx.reader.(revertReplayer)
+	if !ok || txinfo.Tx == nil || txinfo.Tx.To() == nil {
+		return ""
+	}
+	data, err := rp.RevertData(*txinfo)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	var a *abi.ABI
+	if sel := hexutil.Encode(data[:min(4, len(data))]); sel != errorStringSelector && sel != panicSelector {
+		to := txinfo.Tx.To().Hex()
+		a = customABIs[strings.ToLower(to)]
+		if a == nil && lookupABI != nil {
+			a, _ = lookupABI(to, self.ctx.Network)
+		}
+	}
+	return DecodeRevertData(data, a)
+}
+
+const (
+	errorStringSelector = "0x08c379a0" // Error(string)
+	panicSelector       = "0x4e487b71" // Panic(uint256)
+)
+
+var panicCodes = map[uint64]string{
+	0x00: "generic compiler panic",
+	0x01: "assert failed",
+	0x11: "arithmetic overflow or underflow",
+	0x12: "division or modulo by zero",
+	0x21: "invalid enum value",
+	0x22: "corrupted storage byte array",
+	0x31: "pop on empty array",
+	0x32: "array index out of bounds",
+	0x41: "out of memory",
+	0x51: "call to uninitialised function pointer",
+}
+
+// DecodeRevertData renders a revert payload for humans: Error(string) as the
+// quoted message, Panic(uint256) as its meaning, a custom error by name when a
+// carries its definition, and the bare selector otherwise.
+func DecodeRevertData(data []byte, a *abi.ABI) string {
+	if len(data) < 4 {
+		if len(data) == 0 {
+			return ""
+		}
+		return fmt.Sprintf("revert data %s", hexutil.Encode(data))
+	}
+	selector, payload := data[:4], data[4:]
+	stringT, _ := abi.NewType("string", "", nil)
+	uintT, _ := abi.NewType("uint256", "", nil)
+	switch hexutil.Encode(selector) {
+	case errorStringSelector:
+		if vals, err := (abi.Arguments{{Type: stringT}}).Unpack(payload); err == nil && len(vals) == 1 {
+			return fmt.Sprintf("%q", vals[0])
+		}
+	case panicSelector:
+		if vals, err := (abi.Arguments{{Type: uintT}}).Unpack(payload); err == nil && len(vals) == 1 {
+			code := vals[0].(*big.Int).Uint64()
+			if msg, ok := panicCodes[code]; ok {
+				return fmt.Sprintf("panic 0x%02x: %s", code, msg)
+			}
+			return fmt.Sprintf("panic 0x%02x", code)
+		}
+	}
+	if a != nil {
+		for _, e := range a.Errors {
+			if !bytes.Equal(e.ID.Bytes()[:4], selector) {
+				continue
+			}
+			vals, err := e.Inputs.Unpack(payload)
+			if err != nil {
+				return e.Name + "(…)"
+			}
+			parts := make([]string, len(vals))
+			for i, v := range vals {
+				parts[i] = fmt.Sprintf("%v", v)
+			}
+			return fmt.Sprintf("%s(%s)", e.Name, strings.Join(parts, ", "))
+		}
+	}
+	return fmt.Sprintf("custom error %s", hexutil.Encode(selector))
 }

--- a/txanalyzer/log_test.go
+++ b/txanalyzer/log_test.go
@@ -1,10 +1,14 @@
 package txanalyzer
 
 import (
+	"fmt"
+	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/tranvictor/jarvis/networks"
 )
@@ -21,5 +25,93 @@ func TestAnalyzeLogEmptyTopics(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for log with no topics")
+	}
+}
+
+// failingLookup stands in for a block explorer that has no ABI for anything.
+func failingLookup(addr string, _ networks.Network) (*abi.ABI, error) {
+	return nil, fmt.Errorf("no abi for %s", addr)
+}
+
+func TestAnalyzeLogFallsBackToWellKnownEvents(t *testing.T) {
+	network, _ := networks.GetNetwork("mainnet")
+	ta := NewGenericAnalyzer(nil, network)
+	transferSig := crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))
+	from := common.HexToAddress("0x9642b23Ed1E01Df1092B92641051881a322F5D4E")
+	to := common.HexToAddress("0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+	value := common.LeftPadBytes(big.NewInt(1000).Bytes(), 32)
+
+	erc20, err := ta.AnalyzeLog(failingLookup, nil, &types.Log{
+		Address: common.HexToAddress("0x48B8419B2Bc0fB63Ee96e3a370e30B200cC2e672"),
+		Topics:  []common.Hash{transferSig, common.BytesToHash(from.Bytes()), common.BytesToHash(to.Bytes())},
+		Data:    value,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if erc20.Name != "Transfer" || len(erc20.Topics) != 2 || len(erc20.Data) != 1 {
+		t.Fatalf("erc20 transfer not decoded from well-known ABI: %+v", erc20)
+	}
+	if erc20.Topics[0].Name != "from" || erc20.Data[0].Values[0].Raw != "1000" {
+		t.Fatalf("unexpected decoded fields: %+v", erc20)
+	}
+
+	erc721, err := ta.AnalyzeLog(failingLookup, nil, &types.Log{
+		Address: common.HexToAddress("0x48B8419B2Bc0fB63Ee96e3a370e30B200cC2e672"),
+		Topics:  []common.Hash{transferSig, common.BytesToHash(from.Bytes()), common.BytesToHash(to.Bytes()), common.BigToHash(big.NewInt(7))},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if erc721.Name != "Transfer" || len(erc721.Topics) != 3 || erc721.Topics[2].Name != "tokenId" || erc721.Topics[2].Value.Raw != "7" {
+		t.Fatalf("erc721 transfer not decoded: %+v", erc721)
+	}
+}
+
+func TestAnalyzeLogKeepsUndecodedLogsRaw(t *testing.T) {
+	network, _ := networks.GetNetwork("mainnet")
+	ta := NewGenericAnalyzer(nil, network)
+	topic0 := crypto.Keccak256Hash([]byte("Something(uint256)"))
+	res, err := ta.AnalyzeLog(failingLookup, nil, &types.Log{
+		Address: common.HexToAddress("0x48B8419B2Bc0fB63Ee96e3a370e30B200cC2e672"),
+		Topics:  []common.Hash{topic0, common.BigToHash(big.NewInt(3))},
+		Data:    common.LeftPadBytes([]byte{1}, 32),
+	})
+	if err != nil {
+		t.Fatalf("undecodable logs must not be errors: %s", err)
+	}
+	if res.Name != "" {
+		t.Fatalf("name should stay empty, got %q", res.Name)
+	}
+	if len(res.Topics) != 2 || res.Topics[0].Name != "topic0" || res.Topics[0].Value.Raw != topic0.Hex() {
+		t.Fatalf("raw topics missing: %+v", res.Topics)
+	}
+	if len(res.Data) != 1 || res.Data[0].Name != "data" {
+		t.Fatalf("raw data missing: %+v", res.Data)
+	}
+}
+
+func TestDecodeRevertData(t *testing.T) {
+	stringT, _ := abi.NewType("string", "", nil)
+	msg, _ := (abi.Arguments{{Type: stringT}}).Pack("Insufficient output")
+	if got := DecodeRevertData(append(common.FromHex("0x08c379a0"), msg...), nil); got != `"Insufficient output"` {
+		t.Fatalf("Error(string): %q", got)
+	}
+	uintT, _ := abi.NewType("uint256", "", nil)
+	code, _ := (abi.Arguments{{Type: uintT}}).Pack(big.NewInt(0x11))
+	if got := DecodeRevertData(append(common.FromHex("0x4e487b71"), code...), nil); got != "panic 0x11: arithmetic overflow or underflow" {
+		t.Fatalf("Panic: %q", got)
+	}
+	custom := abiFromJSON(t, `[{"type":"error","name":"SlippageExceeded","inputs":[{"name":"minOut","type":"uint256"},{"name":"got","type":"uint256"}]}]`)
+	e := custom.Errors["SlippageExceeded"]
+	args, _ := e.Inputs.Pack(big.NewInt(100), big.NewInt(90))
+	if got := DecodeRevertData(append(e.ID.Bytes()[:4], args...), custom); got != "SlippageExceeded(100, 90)" {
+		t.Fatalf("custom error: %q", got)
+	}
+	if got := DecodeRevertData(common.FromHex("0x97a6f3b9"), nil); got != "custom error 0x97a6f3b9" {
+		t.Fatalf("unknown selector: %q", got)
+	}
+	if got := DecodeRevertData(nil, nil); got != "" {
+		t.Fatalf("empty payload: %q", got)
 	}
 }

--- a/util/display.go
+++ b/util/display.go
@@ -118,18 +118,19 @@ func buildLogDisplay(log jarviscommon.LogResult) LogDisplay {
 
 func buildTxDisplay(result *jarviscommon.TxResult) *TxDisplay {
 	d := &TxDisplay{
-		Status:      result.Status,
-		From:        styledParamAddress(result.From),
-		To:          StyledAddress(result.To),
-		Value:       result.Value,
-		TxType:      result.TxType,
-		Error:       result.Error,
-		Nonce:       result.Nonce,
-		GasPrice:    result.GasPrice,
-		GasLimit:    result.GasLimit,
-		GasUsed:     result.GasUsed,
-		GasCost:     result.GasCost,
-		BlockNumber: result.BlockNumber,
+		Status:       result.Status,
+		From:         styledParamAddress(result.From),
+		To:           StyledAddress(result.To),
+		Value:        result.Value,
+		TxType:       result.TxType,
+		RevertReason: result.RevertReason,
+		Error:        result.Error,
+		Nonce:        result.Nonce,
+		GasPrice:     result.GasPrice,
+		GasLimit:     result.GasLimit,
+		GasUsed:      result.GasUsed,
+		GasCost:      result.GasCost,
+		BlockNumber:  result.BlockNumber,
 	}
 	if result.TxType == "" || result.TxType == "normal" {
 		return d
@@ -163,19 +164,31 @@ func buildTransfers(logs []jarviscommon.LogResult) []TransferDisplay {
 			continue
 		}
 		td := TransferDisplay{Amount: amount, Unlimited: unlimited, Token: transferToken(l, args)}
+		// Parties are looked up by the usual names first and by topic
+		// position otherwise: DAI/WETH-style ABIs call them src/guy/wad, and
+		// any ERC-20 puts (from, to) / (owner, spender) in topics 1 and 2.
+		party := func(idx int, names ...string) ui.StyledText {
+			if v := transferParty(args, names...); v.Text != "" {
+				return v
+			}
+			if idx < len(l.Topics) {
+				return styledValue(l.Topics[idx].Value)
+			}
+			return ui.StyledText{}
+		}
 		switch l.Name {
 		case "Transfer":
 			td.Kind = "transfer"
-			td.From, td.To = transferParty(args, "from", "src", "_from"), transferParty(args, "to", "dst", "_to")
+			td.From, td.To = party(0, "from", "src", "_from"), party(1, "to", "dst", "_to")
 		case "Approval":
 			td.Kind = "approval"
-			td.From, td.To = transferParty(args, "owner", "_owner"), transferParty(args, "spender", "_spender")
+			td.From, td.To = party(0, "owner", "src", "_owner"), party(1, "spender", "guy", "_spender")
 		case "Deposit":
 			td.Kind = "deposit"
-			td.To = transferParty(args, "dst", "to", "user", "account")
+			td.To = party(0, "dst", "to", "user", "account")
 		case "Withdrawal":
 			td.Kind = "withdrawal"
-			td.From = transferParty(args, "src", "from", "user", "account")
+			td.From = party(0, "src", "from", "user", "account")
 		default:
 			continue
 		}
@@ -374,7 +387,7 @@ func printAllLogs(u ui.UI, logs []LogDisplay) {
 
 	groups := make([][][]ui.TableCell, len(logs))
 	for i, d := range logs {
-		eventLabel := fmt.Sprintf("%d. %s", i+1, d.Name)
+		eventLabel := fmt.Sprintf("%d. %s", i+1, eventName(d))
 		paramRows := logSimpleRows(d)
 		if len(paramRows) == 0 {
 			groups[i] = [][]ui.TableCell{{ui.TC(eventLabel), ui.TC(""), ui.TC("")}}

--- a/util/display_model.go
+++ b/util/display_model.go
@@ -103,5 +103,8 @@ type TxDisplay struct {
 	FunctionCall *FunctionCallDisplay `json:"function_call,omitempty"`
 	Transfers    []TransferDisplay    `json:"transfers,omitempty"`
 	Logs         []LogDisplay         `json:"logs,omitempty"`
-	Error        string               `json:"error,omitempty"`
+	// RevertReason is the decoded revert payload of a reverted tx, when the
+	// replay could recover one.
+	RevertReason string `json:"revert_reason,omitempty"`
+	Error        string `json:"error,omitempty"`
 }

--- a/util/display_test.go
+++ b/util/display_test.go
@@ -325,7 +325,7 @@ func TestUndecodedCallShowsContractAndData(t *testing.T) {
 		"selector 0xdeadbeef   36 bytes",
 		"Raw calldata (36 bytes):",
 		"0xdeadbeef00000000000000000000000000000000000000000000000000000000",
-		"no method with id: 0xdeadbeef",
+		"calldata not decoded: no available ABI covers selector 0xdeadbeef",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("output missing %q:\n%s", want, joined)

--- a/util/display_tx.go
+++ b/util/display_tx.go
@@ -148,8 +148,12 @@ func (p txPrinter) intent(d *TxDisplay, network networks.Network) string {
 	switch {
 	case d.TxType == "normal":
 		return "transfer " + d.Value + " " + network.GetNativeTokenSymbol()
+	case d.TxType == "contract creation":
+		return "deploy contract"
 	case d.FunctionCall == nil:
 		return "contract call"
+	case d.FunctionCall.Method == "" && (d.FunctionCall.Data == "" || d.FunctionCall.Data == "0x"):
+		return "transfer " + d.Value + " " + network.GetNativeTokenSymbol() + " to contract"
 	case d.FunctionCall.Method == "":
 		return "<undecoded call>"
 	default:
@@ -178,7 +182,11 @@ func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network, layout TxLa
 	}
 
 	u.Info("%s", p.headline(d, network))
-	u.Info("%s", p.muted(strings.Repeat(" ", ui.VisibleWidth(statusText(d.Status).Text)+3)+p.details(d, network)))
+	indent := strings.Repeat(" ", ui.VisibleWidth(statusText(d.Status).Text)+3)
+	u.Info("%s", p.muted(indent+p.details(d, network)))
+	if d.RevertReason != "" {
+		u.Info("%s%s", indent, p.u.Style(ui.StyledText{Text: "reason  " + d.RevertReason, Severity: ui.SeverityError}))
+	}
 
 	if layout == LayoutInfoFull {
 		p.printCard(d, network)
@@ -192,7 +200,9 @@ func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network, layout TxLa
 		p.printTransfers(d.Transfers)
 		printed = true
 	}
-	showCall := d.FunctionCall != nil && (layout != LayoutPostSign || d.Status == "reverted")
+	emptyCall := d.FunctionCall != nil && d.FunctionCall.Method == "" &&
+		(d.FunctionCall.Data == "" || d.FunctionCall.Data == "0x") && len(d.FunctionCall.InnerCalls) == 0
+	showCall := d.FunctionCall != nil && !emptyCall && (layout != LayoutPostSign || d.Status == "reverted")
 	if showCall {
 		p.printCall(d.FunctionCall)
 		printed = true
@@ -330,7 +340,7 @@ func (p txPrinter) printCallBody(u ui.UI, d *FunctionCallDisplay) {
 		u.Info("%s %s", p.muted("value"), d.Value)
 	}
 	if d.Error != "" {
-		u.Error("%s", d.Error)
+		u.Warn("! %s", friendlyDecodeError(d.Error))
 	}
 	if d.Method == "" && d.Data != "" {
 		selector := d.Data
@@ -467,11 +477,18 @@ func (p txPrinter) fieldLines(fields []ParamDisplay) [][]string {
 }
 
 // printEvents renders one line per event: "N. Name  emitter   arg value  arg value".
+// undecodedEventLabel stands in for the name of a log no ABI describes.
+const undecodedEventLabel = "<undecoded>"
+
 func (p txPrinter) printEvents(logs []LogDisplay) {
 	p.u.Subsection(fmt.Sprintf("Events (%d)", len(logs)))
 	nameWidth := 0
+	undecoded := 0
 	for _, l := range logs {
-		if w := ui.VisibleWidth(l.Name); w > nameWidth {
+		if l.Name == "" {
+			undecoded++
+		}
+		if w := ui.VisibleWidth(eventName(l)); w > nameWidth {
 			nameWidth = w
 		}
 	}
@@ -483,12 +500,44 @@ func (p txPrinter) printEvents(logs []LogDisplay) {
 		for _, prm := range l.Data {
 			args = append(args, p.muted(prm.Name)+" "+p.paramInline(prm))
 		}
-		name := l.Name + strings.Repeat(" ", nameWidth-ui.VisibleWidth(l.Name))
-		line := fmt.Sprintf("%d. %s  %s", i+1, p.bold(name), p.text(l.Address))
+		plain := eventName(l)
+		name := plain + strings.Repeat(" ", nameWidth-ui.VisibleWidth(plain))
+		if l.Name == "" {
+			name = p.muted(name)
+		} else {
+			name = p.bold(name)
+		}
+		line := fmt.Sprintf("%d. %s  %s", i+1, name, p.text(l.Address))
 		if len(args) > 0 {
 			line += "   " + strings.Join(args, "  ")
 		}
 		p.u.Indent().Info("%s", line)
+	}
+	if undecoded > 0 {
+		p.u.Indent().Info("%s", p.muted(fmt.Sprintf(
+			"%d event(s) shown raw: the emitting contract has no ABI available (unverified or explorer unreachable)", undecoded)))
+	}
+}
+
+func eventName(l LogDisplay) string {
+	if l.Name == "" {
+		return undecodedEventLabel
+	}
+	return l.Name
+}
+
+// friendlyDecodeError rewrites the analyzer's calldata error into a sentence
+// that says what it means for the operator, keeping the technical cause.
+func friendlyDecodeError(err string) string {
+	cause := strings.TrimPrefix(err, "couldn't decode calldata: ")
+	switch {
+	case strings.Contains(cause, "no method with id"):
+		sel := cause[strings.LastIndex(cause, " ")+1:]
+		return fmt.Sprintf("calldata not decoded: no available ABI covers selector %s (contract unverified or ABI mismatch)", sel)
+	case strings.HasPrefix(cause, "abi:"):
+		return "calldata not decoded: it does not match the contract ABI (" + strings.TrimSpace(strings.TrimPrefix(cause, "abi:")) + ")"
+	default:
+		return "calldata not decoded: " + cause
 	}
 }
 

--- a/util/display_tx_test.go
+++ b/util/display_tx_test.go
@@ -317,3 +317,91 @@ func TestUnknownCallTargetIsWarnButParamsAreNot(t *testing.T) {
 		t.Fatalf("known param address should be green, got %v", path.Values[0].Severity)
 	}
 }
+
+func TestRevertReasonShownUnderHeadline(t *testing.T) {
+	r := swapTxResult()
+	r.Status = "reverted"
+	r.Logs = nil
+	r.RevertReason = `"UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"`
+
+	out := render(t, r, util.LayoutInfo, hashHex)
+	lines := strings.Split(out, "\n")
+	if len(lines) < 3 || !strings.Contains(lines[2], `reason  "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"`) {
+		t.Fatalf("revert reason should be the third line:\n%s", out)
+	}
+	if !strings.HasPrefix(lines[2], "             reason") {
+		t.Fatalf("reason should align with the details line:\n%q", lines[2])
+	}
+	d := util.DisplayTxResult(ui.NewRecordingUI(), r, networks.EthereumMainnet, util.LayoutInfo, hashHex)
+	raw, _ := json.Marshal(d)
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil || m["revert_reason"] != r.RevertReason {
+		t.Fatalf("revert_reason should be in the JSON: %v %s", err, raw)
+	}
+}
+
+func TestContractCreationAndEmptyCalldataIntents(t *testing.T) {
+	r := jarviscommon.NewTxResult()
+	r.Status = "done"
+	r.TxType = "contract creation"
+	r.From = addr(meHex, "me")
+	r.To = addr(routerHex, "")
+	r.Value = "0"
+	out := render(t, r, util.LayoutInfo, hashHex)
+	if !strings.HasPrefix(out, "✓ done   deploy contract  →  0x7a25…488D (unknown)") {
+		t.Fatalf("creation headline:\n%s", out)
+	}
+
+	r = swapTxResult()
+	r.Logs = nil
+	r.Value = "0.5"
+	r.FunctionCall = &jarviscommon.FunctionCall{Destination: r.To, Data: nil}
+	out = render(t, r, util.LayoutInfo, hashHex)
+	if !strings.HasPrefix(out, "✓ done   transfer 0.5 ETH to contract  →  Uniswap V2 Router") {
+		t.Fatalf("empty calldata headline:\n%s", out)
+	}
+	if strings.Contains(out, "Call ") || strings.Contains(out, "not decoded") {
+		t.Fatalf("empty calldata must not render a Call section:\n%s", out)
+	}
+}
+
+func TestUndecodedEventsAreCountedAndShownRaw(t *testing.T) {
+	r := swapTxResult()
+	r.Logs = append(r.Logs, jarviscommon.LogResult{
+		Address: addr(pairHex, ""),
+		Topics: []jarviscommon.TopicResult{
+			{Name: "topic0", Value: jarviscommon.Value{Raw: "0x" + strings.Repeat("ab", 32), Kind: jarviscommon.DisplayRaw}},
+		},
+		Data: []jarviscommon.ParamResult{{Name: "data", Type: "bytes", Values: []jarviscommon.Value{{Raw: "0x" + strings.Repeat("00", 64), Kind: jarviscommon.DisplayRaw}}}},
+	})
+	out := render(t, r, util.LayoutInfo, hashHex)
+	if !strings.Contains(out, "Events (4)") {
+		t.Fatalf("undecoded logs must count:\n%s", out)
+	}
+	if !strings.Contains(out, "4. <undecoded>  0x0d4a…1852 (unknown)   topic0 0xabab") {
+		t.Fatalf("raw event line missing:\n%s", out)
+	}
+	if !strings.Contains(out, "1 event(s) shown raw") {
+		t.Fatalf("raw-event note missing:\n%s", out)
+	}
+}
+
+func TestTransfersUseTopicPositionsForDaiStyleNames(t *testing.T) {
+	r := swapTxResult()
+	r.FunctionCall = nil
+	me := addr(meHex, "me")
+	router := addr(routerHex, "Uniswap V2 Router")
+	r.Logs = []jarviscommon.LogResult{{
+		Name:    "Approval",
+		Address: addr(wethHex, "WETH token"),
+		Topics: []jarviscommon.TopicResult{
+			{Name: "src", Value: addrValue(me.Address, me.Desc)},
+			{Name: "guy", Value: addrValue(router.Address, router.Desc)},
+		},
+		Data: []jarviscommon.ParamResult{scalar("wad", "uint256", tokenValue("5000000000000000000", "WETH", 18))},
+	}}
+	out := render(t, r, util.LayoutInfo, hashHex)
+	if !strings.Contains(out, "5 WETH   me (0x9642…5D4E) approves  Uniswap V2 Router (0x7a25…488D)") {
+		t.Fatalf("dai-style approval parties missing:\n%s", out)
+	}
+}

--- a/util/explorers/etherscan_alike_explorer.go
+++ b/util/explorers/etherscan_alike_explorer.go
@@ -2,11 +2,14 @@ package explorers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -119,26 +122,72 @@ type abiresponse struct {
 	Result  string `json:"result"`
 }
 
+// abiFetchAttempts and abiRetryDelay bound the retry loop around Etherscan's
+// per-second rate limit. A single `jarvis info` can look up a dozen ABIs in a
+// burst, so one short pause usually turns "rate limit reached" into a hit.
+var (
+	abiFetchAttempts = 3
+	abiRetryDelay    = 400 * time.Millisecond
+)
+
+// label names the explorer in errors without echoing the request URL, which
+// carries the API key.
+func (ee *EtherscanLikeExplorer) label() string {
+	return fmt.Sprintf("%s (chain %d)", ee.Domain, ee.ChainID)
+}
+
+func isRateLimited(msg string) bool {
+	return strings.Contains(strings.ToLower(msg), "rate limit")
+}
+
 func (ee *EtherscanLikeExplorer) GetABIString(address string) (string, error) {
-	url := ee.GetABIStringAPIURL(address)
-	resp, err := http.Get(url)
+	var lastErr error
+	for attempt := 0; attempt < abiFetchAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(abiRetryDelay)
+		}
+		result, retry, err := ee.getABIStringOnce(address)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if !retry {
+			break
+		}
+	}
+	return "", lastErr
+}
+
+// getABIStringOnce performs one getabi request. retry is true only for
+// transient failures (rate limiting, transport errors).
+func (ee *EtherscanLikeExplorer) getABIStringOnce(address string) (result string, retry bool, err error) {
+	resp, err := http.Get(ee.GetABIStringAPIURL(address))
 	if err != nil {
-		return "", err
+		return "", true, fmt.Errorf("%s: %w", ee.label(), redactURLError(err))
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("error reading body from %s: %w", url, err)
+		return "", true, fmt.Errorf("%s: reading response: %w", ee.label(), err)
 	}
 	abiresp := abiresponse{}
-	err = json.Unmarshal(body, &abiresp)
-	if err != nil {
-		return "", fmt.Errorf("error unmarshalling body from %s: %w", url, err)
+	if err := json.Unmarshal(body, &abiresp); err != nil {
+		return "", false, fmt.Errorf("%s: unexpected response: %w", ee.label(), err)
 	}
 	if abiresp.Status != "1" {
-		return "", fmt.Errorf("error from %s: %s", url, abiresp.Result)
+		return "", isRateLimited(abiresp.Result), fmt.Errorf("%s: %s", ee.label(), abiresp.Result)
 	}
-	return abiresp.Result, nil
+	return abiresp.Result, false, nil
+}
+
+// redactURLError strips the request URL (and with it the API key) out of
+// net/http transport errors, keeping only the underlying cause.
+func redactURLError(err error) error {
+	var uerr *url.Error
+	if errors.As(err, &uerr) {
+		return uerr.Err
+	}
+	return err
 }
 
 func (ee *EtherscanLikeExplorer) getSourceCodeAPIURL(address string) string {
@@ -167,15 +216,14 @@ type sourceCodeResponse struct {
 }
 
 func (ee *EtherscanLikeExplorer) GetContractInfo(address string) (ContractInfo, error) {
-	url := ee.getSourceCodeAPIURL(address)
-	resp, err := http.Get(url)
+	resp, err := http.Get(ee.getSourceCodeAPIURL(address))
 	if err != nil {
-		return ContractInfo{}, err
+		return ContractInfo{}, fmt.Errorf("%s: %w", ee.label(), redactURLError(err))
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return ContractInfo{}, fmt.Errorf("error reading body from %s: %w", url, err)
+		return ContractInfo{}, fmt.Errorf("%s: reading response: %w", ee.label(), err)
 	}
 	var sc sourceCodeResponse
 	if err := json.Unmarshal(body, &sc); err != nil {

--- a/util/explorers/etherscan_alike_explorer_test.go
+++ b/util/explorers/etherscan_alike_explorer_test.go
@@ -1,0 +1,60 @@
+package explorers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGetABIStringRetriesRateLimitAndRedactsKey(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Write([]byte(`{"status":"0","message":"NOTOK","result":"Max calls per sec rate limit reached (3/sec)"}`))
+			return
+		}
+		w.Write([]byte(`{"status":"1","message":"OK","result":"[]"}`))
+	}))
+	defer srv.Close()
+
+	prevDelay := abiRetryDelay
+	abiRetryDelay = time.Millisecond
+	t.Cleanup(func() { abiRetryDelay = prevDelay })
+
+	ee := NewEtherscanLikeExplorer(srv.URL, "SECRETKEY", 1)
+	got, err := ee.GetABIString("0x0000000000000000000000000000000000000001")
+	if err != nil || got != "[]" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("expected one retry, got %d calls", calls)
+	}
+}
+
+func TestGetABIStringErrorsNeverContainTheKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status":"0","message":"NOTOK","result":"Contract source code not verified"}`))
+	}))
+	defer srv.Close()
+
+	ee := NewEtherscanLikeExplorer(srv.URL, "SECRETKEY", 1)
+	_, err := ee.GetABIString("0x0000000000000000000000000000000000000001")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "SECRETKEY") || strings.Contains(err.Error(), "apikey") {
+		t.Fatalf("error leaks the api key: %s", err)
+	}
+	if !strings.Contains(err.Error(), "Contract source code not verified") {
+		t.Fatalf("error lost the explorer message: %s", err)
+	}
+
+	srv.Close()
+	_, err = ee.GetABIString("0x0000000000000000000000000000000000000001")
+	if err == nil || strings.Contains(err.Error(), "SECRETKEY") {
+		t.Fatalf("transport error leaks the api key: %v", err)
+	}
+}

--- a/util/reader/ethereum_node.go
+++ b/util/reader/ethereum_node.go
@@ -38,6 +38,9 @@ type EthereumNode interface {
 		args ...interface{},
 	) ([]byte, error)
 	EthCall(from string, to string, value *big.Int, data []byte, overrides *map[ethereum.Address]gethclient.OverrideAccount) ([]byte, error)
+	// CallAtBlock replays a call against the state at atBlock (nil = latest).
+	// Reverts surface as errors carrying the revert data (rpc.DataError).
+	CallAtBlock(from, to string, value *big.Int, gas uint64, data []byte, atBlock *big.Int) ([]byte, error)
 	StorageAt(atBlock int64, caddr string, slot string) ([]byte, error)
 	HeaderByNumber(number int64) (*types.Header, error)
 	GetLogs(fromBlock, toBlock int, addresses []string, topic string) ([]types.Log, error)

--- a/util/reader/one_node_reader.go
+++ b/util/reader/one_node_reader.go
@@ -326,6 +326,23 @@ func (onr *OneNodeReader) EthCall(from string, to string, value *big.Int, data [
 	}, big.NewInt(int64(rpc.PendingBlockNumber))) // pending block number is used to call the contract on the pending block
 }
 
+func (onr *OneNodeReader) CallAtBlock(from, to string, value *big.Int, gas uint64, data []byte, atBlock *big.Int) ([]byte, error) {
+	ethcli, err := onr.EthClient()
+	if err != nil {
+		return nil, err
+	}
+	contract := jarviscommon.HexToAddress(to)
+	timeout, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	return ethcli.CallContract(timeout, ethereum.CallMsg{
+		From:  jarviscommon.HexToAddress(from),
+		To:    &contract,
+		Gas:   gas,
+		Value: value,
+		Data:  data,
+	}, atBlock)
+}
+
 func (onr *OneNodeReader) CurrentBlock() (uint64, error) {
 	ethcli, err := onr.EthClient()
 	if err != nil {

--- a/util/reader/reader.go
+++ b/util/reader/reader.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	jarviscommon "github.com/tranvictor/jarvis/common"
 	jarvisnetworks "github.com/tranvictor/jarvis/util/explorers"
@@ -396,6 +398,72 @@ func (er *EthReader) EthCall(from string, to string, value *big.Int, data []byte
 		errs = append(errs, result.Error)
 	}
 	return nil, fmt.Errorf("couldn't read from any nodes: %w", errors.Join(errs...))
+}
+
+// ErrNoRevertData is returned by RevertData when the replay did not revert
+// (state has moved on) or reverted without any data.
+var ErrNoRevertData = errors.New("replay produced no revert data")
+
+// RevertData replays a mined, reverted transaction against the state at the
+// start of its block and returns the raw revert payload (Error(string),
+// Panic(uint256) or a custom error). Replaying at the parent block ignores
+// earlier transactions in the same block, so the reason is a best effort;
+// callers should treat it as a hint, not proof.
+func (er *EthReader) RevertData(txinfo jarviscommon.TxInfo) ([]byte, error) {
+	if txinfo.Receipt == nil || txinfo.Receipt.BlockNumber == nil || txinfo.Tx == nil || txinfo.Tx.To() == nil {
+		return nil, ErrNoRevertData
+	}
+	parent := new(big.Int).Sub(txinfo.Receipt.BlockNumber, big.NewInt(1))
+	type reply struct {
+		data []byte
+		err  error
+	}
+	resCh := make(chan reply, len(er.nodes))
+	for i := range er.nodes {
+		n := er.nodes[i]
+		go func() {
+			data, err := n.CallAtBlock(
+				txinfo.Tx.Extra.From.Hex(), txinfo.Tx.To().Hex(),
+				txinfo.Tx.Value(), txinfo.Tx.Gas(), txinfo.Tx.Data(), parent,
+			)
+			resCh <- reply{data: data, err: wrapError(err, n.NodeName())}
+		}()
+	}
+	errs := []error{}
+	replaySucceeded := false
+	for i := 0; i < len(er.nodes); i++ {
+		r := <-resCh
+		if r.err == nil {
+			replaySucceeded = true
+			continue
+		}
+		if data := revertDataFromError(r.err); len(data) > 0 {
+			return data, nil
+		}
+		errs = append(errs, r.err)
+	}
+	if replaySucceeded || len(errs) == 0 {
+		return nil, ErrNoRevertData
+	}
+	return nil, fmt.Errorf("couldn't replay on any node: %w", errors.Join(errs...))
+}
+
+// revertDataFromError extracts the hex revert payload that JSON-RPC nodes
+// attach to "execution reverted" errors.
+func revertDataFromError(err error) []byte {
+	var de rpc.DataError
+	if !errors.As(err, &de) {
+		return nil
+	}
+	hexStr, ok := de.ErrorData().(string)
+	if !ok {
+		return nil
+	}
+	data, decErr := hexutil.Decode(hexStr)
+	if decErr != nil {
+		return nil
+	}
+	return data
 }
 
 func (er *EthReader) ImplementationOfEIP1967(

--- a/util/util.go
+++ b/util/util.go
@@ -372,8 +372,11 @@ func AnalyzeAndPrint(
 		return nil
 	}
 
+	// A contract creation has no destination to classify or fetch an ABI
+	// for; the analyzer reports it from the receipt.
 	if txinfo.Tx.To() == nil {
-		return nil
+		result := analyzer.AnalyzeOffline(&txinfo, GetABI, customABIs, false)
+		return DisplayTxResult(u, result, network, layout, tx)
 	}
 	contractAddress := txinfo.Tx.To().Hex()
 
@@ -383,21 +386,30 @@ func AnalyzeAndPrint(
 		return nil
 	}
 
-	var result *jarviscommon.TxResult
-
+	lookup := GetABI
 	if isContract {
 		if a == nil {
+			// An unavailable ABI (unverified contract, explorer outage) must
+			// not hide the transaction: the analyzer falls back to the ERC-20
+			// ABI and reports what it could not decode. Remember the failure
+			// so the analyzer doesn't repeat the lookup for the same address.
 			a, err = ConfigToABI(contractAddress, forceERC20ABI, customABI, network)
 			if err != nil {
-				u.Error("Couldn't get abi for %s: %s", contractAddress, err)
-				return nil
+				a = nil
+				abiErr := err
+				lookup = func(addr string, n networks.Network) (*abi.ABI, error) {
+					if strings.EqualFold(addr, contractAddress) {
+						return nil, abiErr
+					}
+					return GetABI(addr, n)
+				}
 			}
 		}
-		customABIs[strings.ToLower(txinfo.Tx.To().Hex())] = a
-		result = analyzer.AnalyzeOffline(&txinfo, GetABI, customABIs, true)
-	} else {
-		result = analyzer.AnalyzeOffline(&txinfo, GetABI, nil, false)
+		if a != nil {
+			customABIs[strings.ToLower(txinfo.Tx.To().Hex())] = a
+		}
 	}
+	result := analyzer.AnalyzeOffline(&txinfo, lookup, customABIs, isContract)
 
 	return DisplayTxResult(u, result, network, layout, tx)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Batch A of the follow-up review of `improved-ui`, run against live mainnet transactions. Everything here is a behaviour fix; the layout itself is unchanged.

### Amounts were truncated one unit short

`common.FloatStringToBig` multiplied a default-precision `big.Float`, so `0.001 USDC` became `999` and `0.1 ETH` was 1 wei short. It now uses `big.Rat` (exact), accepts `,`/`_` digit separators and exponent notation, and truncates (never rounds up) digits beyond the token's precision. This helper backs `send --amount`, `--amount`/`-v`, and every `<amount> <TOKEN>` parameter input.

### `jarvis info` printed nothing for whole classes of txs

`util.AnalyzeAndPrint` returned early when the destination ABI could not be fetched (unverified contract, Etherscan rate limit) and when `To == nil`. Now:

- A missing ABI is remembered and passed to the analyzer, which falls back to the ERC-20 ABI and reports what it could not decode. The tx headline, value, gas, transfers and decodable events always print.
- Contract creations render as `✓ done   deploy contract  →  0xNew…`, with `To` taken from the receipt and logs analysed.
- A value transfer into a contract with empty calldata reads `transfer 0.0001 ETH to contract  →  …` instead of `<undecoded call>` plus a decode error.
- Calldata decode errors are `! calldata not decoded: …` warnings with a plain-language cause (unverified / selector not covered / does not match the ABI) instead of a red raw Go error.

### Undecoded logs no longer vanish

`AnalyzeLog` used to drop any log whose emitter had no fetchable ABI, so a 126-log tx showed `Events (42)`. Now:

- Standard token events (ERC-20 `Transfer`/`Approval`, WETH `Deposit`/`Withdrawal`, `ApprovalForAll`, and the ERC-721 three-indexed variant picked by topic count) decode through a built-in ABI, so **Transfers** is complete without a block explorer.
- Anything else is kept as a raw log (`<undecoded>` + topics + data, muted) so `Events (N)` is honest, followed by one muted note about how many were shown raw.
- Transfer/Approval parties fall back to topic positions, so DAI/WETH-style `src`/`guy`/`wad` ABIs no longer produce approval rows with empty parties.

### Revert reasons

`EthReader.RevertData` replays a reverted tx (`eth_call` at the parent block, same from/to/value/gas/data) and extracts the `rpc.DataError` payload; `txanalyzer.DecodeRevertData` renders `Error(string)` as the quoted message, `Panic(uint256)` by meaning, custom errors by name when the ABI has them, otherwise `custom error 0x…`. Shown as a red `reason  …` line under the headline and as `revert_reason` in JSON. Best effort: any failure just leaves it out.

### Etherscan errors leaked the API key

Explorer errors now read `api.etherscan.io (chain 1): Contract source code not verified` — no URL, no key — and transient rate-limit responses are retried after a short pause (3 attempts).

## Tests

- `common`: exactness cases for `FloatStringToBig`.
- `util/explorers`: retry on rate limit; error text never contains the key (API and transport errors).
- `txanalyzer`: well-known event fallback (ERC-20 and ERC-721), raw undecoded logs, `DecodeRevertData` for all four shapes.
- `util`: revert reason line + JSON, creation and empty-calldata intents, raw event count/note, DAI-style transfer parties.

Verified live against a reverted 0x settler tx (`reason  custom error 0x97a6f3b9`), a value transfer to an unverified contract, a contract creation with 148 logs, and the rate-limited swap tx that previously printed nothing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

