### PR TITLE
info: denser compact layout (net effect, rounded amounts, wrapped events)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 Everything jarvis prints was reworked so that the information you act on
 comes first and reads the same way across `info`, signing and batch flows.
 No RPC, signing or storage behaviour changed. `--json-output` files are
-byte-for-byte compatible apart from the new `transfers`, `block_number` and
-per-log `address` fields.
+byte-for-byte compatible apart from the new `transfers`, `net_effect`,
+`revert_reason`, `block_number` and per-log `address` fields.
 
 ### `jarvis info <hash>`
 
@@ -18,10 +18,25 @@ per-log `address` fields.
   long `bytes` values collapse. Events are one line each.
 - `--degen` expands collapsed values, shows full addresses and switches the
   parameter list back to a bordered table.
-- Addresses are name-first (`me (0x9642…5D4E)`); only an *unknown call
-  target* is highlighted in yellow. Each tx ends with a one-line footer
-  (status, method, hash) so the outcome is visible even after a long event
-  list.
+- Addresses are name-first (`me (0x9642…5D4E)`); unknown ones are bare
+  short hex, the zero address is labelled. Only an *unknown call target* is
+  highlighted in yellow. Each tx ends with a one-line footer (status,
+  method, hash) so the outcome is visible even after a long event list.
+- **Net effect** block (per-address net token change) when a tx has four or
+  more transfers; the transfer list is capped at eight in the compact view.
+- Integers carry thousands separators (`1,000,000,000`); token amounts are
+  rounded to four decimals in compact views. `--degen`/JSON keep full
+  precision.
+- Event lines wrap to the terminal width instead of running off screen.
+- Revert reasons are recovered by replaying the call (`Error(string)`,
+  `Panic`, custom errors by name) and shown under the headline; JSON gains
+  `revert_reason` and `net_effect`.
+- `info` never gives up on a tx: unverified contracts, rate-limited
+  explorers, contract creations and plain value transfers into contracts
+  all render, with undecoded calls/events shown raw and counted.
+- Overloaded methods show their Solidity name (`execute`, not `execute0`).
+- The `Network:` header and the bare hash echo are gone; the network sits on
+  the details line.
 
 ### Interactive parameter entry
 

--- a/README.md
+++ b/README.md
@@ -146,39 +146,50 @@ this and always carries full, untruncated values.
 
 ```
 ✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)
-         from me (0x9642…5D4E)   value 0 ETH   gas 0.00213000 ETH   nonce 412   block 19234567
+         mainnet   from me (0x9642…5D4E)   value 0 ETH   gas 0.00213000 ETH   nonce 412   block 19234567
 
 Transfers
-  1000 USDC     me (0x9642…5D4E)  →  USDC/WETH pair (0x0d4a…1852)
+  1,000 USDC    me (0x9642…5D4E)  →  USDC/WETH pair (0x0d4a…1852)
   0.3121 WETH   USDC/WETH pair (0x0d4a…1852)  →  me (0x9642…5D4E)
 
 Call  swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)
-  amountIn      1000000000 (1‸000￺000￺000)  uint256
-  amountOutMin  311200000000000000 (311￺200￺000‸000￺000￺000)  uint256
+  amountIn      1,000,000,000  uint256
+  amountOutMin  311,200,000,000,000,000  uint256
   path          [2 items]  address[]
   ├─ USDC (0xA0b8…eB48)
   └─ WETH (0xC02a…6Cc2)
   to            me (0x9642…5D4E)  address
-  deadline      1725600000 (1‸725￺600￺000)  uint256
+  deadline      1,725,600,000  uint256
 
 Events (3)
-  1. Transfer  USDC token (0xA0b8…eB48)   from me (0x9642…5D4E)  to USDC/WETH pair (0x0d4a…1852)  value 1000000000 (1000 USDC)
-  2. Sync      USDC/WETH pair (0x0d4a…1852)   reserve0 5000000000000 (…)  reserve1 1500000000000000000000 (…)
-  3. Transfer  WETH token (0xC02a…6Cc2)   from USDC/WETH pair (0x0d4a…1852)  to me (0x9642…5D4E)  value 312100000000000000 (0.3121 WETH)
+  1. Transfer  USDC token (0xA0b8…eB48)   from me (0x9642…5D4E)  to USDC/WETH pair (0x0d4a…1852)  value 1,000 USDC
+  2. Sync      USDC/WETH pair (0x0d4a…1852)   reserve0 5,000,000,000,000  reserve1 1,500,000,000,000,000,000,000
+  3. Transfer  WETH token (0xC02a…6Cc2)   from USDC/WETH pair (0x0d4a…1852)  to me (0x9642…5D4E)  value 0.3121 WETH
 
 ✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)   0x3f9a…e1c2
 ```
 
 - The headline is status + what was called + where. The muted second line
-  holds the numbers you rarely need (gas, nonce, block).
-- **Transfers** is derived from the `Transfer` / `Approval` logs so asset
-  movement is visible without reading the events. Unlimited approvals are
-  marked `UNLIMITED`.
+  holds the numbers you rarely need (network, gas, nonce, block).
+- **Transfers** is derived from the `Transfer` / `Approval` / `Deposit` /
+  `Withdrawal` logs so asset movement is visible without reading the
+  events. Unlimited approvals are marked `UNLIMITED`. Standard token events
+  decode even when the emitting contract is unverified.
+- With four or more transfers a **Net effect** block comes first: one line
+  per address with its net change per token, sender first, so a swap that
+  hops through three pools still reads as "−1,000 USDC, +0.3121 WETH". The
+  transfer list is capped at eight lines in the compact view.
+- Unknown addresses are shown as bare short hex; `(zero address)` marks
+  mints and burns. Integers get thousands separators and token amounts are
+  rounded to four decimals (four significant digits below 1). `--degen` and
+  `--json-output` keep every digit.
 - Arrays longer than a few items and long `bytes` blobs are collapsed;
   `--degen` expands everything, shows full addresses and switches the
   parameter list to a table.
-- A reverted tx opens with `✗ reverted`; the revert reason, when known, is
-  the next line.
+- A reverted tx opens with `✗ reverted`; the revert reason, when it can be
+  recovered by replaying the call, is the red `reason` line under the
+  headline. Events that no ABI describes are listed as `<undecoded>` with
+  their raw topics so the event count is always complete.
 
 ### Signing screen
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -48,8 +48,13 @@ var txCmd = &cobra.Command{
 			}()
 		}
 
-		for _, t := range txs {
-			appUI.Info("%s", t)
+		for i, t := range txs {
+			if i > 0 {
+				appUI.Info("")
+			}
+			if len(txs) > 1 {
+				appUI.Info("%s", t)
+			}
 			d := util.AnalyzeAndPrint(
 				appUI,
 				tc.Reader,
@@ -63,7 +68,6 @@ var txCmd = &cobra.Command{
 				util.InfoLayout(config.DegenMode),
 			)
 			displays[t] = d
-			appUI.Info("")
 		}
 	},
 }

--- a/cmd/util/pre_process.go
+++ b/cmd/util/pre_process.go
@@ -121,7 +121,7 @@ func CommonNetworkPreprocess(u ui.UI, cmd *cobra.Command, args []string) error {
 	if err := config.SetNetwork(config.NetworkString); err != nil {
 		return err
 	}
-	u.Info("Network: %s", config.Network().GetName())
+	// The network is part of the tx details line; no separate header.
 
 	tc := TxContext{}
 

--- a/cmd/util/prompt_util_test.go
+++ b/cmd/util/prompt_util_test.go
@@ -142,7 +142,7 @@ func TestPromptFunctionCallDataEchoesCompactForm(t *testing.T) {
 		// folded into the "> answer" row.
 		"Info:   → [2 items]",
 		"Info:     ├─ alice (0xaAaA…1111)",
-		"Info:     └─ 0xBbbb…2222 (unknown)",
+		"Info:     └─ 0xBbbb…2222",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("entry count %d != %d:\n%s", len(got), len(want), strings.Join(got, "\n"))
@@ -188,7 +188,7 @@ func TestPromptFunctionCallDataPrefillDoesNotFold(t *testing.T) {
 		t.Fatalf("expected exactly one folded echo for the prompted slot, got %v", rewrites)
 	}
 	joined := strings.Join(infos, "\n")
-	if !strings.Contains(joined, "  → 0xd8dA…6045 (unknown)") || !strings.Contains(joined, "  → [0 items]") {
+	if !strings.Contains(joined, "  → 0xd8dA…6045") || !strings.Contains(joined, "  → [0 items]") {
 		t.Fatalf("prefilled slots should be echoed as plain lines:\n%s", joined)
 	}
 }

--- a/common/printer.go
+++ b/common/printer.go
@@ -32,26 +32,70 @@ func MaxUintLabel(value string) (string, bool) {
 	return label, ok
 }
 
+// ReadableNumber renders a big integer as "raw (grouped)" where grouped has
+// thousands separators: "1000000000 (1,000,000,000)". Well-known max-uint
+// sentinels render as their label. Short numbers are returned as is.
 func ReadableNumber(value string) string {
 	if label, ok := MaxUintLabel(value); ok {
 		return label
 	}
-	if len(value) <= 4 {
+	if len(strings.TrimPrefix(value, "-")) <= 4 {
 		return value
 	}
+	return fmt.Sprintf("%s (%s)", value, GroupDigits(value))
+}
 
-	digits := []string{}
-	for i := range value {
-		digits = append([]string{string(value[len(value)-1-i])}, digits...)
-		if (i+1)%3 == 0 && i < len(value)-1 {
-			if (i+1)%9 == 0 {
-				digits = append([]string{"‸"}, digits...)
-			} else {
-				digits = append([]string{"￺"}, digits...)
-			}
+// GroupDigits inserts thousands separators into the integer part of a
+// decimal number string: "1234567.891" → "1,234,567.891". Non-numeric input
+// is returned unchanged.
+func GroupDigits(value string) string {
+	sign := ""
+	if strings.HasPrefix(value, "-") {
+		sign, value = "-", value[1:]
+	}
+	intPart, frac := value, ""
+	if i := strings.IndexByte(value, '.'); i >= 0 {
+		intPart, frac = value[:i], value[i:]
+	}
+	for _, c := range intPart {
+		if c < '0' || c > '9' {
+			return sign + intPart + frac
 		}
 	}
-	return fmt.Sprintf("%s (%s)", value, strings.Join(digits, ""))
+	var b strings.Builder
+	for i, c := range intPart {
+		if i > 0 && (len(intPart)-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+		b.WriteRune(c)
+	}
+	return sign + b.String() + frac
+}
+
+// CompactAmount shortens a human token amount for dense read-only views:
+// thousands separators on the integer part and the fraction truncated to four
+// decimals (or four significant digits when the integer part is zero).
+// Precision is for the signing card and JSON; this is for scanning.
+func CompactAmount(human string) string {
+	intPart, frac := human, ""
+	if i := strings.IndexByte(human, '.'); i >= 0 {
+		intPart, frac = human[:i], human[i+1:]
+	}
+	if frac == "" {
+		return GroupDigits(intPart)
+	}
+	keep := 4
+	if strings.Trim(intPart, "-0") == "" {
+		keep = len(frac) - len(strings.TrimLeft(frac, "0")) + 4
+	}
+	if len(frac) > keep {
+		frac = frac[:keep]
+	}
+	frac = strings.TrimRight(frac, "0")
+	if frac == "" {
+		return GroupDigits(intPart)
+	}
+	return GroupDigits(intPart) + "." + frac
 }
 
 // PlainAddress formats an Address as a plain string with no ANSI color codes.
@@ -100,10 +144,22 @@ func NameFirst(addr Address, full bool) string {
 	if !full {
 		hex = ShortAddress(hex)
 	}
+	if IsZeroAddress(addr.Address) {
+		return hex + " (zero address)"
+	}
 	if !IsKnownAddress(addr) {
-		return hex + " (unknown)"
+		return hex
 	}
 	return fmt.Sprintf("%s (%s)", addr.Desc, hex)
+}
+
+// IsZeroAddress reports whether hex is 0x0000…0000, the conventional mint /
+// burn counterparty and "no address" sentinel.
+func IsZeroAddress(hex string) bool {
+	if !strings.HasPrefix(hex, "0x") || len(hex) != 42 {
+		return false
+	}
+	return strings.Trim(hex[2:], "0") == ""
 }
 
 // VerboseAddress formats an Address for terminal display. The description is

--- a/common/printer_test.go
+++ b/common/printer_test.go
@@ -28,8 +28,9 @@ func TestNameFirst(t *testing.T) {
 	}{
 		{known, false, "Uniswap V2 Router (0x7a25…488D)"},
 		{known, true, "Uniswap V2 Router (0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D)"},
-		{unknown, false, "0x9642…5D4E (unknown)"},
-		{blank, true, "0x9642b23Ed1E01Df1092B92641051881a322F5D4E (unknown)"},
+		{unknown, false, "0x9642…5D4E"},
+		{blank, true, "0x9642b23Ed1E01Df1092B92641051881a322F5D4E"},
+		{Address{Address: "0x0000000000000000000000000000000000000000"}, false, "0x0000…0000 (zero address)"},
 		{Address{}, false, ""},
 	}
 	for _, c := range cases {
@@ -45,5 +46,47 @@ func TestIsKnownAddress(t *testing.T) {
 	}
 	if !IsKnownAddress(Address{Desc: "USDC"}) {
 		t.Fatal("named address must count as known")
+	}
+}
+
+func TestGroupDigitsAndReadableNumber(t *testing.T) {
+	cases := map[string]string{
+		"1000000000":  "1,000,000,000",
+		"1234567.891": "1,234,567.891",
+		"-1234567":    "-1,234,567",
+		"999":         "999",
+		"0.5":         "0.5",
+		"abc":         "abc",
+	}
+	for in, want := range cases {
+		if got := GroupDigits(in); got != want {
+			t.Errorf("GroupDigits(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := ReadableNumber("1000000000"); got != "1000000000 (1,000,000,000)" {
+		t.Errorf("ReadableNumber = %q", got)
+	}
+	if got := ReadableNumber("1234"); got != "1234" {
+		t.Errorf("short numbers stay bare, got %q", got)
+	}
+}
+
+func TestCompactAmount(t *testing.T) {
+	cases := map[string]string{
+		"1000":                          "1,000",
+		"1000.5":                        "1,000.5",
+		"2552732552.244911963753134392": "2,552,732,552.2449",
+		"14.633701431326966591":         "14.6337",
+		"0.3121":                        "0.3121",
+		"0.051932126031271887":          "0.05193",
+		"0.000000123456":                "0.0000001234",
+		"1.00001":                       "1",
+		"0.0000000000000000001":         "0.0000000000000000001",
+		"0":                             "0",
+	}
+	for in, want := range cases {
+		if got := CompactAmount(in); got != want {
+			t.Errorf("CompactAmount(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/db/default_address_database.go
+++ b/db/default_address_database.go
@@ -33,26 +33,30 @@ func getDataFromDefaultFile() map[string]string {
 	file := path.Join(dir, "addresses.json")
 	fi, err := os.Lstat(file)
 	if err != nil {
-		fmt.Printf("reading addresses from ~/addresses.json failed: %s. Ignored.\n", err)
+		// Having no personal address book is the normal state for a fresh
+		// install; only a file that exists but can't be read is worth a note.
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "reading addresses from ~/addresses.json failed: %s. Ignored.\n", err)
+		}
 		return map[string]string{}
 	}
 	// if the file is a symlink
 	if fi.Mode()&os.ModeSymlink != 0 {
 		file, err = os.Readlink(file)
 		if err != nil {
-			fmt.Printf("reading addresses from ~/addresses.json failed: %s. Ignored.\n", err)
+			fmt.Fprintf(os.Stderr, "reading addresses from ~/addresses.json failed: %s. Ignored.\n", err)
 			return map[string]string{}
 		}
 	}
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
-		fmt.Printf("reading addresses from ~/addresses.json failed: %s. Ignored.\n", err)
+		fmt.Fprintf(os.Stderr, "reading addresses from ~/addresses.json failed: %s. Ignored.\n", err)
 		return map[string]string{}
 	}
 	result := map[string]string{}
 	err = json.Unmarshal(content, &result)
 	if err != nil {
-		fmt.Printf("reading addresses from ~/addresses.json failed: %s. Ignored.\n", err)
+		fmt.Fprintf(os.Stderr, "reading addresses from ~/addresses.json failed: %s. Ignored.\n", err)
 		return map[string]string{}
 	}
 

--- a/txanalyzer/analyzer.go
+++ b/txanalyzer/analyzer.go
@@ -450,7 +450,9 @@ func (self *TxAnalyzer) analyzeMethodCall(
 	if err != nil {
 		return "", []ParamResult{}, err
 	}
-	method = m.Name
+	// RawName is the Solidity name; Name carries go-ethereum's overload
+	// suffix ("execute0"), which means nothing to the operator.
+	method = m.RawName
 	ps, err := m.Inputs.UnpackValues(data[4:])
 	if err != nil {
 		return method, []ParamResult{}, err

--- a/ui/table.go
+++ b/ui/table.go
@@ -175,6 +175,12 @@ func shrinkToTerminal(widths []int) {
 // detectTerminalWidth returns os.Stdout's current column count, or 0
 // if we can't determine it (not a TTY, error, etc.) — callers treat 0
 // as "no cap".
+// TerminalWidth returns the current column count of stdout, or 0 when it is
+// not a terminal. Callers use 0 as "do not wrap".
+func TerminalWidth() int {
+	return detectTerminalWidth()
+}
+
 func detectTerminalWidth() int {
 	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
 		return w

--- a/util/display.go
+++ b/util/display.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"fmt"
+	"math/big"
+	"sort"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -139,6 +141,7 @@ func buildTxDisplay(result *jarviscommon.TxResult) *TxDisplay {
 		d.FunctionCall = buildFunctionCallDisplay(result.FunctionCall, false)
 	}
 	d.Transfers = buildTransfers(result.Logs)
+	d.NetEffect = buildNetEffect(d.Transfers, d.From)
 	for _, l := range result.Logs {
 		d.Logs = append(d.Logs, buildLogDisplay(l))
 	}
@@ -195,6 +198,107 @@ func buildTransfers(logs []jarviscommon.LogResult) []TransferDisplay {
 		out = append(out, td)
 	}
 	return out
+}
+
+// netEffectMinTransfers is the transfer count from which a per-address net
+// summary is worth printing; below it the list itself is the summary.
+const netEffectMinTransfers = 4
+
+// netEffectMaxRows caps the summary so it stays a summary.
+const netEffectMaxRows = 6
+
+// buildNetEffect folds transfers into per-address, per-token net changes.
+// Approvals are not movements and NFTs are counted as ±1. The sender comes
+// first; other addresses follow by how many tokens they touched. Mint/burn
+// counterparties (the zero address) are left out.
+func buildNetEffect(transfers []TransferDisplay, sender ui.StyledText) []NetEffectDisplay {
+	if len(transfers) < netEffectMinTransfers {
+		return nil
+	}
+	type tokenNet struct {
+		token ui.StyledText
+		net   *big.Rat
+	}
+	type addrNet struct {
+		addr   ui.StyledText
+		tokens []*tokenNet // insertion order
+		byName map[string]*tokenNet
+	}
+	addrs := map[string]*addrNet{}
+	order := []string{}
+	add := func(who ui.StyledText, token ui.StyledText, amount *big.Rat) {
+		if who.Text == "" || jarviscommon.IsZeroAddress(strings.Fields(who.Text)[0]) {
+			return
+		}
+		an := addrs[who.Text]
+		if an == nil {
+			an = &addrNet{addr: who, byName: map[string]*tokenNet{}}
+			addrs[who.Text] = an
+			order = append(order, who.Text)
+		}
+		tn := an.byName[token.Text]
+		if tn == nil {
+			tn = &tokenNet{token: token, net: new(big.Rat)}
+			an.byName[token.Text] = tn
+			an.tokens = append(an.tokens, tn)
+		}
+		tn.net.Add(tn.net, amount)
+	}
+	for _, t := range transfers {
+		amount := new(big.Rat)
+		if strings.HasPrefix(t.Amount, "#") {
+			amount.SetInt64(1)
+		} else if _, ok := amount.SetString(t.Amount); !ok {
+			continue
+		}
+		neg := new(big.Rat).Neg(amount)
+		switch t.Kind {
+		case "transfer":
+			add(t.From, t.Token, neg)
+			add(t.To, t.Token, amount)
+		case "deposit":
+			add(t.To, t.Token, amount)
+		case "withdrawal":
+			add(t.From, t.Token, neg)
+		}
+	}
+	rows := []NetEffectDisplay{}
+	for _, key := range order {
+		an := addrs[key]
+		row := NetEffectDisplay{Address: an.addr}
+		for _, tn := range an.tokens {
+			if tn.net.Sign() == 0 {
+				continue
+			}
+			row.Deltas = append(row.Deltas, signedAmount(tn.net)+" "+tn.token.Text)
+		}
+		if len(row.Deltas) > 0 {
+			rows = append(rows, row)
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if (rows[i].Address.Text == sender.Text) != (rows[j].Address.Text == sender.Text) {
+			return rows[i].Address.Text == sender.Text
+		}
+		return len(rows[i].Deltas) > len(rows[j].Deltas)
+	})
+	if len(rows) > netEffectMaxRows {
+		rows = rows[:netEffectMaxRows]
+	}
+	return rows
+}
+
+// signedAmount renders r as a decimal with an explicit sign and no trailing
+// zeros, exact to 18 places.
+func signedAmount(r *big.Rat) string {
+	s := r.FloatString(18)
+	if strings.Contains(s, ".") {
+		s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	}
+	if r.Sign() > 0 {
+		return "+" + s
+	}
+	return s
 }
 
 // transferAmount picks the amount-like argument of a token event and renders

--- a/util/display_model.go
+++ b/util/display_model.go
@@ -82,6 +82,14 @@ type TransferDisplay struct {
 	Unlimited bool `json:"unlimited,omitempty"`
 }
 
+// NetEffectDisplay is one address's net token position change across all the
+// transfers in a tx: what it ended up with, after intermediate hops cancel out.
+type NetEffectDisplay struct {
+	Address ui.StyledText `json:"address"`
+	// Deltas are signed human amounts with symbol, e.g. "-1000 USDC".
+	Deltas []string `json:"deltas"`
+}
+
 // TxDisplay is the complete human-readable view-model for a single analyzed
 // transaction. StyledText fields carry Severity annotations used only by the
 // terminal print phase; JSON consumers receive clean plain strings.
@@ -102,7 +110,10 @@ type TxDisplay struct {
 	TxType       string               `json:"tx_type"`
 	FunctionCall *FunctionCallDisplay `json:"function_call,omitempty"`
 	Transfers    []TransferDisplay    `json:"transfers,omitempty"`
-	Logs         []LogDisplay         `json:"logs,omitempty"`
+	// NetEffect summarises Transfers per address; only computed when there
+	// are enough transfers for the list alone to be hard to read.
+	NetEffect []NetEffectDisplay `json:"net_effect,omitempty"`
+	Logs      []LogDisplay       `json:"logs,omitempty"`
 	// RevertReason is the decoded revert payload of a reverted tx, when the
 	// replay could recover one.
 	RevertReason string `json:"revert_reason,omitempty"`

--- a/util/display_tx.go
+++ b/util/display_tx.go
@@ -29,6 +29,26 @@ var addressWithDesc = regexp.MustCompile(`(^|[^0-9a-fA-Fx])(0x[0-9a-fA-F]{40})( 
 
 var descDecimalSuffix = regexp.MustCompile(` - \d+$`)
 
+// The "raw (readable)" number forms produced by PlainValue. Compact layouts
+// keep only the readable half.
+var (
+	groupedInteger  = regexp.MustCompile(`\b(-?\d{5,}) \((-?[\d,]+)\)`)
+	tokenAmount     = regexp.MustCompile(`\b(\d+) \((-?\d+(?:\.\d+)?)( [^\s()]+)?\)`)
+	unlimitedAmount = regexp.MustCompile(`\b(\d+) \((uint\d+\.max(?: \(∞\))?), all ([^\s()]+)\)`)
+)
+
+// compactNumberText rewrites every "raw (readable)" integer and token amount
+// in text into its readable form only: "1000000000 (1,000,000,000)" becomes
+// "1,000,000,000" and "1000000 (1 USDC)" becomes "1 USDC".
+func compactNumberText(text string) string {
+	text = unlimitedAmount.ReplaceAllString(text, "$2 $3")
+	text = groupedInteger.ReplaceAllString(text, "$2")
+	return tokenAmount.ReplaceAllStringFunc(text, func(m string) string {
+		sub := tokenAmount.FindStringSubmatch(m)
+		return jarviscommon.CompactAmount(sub[2]) + sub[3]
+	})
+}
+
 // compactAddressText rewrites every "0x… (Desc)" occurrence in text into the
 // NameFirst / ShortAddress form. Text without addresses is returned unchanged.
 func compactAddressText(text string) string {
@@ -58,6 +78,9 @@ type txPrinter struct {
 	u       ui.UI
 	layout  TxLayout
 	compact bool // shorten addresses / hex, collapse long arrays
+	// width is the terminal column count used to wrap event lines; 0 disables
+	// wrapping (non-TTY output, tests).
+	width int
 	// expandAll keeps every array element visible even in compact mode; used
 	// when echoing user input, where hiding elements would hide typos.
 	expandAll bool
@@ -113,10 +136,16 @@ func (p txPrinter) valueTree(d ParamDisplay) []string {
 
 func (p txPrinter) text(st ui.StyledText) string {
 	t := st.Text
+	sev := st.Severity
 	if p.compact {
-		t = compactHex(compactAddressText(t))
+		t = compactHex(compactNumberText(compactAddressText(t)))
+		// Green for "in the address book" earns its keep on the signing
+		// card; in a dense read-only view it just competes with the status.
+		if sev == ui.SeveritySuccess {
+			sev = ui.SeverityInfo
+		}
 	}
-	return p.u.Style(ui.StyledText{Text: t, Severity: st.Severity})
+	return p.u.Style(ui.StyledText{Text: t, Severity: sev})
 }
 
 func (p txPrinter) muted(s string) string {
@@ -173,7 +202,7 @@ func (p txPrinter) headline(d *TxDisplay, network networks.Network) string {
 // what happened (headline), what moved (transfers), what was called, what was
 // emitted, and the headline again so the last line on screen is the summary.
 func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network, layout TxLayout) {
-	p := txPrinter{u: u, layout: layout, compact: layout != LayoutInfoFull}
+	p := txPrinter{u: u, layout: layout, compact: layout != LayoutInfoFull, width: ui.TerminalWidth()}
 
 	if d.TxType == "" {
 		u.Info("%s", p.headline(d, network))
@@ -196,6 +225,10 @@ func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network, layout TxLa
 	}
 
 	printed := false
+	if len(d.NetEffect) > 0 {
+		p.printNetEffect(d.NetEffect)
+		printed = true
+	}
 	if len(d.Transfers) > 0 {
 		p.printTransfers(d.Transfers)
 		printed = true
@@ -236,6 +269,9 @@ func (p txPrinter) details(d *TxDisplay, network networks.Network) string {
 		from = compactAddressText(from)
 	}
 	parts := []string{"from " + from}
+	if p.layout != LayoutPostSign {
+		parts = []string{network.GetName(), "from " + from}
+	}
 	if d.TxType != "normal" && d.Value != "" {
 		parts = append(parts, "value "+d.Value+" "+sym)
 	}
@@ -285,14 +321,69 @@ func (p txPrinter) printCard(d *TxDisplay, network networks.Network) {
 	p.u.KeyValueCells(rows)
 }
 
+// maxCompactTransfers caps the Transfers list in compact layouts. Past this
+// the Net effect block carries the meaning; -x still lists everything.
+const maxCompactTransfers = 8
+
+// printNetEffect renders the per-address summary: one line per address, its
+// token deltas coloured by sign.
+func (p txPrinter) printNetEffect(rows []NetEffectDisplay) {
+	p.u.Subsection("Net effect")
+	addrWidth := 0
+	plainAddr := func(r NetEffectDisplay) string {
+		if p.compact {
+			return compactAddressText(r.Address.Text)
+		}
+		return r.Address.Text
+	}
+	for _, r := range rows {
+		if w := ui.VisibleWidth(plainAddr(r)); w > addrWidth {
+			addrWidth = w
+		}
+	}
+	for _, r := range rows {
+		pad := strings.Repeat(" ", addrWidth-ui.VisibleWidth(plainAddr(r)))
+		deltas := make([]string, len(r.Deltas))
+		for i, delta := range r.Deltas {
+			text := delta
+			if p.compact {
+				amount, sym, _ := strings.Cut(delta, " ")
+				text = string(amount[0]) + jarviscommon.CompactAmount(amount[1:])
+				if sym != "" {
+					text += " " + compactAddressText(sym)
+				}
+			}
+			sev := ui.SeveritySuccess
+			if strings.HasPrefix(delta, "-") {
+				sev = ui.SeverityError
+			}
+			deltas[i] = p.u.Style(ui.StyledText{Text: text, Severity: sev})
+		}
+		p.u.Indent().Info("%s%s   %s", p.text(r.Address), pad, strings.Join(deltas, "   "))
+	}
+}
+
 func (p txPrinter) printTransfers(ts []TransferDisplay) {
-	p.u.Subsection("Transfers")
+	title := "Transfers"
+	hidden := 0
+	if p.compact && len(ts) > maxCompactTransfers {
+		title = fmt.Sprintf("Transfers (%d)", len(ts))
+		hidden = len(ts) - maxCompactTransfers
+		ts = ts[:maxCompactTransfers]
+	}
+	p.u.Subsection(title)
 	amountWidth := 0
+	amountText := func(t TransferDisplay) string {
+		if p.compact && !strings.HasPrefix(t.Amount, "#") {
+			return jarviscommon.CompactAmount(t.Amount)
+		}
+		return t.Amount
+	}
 	plain := func(t TransferDisplay) string {
 		if t.Unlimited {
 			return compactAddressText(t.Token.Text)
 		}
-		return t.Amount + " " + compactAddressText(t.Token.Text)
+		return amountText(t) + " " + compactAddressText(t.Token.Text)
 	}
 	for _, t := range ts {
 		if w := ui.VisibleWidth(plain(t)); w > amountWidth {
@@ -300,7 +391,7 @@ func (p txPrinter) printTransfers(ts []TransferDisplay) {
 		}
 	}
 	for _, t := range ts {
-		amount := t.Amount + " " + p.text(t.Token)
+		amount := amountText(t) + " " + p.text(t.Token)
 		if t.Unlimited {
 			amount = p.text(t.Token)
 		}
@@ -321,6 +412,9 @@ func (p txPrinter) printTransfers(ts []TransferDisplay) {
 			line = fmt.Sprintf("%s%s   %s  →  %s", amount, pad, p.text(t.From), p.text(t.To))
 		}
 		p.u.Indent().Info("%s", line)
+	}
+	if hidden > 0 {
+		p.u.Indent().Info("%s", p.muted(fmt.Sprintf("… %d more (-x lists all)", hidden)))
 	}
 }
 
@@ -507,16 +601,49 @@ func (p txPrinter) printEvents(logs []LogDisplay) {
 		} else {
 			name = p.bold(name)
 		}
-		line := fmt.Sprintf("%d. %s  %s", i+1, name, p.text(l.Address))
-		if len(args) > 0 {
-			line += "   " + strings.Join(args, "  ")
+		head := fmt.Sprintf("%d. %s  %s", i+1, name, p.text(l.Address))
+		// Continuation lines start under the address so the event name and
+		// number column stay scannable.
+		contIndent := len(fmt.Sprintf("%d. ", len(logs))) + nameWidth + 2
+		for _, line := range p.packArgs(head, args, contIndent, 2) {
+			p.u.Indent().Info("%s", line)
 		}
-		p.u.Indent().Info("%s", line)
 	}
 	if undecoded > 0 {
 		p.u.Indent().Info("%s", p.muted(fmt.Sprintf(
 			"%d event(s) shown raw: the emitting contract has no ABI available (unverified or explorer unreachable)", undecoded)))
 	}
+}
+
+// packArgs lays out args after head, greedily filling terminal lines. The
+// first line holds head plus as many args as fit; overflow lines are indented
+// by contIndent. baseIndent is the indentation the caller will add. With no
+// known width everything goes on one line.
+func (p txPrinter) packArgs(head string, args []string, contIndent, baseIndent int) []string {
+	if len(args) == 0 {
+		return []string{head}
+	}
+	avail := p.width - baseIndent
+	joined := head + "   " + strings.Join(args, "  ")
+	if p.width == 0 || ui.VisibleWidth(joined) <= avail {
+		return []string{joined}
+	}
+	lines := []string{}
+	cur, curW := head+" ", ui.VisibleWidth(head)+1
+	first := true
+	pad := strings.Repeat(" ", contIndent)
+	for _, a := range args {
+		w := ui.VisibleWidth(a)
+		if !first && curW+2+w > avail {
+			lines = append(lines, cur)
+			cur, curW = pad+a, contIndent+w
+			continue
+		}
+		cur += "  " + a
+		curW += 2 + w
+		first = false
+	}
+	return append(lines, cur)
 }
 
 func eventName(l LogDisplay) string {

--- a/util/display_tx_internal_test.go
+++ b/util/display_tx_internal_test.go
@@ -8,12 +8,12 @@ func TestCompactAddressText(t *testing.T) {
 	const hash = "0x3f9a1c2b4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e1c2"
 
 	cases := map[string]string{
-		a:                                 a[:6] + "…5D4E (unknown)",
+		a:                                 a[:6] + "…5D4E",
 		a + " (me)":                       "me (0x9642…5D4E)",
 		a + " (USDC - 6)":                 "USDC (0x9642…5D4E)",
-		a + " (unknown)":                  "0x9642…5D4E (unknown)",
-		"from " + a + " to " + b:          "from 0x9642…5D4E (unknown) to 0x7a25…488D (unknown)",
-		a + "," + b:                       "0x9642…5D4E (unknown),0x7a25…488D (unknown)",
+		a + " (unknown)":                  "0x9642…5D4E",
+		"from " + a + " to " + b:          "from 0x9642…5D4E to 0x7a25…488D",
+		a + "," + b:                       "0x9642…5D4E,0x7a25…488D",
 		hash:                              hash,
 		"1000000000 (1000 USDC)":          "1000000000 (1000 USDC)",
 		"0x" + a[2:] + "deadbeef":         "0x" + a[2:] + "deadbeef",
@@ -46,4 +46,50 @@ func repeatHex(unit string, n int) string {
 		out += unit
 	}
 	return out
+}
+
+func TestCompactNumberText(t *testing.T) {
+	cases := map[string]string{
+		"1000000000 (1,000,000,000)":                                        "1,000,000,000",
+		"amountIn 1000000000 (1,000,000,000) uint256":                       "amountIn 1,000,000,000 uint256",
+		"1000000 (1 USDC)":                                                  "1 USDC",
+		"2552732552244911963753134392 (2552732552.244911963753134392 PEPE)": "2,552,732,552.2449 PEPE",
+		"51932126031271887 (0.051932126031271887 WETH)":                     "0.05193 WETH",
+		"1234 (1.234)": "1.234",
+		"115792089237316195423570985008687907853269984665640564039457584007913129639935 (uint256.max (∞), all USDC)": "uint256.max (∞) USDC",
+		"18446744073709551615 (uint64.max, all X)": "uint64.max X",
+		"999": "999",
+		"0x3f9a1c2b4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e1c2": "0x3f9a1c2b4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e1c2",
+	}
+	for in, want := range cases {
+		if got := compactNumberText(in); got != want {
+			t.Errorf("compactNumberText(%q)\n got %q\nwant %q", in, got, want)
+		}
+	}
+}
+
+func TestPackArgsWrapsToTerminalWidth(t *testing.T) {
+	p := txPrinter{width: 36}
+	head := "1. Transfer  USDC"
+	args := []string{"from 0x9642…5D4E", "to 0x0d4a…1852", "value 1,000 USDC"}
+	lines := p.packArgs(head, args, 4, 2)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines at width 36, got %d: %q", len(lines), lines)
+	}
+	if lines[0] != "1. Transfer  USDC   from 0x9642…5D4E" {
+		t.Fatalf("first line %q", lines[0])
+	}
+	if lines[1] != "    to 0x0d4a…1852" || lines[2] != "    value 1,000 USDC" {
+		t.Fatalf("continuation lines %q", lines[1:])
+	}
+	// The first argument stays with the head even when tight; continuation
+	// lines must respect the width.
+	for _, l := range lines[1:] {
+		if w := len([]rune(l)) + 2; w > 36 {
+			t.Fatalf("line exceeds width: %q (%d)", l, w)
+		}
+	}
+	if got := (txPrinter{width: 0}).packArgs(head, args, 4, 2); len(got) != 1 {
+		t.Fatalf("no width must not wrap: %q", got)
+	}
 }

--- a/util/display_tx_test.go
+++ b/util/display_tx_test.go
@@ -110,19 +110,19 @@ func TestInfoLayoutOrdersByImportance(t *testing.T) {
 
 	want := []string{
 		"✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)",
-		"         from me (0x9642…5D4E)   value 0 ETH   gas 0.00213000 ETH   nonce 412   block 19234567",
+		"         mainnet   from me (0x9642…5D4E)   value 0 ETH   gas 0.00213000 ETH   nonce 412   block 19234567",
 		"Transfers",
-		"  1000 USDC     me (0x9642…5D4E)  →  USDC/WETH pair (0x0d4a…1852)",
+		"  1,000 USDC    me (0x9642…5D4E)  →  USDC/WETH pair (0x0d4a…1852)",
 		"  0.3121 WETH   USDC/WETH pair (0x0d4a…1852)  →  me (0x9642…5D4E)",
 		"Call  swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)",
-		"  amountIn      1000000000 (1‸000￺000￺000)  uint256",
+		"  amountIn      1,000,000,000  uint256",
 		"  path          [2 items]  address[]",
 		"  ├─ USDC (0xA0b8…eB48)",
 		"  └─ WETH (0xC02a…6Cc2)",
 		"  to            me (0x9642…5D4E)  address",
 		"Events (3)",
-		"  1. Transfer  USDC token (0xA0b8…eB48)   from me (0x9642…5D4E)  to USDC/WETH pair (0x0d4a…1852)  value 1000000000 (1000 USDC)",
-		"  2. Sync      USDC/WETH pair (0x0d4a…1852)   reserve0 5000000000000",
+		"  1. Transfer  USDC token (0xA0b8…eB48)   from me (0x9642…5D4E)  to USDC/WETH pair (0x0d4a…1852)  value 1,000 USDC",
+		"  2. Sync      USDC/WETH pair (0x0d4a…1852)   reserve0 5,000,000,000,000",
 		"✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)   0x3f9a…e1c2",
 	}
 	pos := -1
@@ -236,10 +236,10 @@ func TestPlainTransferIsHeadlineOnly(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines for a plain transfer, got %d:\n%s", len(lines), out)
 	}
-	if lines[0] != "✓ done   transfer 1.5 ETH  →  0x7a25…488D (unknown)" {
+	if lines[0] != "✓ done   transfer 1.5 ETH  →  0x7a25…488D" {
 		t.Fatalf("unexpected headline %q", lines[0])
 	}
-	if !strings.Contains(lines[1], "from me (0x9642…5D4E)   gas 0.00031500 ETH   nonce 7") {
+	if !strings.Contains(lines[1], "mainnet   from me (0x9642…5D4E)   gas 0.00031500 ETH   nonce 7") {
 		t.Fatalf("unexpected details %q", lines[1])
 	}
 }
@@ -348,7 +348,7 @@ func TestContractCreationAndEmptyCalldataIntents(t *testing.T) {
 	r.To = addr(routerHex, "")
 	r.Value = "0"
 	out := render(t, r, util.LayoutInfo, hashHex)
-	if !strings.HasPrefix(out, "✓ done   deploy contract  →  0x7a25…488D (unknown)") {
+	if !strings.HasPrefix(out, "✓ done   deploy contract  →  0x7a25…488D") {
 		t.Fatalf("creation headline:\n%s", out)
 	}
 
@@ -378,7 +378,7 @@ func TestUndecodedEventsAreCountedAndShownRaw(t *testing.T) {
 	if !strings.Contains(out, "Events (4)") {
 		t.Fatalf("undecoded logs must count:\n%s", out)
 	}
-	if !strings.Contains(out, "4. <undecoded>  0x0d4a…1852 (unknown)   topic0 0xabab") {
+	if !strings.Contains(out, "4. <undecoded>  0x0d4a…1852   topic0 0xabab") {
 		t.Fatalf("raw event line missing:\n%s", out)
 	}
 	if !strings.Contains(out, "1 event(s) shown raw") {
@@ -403,5 +403,73 @@ func TestTransfersUseTopicPositionsForDaiStyleNames(t *testing.T) {
 	out := render(t, r, util.LayoutInfo, hashHex)
 	if !strings.Contains(out, "5 WETH   me (0x9642…5D4E) approves  Uniswap V2 Router (0x7a25…488D)") {
 		t.Fatalf("dai-style approval parties missing:\n%s", out)
+	}
+}
+
+func TestNetEffectSummarisesManyTransfers(t *testing.T) {
+	me := addr(meHex, "me")
+	pair := addr(pairHex, "USDC/WETH pair")
+	router := addr(routerHex, "Uniswap V2 Router")
+	zero := addr("0x0000000000000000000000000000000000000000", "")
+	r := swapTxResult()
+	r.FunctionCall = nil
+	// me → router → pair → router → me: router is a pass-through and must not
+	// appear; a burn to the zero address must not add a row.
+	r.Logs = []jarviscommon.LogResult{
+		transferLog(usdcHex, "USDC", 6, me, router, "1000000000"),
+		transferLog(usdcHex, "USDC", 6, router, pair, "1000000000"),
+		transferLog(wethHex, "WETH", 18, pair, router, "312100000000000000"),
+		transferLog(wethHex, "WETH", 18, router, me, "312100000000000000"),
+		transferLog(usdcHex, "USDC", 6, pair, zero, "5000000"),
+	}
+	rec := ui.NewRecordingUI()
+	d := util.DisplayTxResult(rec, r, networks.EthereumMainnet, util.LayoutInfo, hashHex)
+	if len(d.NetEffect) != 2 {
+		t.Fatalf("expected 2 net rows (me, pair), got %+v", d.NetEffect)
+	}
+	if d.NetEffect[0].Address.Text != meHex+" (me)" {
+		t.Fatalf("sender must come first: %+v", d.NetEffect[0])
+	}
+	if got := strings.Join(d.NetEffect[0].Deltas, " | "); got != "-1000 USDC | +0.3121 WETH" {
+		t.Fatalf("sender deltas %q", got)
+	}
+	if got := strings.Join(d.NetEffect[1].Deltas, " | "); got != "+995 USDC | -0.3121 WETH" {
+		t.Fatalf("pair deltas %q", got)
+	}
+
+	out := render(t, r, util.LayoutInfo, hashHex)
+	if !strings.Contains(out, "Net effect\n  me (0x9642…5D4E)               -1,000 USDC   +0.3121 WETH\n") {
+		t.Fatalf("net effect block:\n%s", out)
+	}
+	if strings.Index(out, "Net effect") > strings.Index(out, "Transfers") {
+		t.Fatalf("net effect should precede the transfer list:\n%s", out)
+	}
+
+	r.Logs = r.Logs[:3]
+	d = util.DisplayTxResult(ui.NewRecordingUI(), r, networks.EthereumMainnet, util.LayoutInfo, hashHex)
+	if d.NetEffect != nil {
+		t.Fatalf("three transfers need no summary: %+v", d.NetEffect)
+	}
+}
+
+func TestCompactTransfersAreCapped(t *testing.T) {
+	me := addr(meHex, "me")
+	pair := addr(pairHex, "USDC/WETH pair")
+	r := swapTxResult()
+	r.FunctionCall = nil
+	r.Logs = nil
+	for i := 0; i < 11; i++ {
+		r.Logs = append(r.Logs, transferLog(usdcHex, "USDC", 6, me, pair, "1000000"))
+	}
+	out := render(t, r, util.LayoutInfo, hashHex)
+	if !strings.Contains(out, "Transfers (11)") || strings.Count(out, "1 USDC   me") != 8 {
+		t.Fatalf("compact layout should list 8 of 11 transfers:\n%s", out)
+	}
+	if !strings.Contains(out, "… 3 more (-x lists all)") {
+		t.Fatalf("hidden count missing:\n%s", out)
+	}
+	full := render(t, r, util.LayoutInfoFull, hashHex)
+	if strings.Count(full, "1 USDC   ") != 11 || strings.Contains(full, "more (-x") {
+		t.Fatalf("full layout must list every transfer:\n%s", full)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Batch B of the `improved-ui` follow-up, stacked on #118. All changes are in the compact `info` layouts; `--degen` and `--json-output` keep every digit and the full address form.

### What changed on screen

- **`(unknown)` is gone.** `NameFirst` renders unknown addresses as bare short hex (`0x9642…5D4E`); the zero address is labelled `(zero address)` so mints/burns are obvious. The signing card's full `0x… (unknown)` form is untouched.
- **Numbers.** `ReadableNumber` uses commas instead of the `‸`/`￺` glyphs (`1000000000 (1,000,000,000)`); compact layouts keep only the readable half (`1,000,000,000`). Token amounts read `1,000 USDC` instead of `1000000000 (1000 USDC)`, and `CompactAmount` rounds to four decimals (four significant digits below 1): `2,552,732,552.2449 PEPE`, `0.05193 WETH`. Max-uint reads `uint256.max (∞) USDC`.
- **Net effect.** With four or more transfers a new block precedes Transfers: one line per address with its net token change, sender first, then by number of tokens touched, capped at six rows; pass-through hops and zero-address counterparties fall out. Deltas are green/red by sign. `net_effect` is added to the JSON view-model.
- **Transfer cap.** Compact layouts list eight transfers and then `… N more (-x lists all)`; the heading becomes `Transfers (N)`.
- **Event lines wrap** to the terminal width (`ui.TerminalWidth()`), continuation lines indented under the address so the number/name column stays scannable. Non-TTY output is unchanged.
- **Colour.** In compact read-only views known addresses render plain instead of green, so status and warnings are the only colour. The signing card keeps green.
- **Header noise.** `info` no longer prints `Network: mainnet` or echoes the hash (network moved onto the details line; the hash is still echoed when several are given, and is in the footer). The `reading addresses from ~/addresses.json failed: no such file` warning is silenced when the file simply doesn't exist, and goes to stderr otherwise.
- **Overloads.** Methods show their Solidity name (`execute`) rather than go-ethereum's suffixed `Name` (`execute0`).

### Tests

`GroupDigits`/`ReadableNumber`/`CompactAmount`/`NameFirst` cases in `common`; `compactNumberText` and `packArgs` wrapping in `util` internal tests; net-effect construction (sender first, pass-through elimination, burn exclusion, threshold), rendering order, and the transfer cap in `util`. Existing expectations updated for the new number/address forms. README and CHANGELOG examples updated.

Verified live on a 148-log flash-loan arbitrage: the Net effect block reads as four lines while the transfer list is capped at eight; events wrap cleanly at 110 columns.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

