### PR TITLE
signing: wallet on the card, cost-first gas, balance warning, quiet cancel, explained failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,27 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 - Prompts say what will happen and what it costs, e.g.
   `Sign and broadcast (≈ 0.0017 ETH)?` /
   `Sign and submit this Safe proposal (off-chain, no gas)?`.
+- `Sign with` shows the wallet's own name when the address book has none,
+  plus the wallet kind (`ledger`, `trezor`, `keystore`) so a hardware prompt
+  is expected. Addresses are always EIP-55 checksummed; the token decimal
+  count no longer leaks into `Send to`.
+- Gas reads cost-first: `≈ 0.0017 ETH   (85,123 gas × max 20 gwei, tip 1.5
+  gwei)`.
+- New warning when the signer's balance does not cover value + max gas.
+- Declining the prompt prints `Cancelled — nothing was signed or sent.` and
+  exits quietly instead of "Failed to proceed after signing".
+- Gas-estimation failures are explained (insufficient funds with the
+  wallet's balance, reverting call) instead of dumping every node's error.
+- `send --to 0x…` accepts a literal address that is not in the address
+  book; `send -g <limit>` no longer drops the amount. EIP-7702 delegated
+  EOAs are not treated as contracts.
+
+### Interactive parameter entry (continued)
+
+- Integer parameters of an ERC-20 call echo with the token amount
+  (`1000000 (1 USDC)`); a rejected answer is followed by the accepted
+  input forms for that type. Integers accept `1e6`, `1_000_000` and
+  `1,000,000`; a bare fraction is rejected with a hint to add the token.
 
 ### Waiting and results
 

--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ Call  approve  →  0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (USDC)
   spender  0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D  address
   amount   uint256.max (∞)  uint256
 
-Sign with  0x9642b23Ed1E01Df1092B92641051881a322F5D4E (me)   mainnet
+Sign with  0x9642b23Ed1E01Df1092B92641051881a322F5D4E (me)   ledger   mainnet
 Send to    0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (USDC)
-Gas        max 20.0000 gwei, tip 1.5000 gwei · 85123 gas · ≈ 0.00170246 ETH   nonce 42
+Gas        ≈ 0.00170246 ETH   (85,123 gas × max 20 gwei, tip 1.5 gwei)   nonce 42
 
 ! approves UNLIMITED USDC to 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D
 ! spender 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D is not in your address book

--- a/cmd/contract.go
+++ b/cmd/contract.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 
@@ -18,8 +20,8 @@ import (
 )
 
 var composeDataContractCmd = &cobra.Command{
-	Use:   "encode",
-	Short: "Encode tx data to interact with smart contracts",
+	Use:              "encode",
+	Short:            "Encode tx data to interact with smart contracts",
 	TraverseChildren: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return cmdutil.CommonFunctionCallPreprocess(appUI, cmd, args)
@@ -163,7 +165,11 @@ var txContractCmd = &cobra.Command{
 		if gasLimit == 0 {
 			gasLimit, err = reader.EstimateExactGas(tc.From, tc.To, 0, tc.Value, data)
 			if err != nil {
-				appUI.Error("Couldn't estimate gas limit: %s", err)
+				var bal *big.Int
+				if b, berr := reader.GetBalance(tc.From); berr == nil {
+					bal = b
+				}
+				appUI.Error("%s", cmdutil.ExplainEstimateGasError(err, tc.From, bal, config.Network().GetNativeTokenSymbol()))
 				return
 			}
 		}
@@ -183,7 +189,7 @@ var txContractCmd = &cobra.Command{
 			appUI, tc.FromAcc, tx,
 			map[string]*abi.ABI{strings.ToLower(tc.To): a},
 			reader, tc.Analyzer, a, tc.Broadcaster,
-		); err != nil && !broadcasted {
+		); err != nil && !broadcasted && !errors.Is(err, cmdutil.ErrUserCancelled) {
 			appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
 		}
 	},
@@ -289,10 +295,10 @@ var readContractCmd = &cobra.Command{
 				appUI.Info("---------------------------------------------------")
 			}
 		} else {
-		resultJSON := contractReadResultJSON{
-			Result: nil,
-			Error:  "",
-		}
+			resultJSON := contractReadResultJSON{
+				Result: nil,
+				Error:  "",
+			}
 
 			if config.JSONOutputFile != "" {
 				defer resultJSON.Write(config.JSONOutputFile)

--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -945,7 +945,9 @@ func runNewSafe(cmd *cobra.Command, args []string) {
 		appUI, tc.FromAcc, tx, customABIs,
 		tc.Reader, tc.Analyzer, safe.GetProxyFactoryABI(), tc.Broadcaster,
 	); err != nil && !broadcasted {
-		appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
+		if !errors.Is(err, cmdutil.ErrUserCancelled) {
+			appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
+		}
 		return
 	}
 

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -64,7 +64,9 @@ func handleMsigSend(
 		if errors.Is(err, cmdutil.ErrWalletUnlock) {
 			os.Exit(126)
 		}
-		appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
+		if !errors.Is(err, cmdutil.ErrUserCancelled) {
+			appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
+		}
 	}
 }
 
@@ -126,7 +128,9 @@ func handleSend(
 		if errors.Is(err, cmdutil.ErrWalletUnlock) {
 			os.Exit(126)
 		}
-		appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
+		if !errors.Is(err, cmdutil.ErrUserCancelled) {
+			appUI.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
+		}
 	}
 }
 
@@ -319,7 +323,7 @@ func sendFromMsig(reader utilreader.Reader, analyzer util.TxAnalyzer, resolver c
 			gasLimit, err = reader.EstimateGas(fromAddr, msigContractAddr, gasPrice+config.ExtraGasPrice, 0, txdata)
 		}
 		if err != nil {
-			appUI.Error("Couldn't estimate gas: %s", err)
+			appUI.Error("%s", cmdutil.ExplainEstimateGasError(err, fromAddr, balanceOrNil(reader, fromAddr), config.Network().GetNativeTokenSymbol()))
 			return
 		}
 	}
@@ -444,61 +448,69 @@ exact addresses start with 0x.`,
 			}
 		}
 
+		// The amount is resolved whether or not the gas limit was given
+		// explicitly: an operator passing -g must never end up sending 0.
 		var amountWei *big.Int
 		gasLimit := config.GasLimit
-		if gasLimit == 0 {
-			if tokenAddrLocal == util.ETH_ADDR {
-				if amountStr == "ALL" {
-					gasLimit, err = reader.EstimateExactGas(fromAddr, toAddr, 0, big.NewInt(1), cmdutil.StringParamToBytes(data))
-					if err != nil {
-						appUI.Error("Getting estimated gas for the tx failed: %s", err)
-						return
-					}
-					extraGasLimit = 0 // exact gas for ALL; no extra needed
-
-					gasCost := big.NewInt(0).Mul(
-						big.NewInt(int64(gasLimit)),
-						jarviscommon.FloatToBigInt(gasPrice+config.ExtraGasPrice, 9),
-					)
-					amountWei, err = cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
-						TokenAddr:      tokenAddrLocal,
-						AmountStr:      amountStr,
-						Holder:         fromAddr,
-						NativeDecimals: config.Network().GetNativeTokenDecimal(),
-						SubtractGas:    gasCost,
-					})
-					if err != nil {
-						appUI.Error("%s", sendAmountUserErrorEOA(err, tokenAddrLocal))
-						return
-					}
-				} else {
-					amountWei, err = cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
-						TokenAddr:      tokenAddrLocal,
-						AmountStr:      amountStr,
-						Holder:         fromAddr,
-						NativeDecimals: config.Network().GetNativeTokenDecimal(),
-					})
-					if err != nil {
-						appUI.Error("%s", sendAmountUserErrorEOA(err, tokenAddrLocal))
-						return
-					}
-					gasLimit, err = reader.EstimateExactGas(fromAddr, toAddr, 0, amountWei, cmdutil.StringParamToBytes(data))
-					if err != nil {
-						appUI.Error("Getting estimated gas for the tx failed: %s", err)
-						return
-					}
-				}
-			} else {
-				amountWei, err = cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
-					TokenAddr:      tokenAddrLocal,
-					AmountStr:      amountStr,
-					Holder:         fromAddr,
-					NativeDecimals: config.Network().GetNativeTokenDecimal(),
-				})
+		estimate := gasLimit == 0
+		explain := func(err error) {
+			appUI.Error("%s", cmdutil.ExplainEstimateGasError(err, fromAddr, balanceOrNil(reader, fromAddr), config.Network().GetNativeTokenSymbol()))
+		}
+		switch {
+		case tokenAddrLocal == util.ETH_ADDR && amountStr == "ALL":
+			if estimate {
+				gasLimit, err = reader.EstimateExactGas(fromAddr, toAddr, 0, big.NewInt(1), cmdutil.StringParamToBytes(data))
 				if err != nil {
-					appUI.Error("%s", sendAmountUserErrorEOA(err, tokenAddrLocal))
+					explain(err)
 					return
 				}
+				extraGasLimit = 0 // exact gas for ALL; no extra needed
+			}
+			gasCost := big.NewInt(0).Mul(
+				big.NewInt(int64(gasLimit+extraGasLimit)),
+				jarviscommon.FloatToBigInt(gasPrice+config.ExtraGasPrice, 9),
+			)
+			amountWei, err = cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
+				TokenAddr:      tokenAddrLocal,
+				AmountStr:      amountStr,
+				Holder:         fromAddr,
+				NativeDecimals: config.Network().GetNativeTokenDecimal(),
+				SubtractGas:    gasCost,
+			})
+			if err != nil {
+				appUI.Error("%s", sendAmountUserErrorEOA(err, tokenAddrLocal))
+				return
+			}
+		case tokenAddrLocal == util.ETH_ADDR:
+			amountWei, err = cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
+				TokenAddr:      tokenAddrLocal,
+				AmountStr:      amountStr,
+				Holder:         fromAddr,
+				NativeDecimals: config.Network().GetNativeTokenDecimal(),
+			})
+			if err != nil {
+				appUI.Error("%s", sendAmountUserErrorEOA(err, tokenAddrLocal))
+				return
+			}
+			if estimate {
+				gasLimit, err = reader.EstimateExactGas(fromAddr, toAddr, 0, amountWei, cmdutil.StringParamToBytes(data))
+				if err != nil {
+					explain(err)
+					return
+				}
+			}
+		default:
+			amountWei, err = cmdutil.ResolveSendAmountWei(reader, cmdutil.AmountWeiOpts{
+				TokenAddr:      tokenAddrLocal,
+				AmountStr:      amountStr,
+				Holder:         fromAddr,
+				NativeDecimals: config.Network().GetNativeTokenDecimal(),
+			})
+			if err != nil {
+				appUI.Error("%s", sendAmountUserErrorEOA(err, tokenAddrLocal))
+				return
+			}
+			if estimate {
 				innerData, err := jarviscommon.PackERC20Data("transfer", jarviscommon.HexToAddress(toAddr), amountWei)
 				if err != nil {
 					appUI.Error("Couldn't pack data: %s", err)
@@ -506,7 +518,7 @@ exact addresses start with 0x.`,
 				}
 				gasLimit, err = reader.EstimateGas(fromAddr, tokenAddrLocal, gasPrice+config.ExtraGasPrice, 0, innerData)
 				if err != nil {
-					appUI.Error("Couldn't estimate gas limit: %s", err)
+					explain(err)
 					return
 				}
 			}
@@ -745,4 +757,19 @@ func init() {
 	sendCmd.MarkFlagRequired("amount")
 
 	rootCmd.AddCommand(sendCmd)
+}
+
+// balanceOrNil fetches the native balance for error messages; nil when the
+// lookup fails so the message degrades to "no balance information".
+func balanceOrNil(reader interface {
+	GetBalance(address string) (*big.Int, error)
+}, addr string) *big.Int {
+	if reader == nil {
+		return nil
+	}
+	bal, err := reader.GetBalance(addr)
+	if err != nil {
+		return nil
+	}
+	return bal
 }

--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/big"
 	"sort"
 	"strconv"
 	"strings"
@@ -120,8 +122,12 @@ const foldableInputLen = 60
 // echoParam shows what jarvis understood from the user's answer. The first
 // line replaces the raw "> answer" row on a TTY (when it is short enough to be
 // sure it occupied one row); nested values follow as an indented tree.
-func echoParam(u ui.UI, analyzer util.TxAnalyzer, input abi.Argument, value any, raw string, fold bool) {
-	d := util.NewParamDisplay(analyzer.ParamAsJarvisParamResult(input.Name, input.Type, value))
+func echoParam(u ui.UI, analyzer util.TxAnalyzer, contract string, input abi.Argument, value any, raw string, fold bool) {
+	// Only integers can be token amounts; skip the ERC-20 lookup otherwise.
+	if t := input.Type.T; t != abi.UintTy && t != abi.IntTy {
+		contract = ""
+	}
+	d := util.NewParamDisplay(analyzer.ParamAsJarvisParamResultFor(contract, input.Name, input.Type, value))
 	lines := util.ParamValueLines(u, d)
 	if len(lines) == 0 {
 		return
@@ -147,10 +153,42 @@ type SigningNote struct {
 	// ExecutesSafeTxHash marks the tx as the execTransaction of a Safe tx the
 	// user has just reviewed, so the card links to it and collapses the call.
 	ExecutesSafeTxHash string
+	// WalletName and WalletKind describe the signing account; the name fills
+	// in for an address-book entry when there is none, the kind is shown
+	// next to the signer.
+	WalletName string
+	WalletKind string
+	// SignerBalance, when known, enables the insufficient-funds warning.
+	SignerBalance *big.Int
 }
 
 // SetNextSigningNote attaches a note to the next PromptTxConfirmation call.
 func SetNextSigningNote(n SigningNote) { nextSigningNote = &n }
+
+// mergeSigningNote fills the empty fields of the pending note from n, so a
+// caller that only knows the wallet does not erase a caller that only knows
+// the Safe context (or vice versa).
+func mergeSigningNote(n SigningNote) {
+	if nextSigningNote == nil {
+		nextSigningNote = &SigningNote{}
+	}
+	if nextSigningNote.ExecutesSafeTxHash == "" {
+		nextSigningNote.ExecutesSafeTxHash = n.ExecutesSafeTxHash
+	}
+	if nextSigningNote.WalletName == "" {
+		nextSigningNote.WalletName = n.WalletName
+	}
+	if nextSigningNote.WalletKind == "" {
+		nextSigningNote.WalletKind = n.WalletKind
+	}
+	if nextSigningNote.SignerBalance == nil {
+		nextSigningNote.SignerBalance = n.SignerBalance
+	}
+}
+
+// ErrUserCancelled is returned when the operator declines the signing card.
+// Nothing has been signed or sent at that point; callers should exit quietly.
+var ErrUserCancelled = errors.New("cancelled by user")
 
 // PromptTxConfirmation displays the signing card for tx and asks the user to
 // confirm before signing. Returns an error if the user aborts.
@@ -170,7 +208,8 @@ func PromptTxConfirmation(
 		return err
 	}
 	if !ConfirmSigningCard(u, card) {
-		return fmt.Errorf("user aborted")
+		u.Warn("Cancelled — nothing was signed or sent.")
+		return ErrUserCancelled
 	}
 	return nil
 }
@@ -188,16 +227,33 @@ func buildEOASigningCard(
 	note *SigningNote,
 ) (*SigningCard, error) {
 	symbol := network.GetNativeTokenSymbol()
+	// The card shows checksummed hex whatever form the wallet file stored.
+	from.Address = jarviscommon.HexToAddress(from.Address).Hex()
+	if note != nil && note.WalletName != "" && !jarviscommon.IsKnownAddress(from) {
+		from.Desc = note.WalletName
+	}
+	legacy := tx.Type() == types.LegacyTxType
+	price := tx.GasFeeCap()
+	if legacy {
+		price = tx.GasPrice()
+	}
 	card := &SigningCard{
 		Kind:    "EOA transaction",
 		Network: network.GetName(),
 		Signer:  util.StyledAddress(from),
 		Nonce:   fmt.Sprintf("%d", tx.Nonce()),
-		Gas: FormatGasLine(tx.Type() == types.LegacyTxType,
-			tx.GasPrice(), tx.GasFeeCap(), tx.GasTipCap(), tx.Gas(), symbol),
+		Gas:     FormatGasLine(legacy, tx.GasPrice(), tx.GasFeeCap(), tx.GasTipCap(), tx.Gas(), symbol),
+	}
+	if note != nil {
+		card.Wallet = note.WalletKind
 	}
 	if tx.Value().Sign() > 0 {
 		card.Value = jarviscommon.BigToFloatString(tx.Value(), network.GetNativeTokenDecimal()) + " " + symbol
+	}
+	maxCost := new(big.Int).Add(tx.Value(), MaxGasCost(price, tx.Gas()))
+	var balance *big.Int
+	if note != nil {
+		balance = note.SignerBalance
 	}
 
 	if tx.To() == nil {
@@ -205,6 +261,9 @@ func buildEOASigningCard(
 		if len(tx.Data()) > 0 {
 			card.RawData = "0x" + ethcommon.Bytes2Hex(tx.Data())
 		}
+		card.Warnings = SigningWarnings(WarningInput{
+			Value: tx.Value(), NativeSymbol: symbol, SignerBalance: balance, MaxCost: maxCost,
+		})
 		card.Prompt = fmt.Sprintf("Sign and broadcast contract creation (%s)?", gasCostOnly(card.Gas))
 		return card, nil
 	}
@@ -224,7 +283,7 @@ func buildEOASigningCard(
 	}
 	warn := WarningInput{
 		To: to, ToIsContract: isContract, Value: tx.Value(), NativeSymbol: symbol,
-		HasData: len(tx.Data()) > 0,
+		HasData: len(tx.Data()) > 0, SignerBalance: balance, MaxCost: maxCost,
 	}
 
 	var fc *jarviscommon.FunctionCall
@@ -260,10 +319,10 @@ func buildEOASigningCard(
 	return card, nil
 }
 
-// gasCostOnly extracts the "≈ 0.0017 ETH" tail of a FormatGasLine string.
+// gasCostOnly extracts the "≈ 0.0017 ETH" head of a FormatGasLine string.
 func gasCostOnly(gas string) string {
-	if i := strings.LastIndex(gas, "≈"); i >= 0 {
-		return gas[i:]
+	if i := strings.Index(gas, "   ("); i >= 0 {
+		return gas[:i]
 	}
 	return gas
 }
@@ -422,17 +481,39 @@ func PromptFunctionCallData(
 		inputParam, err := ConvertParamInput(input, raw, network)
 		if err != nil {
 			paramUI.Error("✗ %s", err)
+			if hint := inputHint(input.Type, network); hint != "" && interactive {
+				paramUI.Info("%s", paramUI.Style(ui.StyledText{Text: hint, Severity: ui.SeverityMuted}))
+			}
 			if !interactive {
 				return nil, nil, fmt.Errorf("your input is not valid: %w", err)
 			}
 			continue
 		}
 
-		echoParam(paramUI, analyzer, input, inputParam, raw, interactive)
+		echoParam(paramUI, analyzer, contractAddress, input, inputParam, raw, interactive)
 		params = append(params, inputParam)
 		pi++
 	}
 	return method, params, nil
+}
+
+// inputHint is the one-line reminder of the accepted input forms for a type,
+// shown after a rejected answer so the operator doesn't have to guess.
+func inputHint(t abi.Type, network jarvisnetworks.Network) string {
+	switch t.T {
+	case abi.UintTy, abi.IntTy:
+		return fmt.Sprintf("accepted: raw integer (1000000), hex (0xf4240), or amount with token (0.5 %s, 1000 USDC)",
+			network.GetNativeTokenSymbol())
+	case abi.AddressTy:
+		return "accepted: 0x address or an address-book name (jarvis addr to list)"
+	case abi.BoolTy:
+		return "accepted: true / false"
+	case abi.BytesTy, abi.FixedBytesTy:
+		return "accepted: 0x-prefixed hex"
+	case abi.SliceTy, abi.ArrayTy:
+		return "accepted: comma-separated items in brackets, e.g. [a, b, c]"
+	}
+	return ""
 }
 
 // renderContractClearSign asks the shared ERC-7730 engine for a

--- a/cmd/util/prompt_util_test.go
+++ b/cmd/util/prompt_util_test.go
@@ -133,6 +133,7 @@ func TestPromptFunctionCallDataEchoesCompactForm(t *testing.T) {
 		"Info: doStuff  →  0x1234567890123456789012345678901234567890",
 		"Info: 1. to  address",
 		"Error: ✗ ",
+		"Info: accepted: 0x address or an address-book name",
 		"Info: 1. to  address", // label repeats so the retry prompt is labelled
 		"Rewrite:   → Vitalik Buterin (0xd8dA…6045)",
 		"Info: 2. amount  uint256",

--- a/cmd/util/send_transfer.go
+++ b/cmd/util/send_transfer.go
@@ -49,7 +49,13 @@ func ResolveSendTransfer(resolver ABIResolver, value, to string) (SendTransfer, 
 
 	dest, _, err := resolver.GetMatchingAddress(to)
 	if err != nil {
-		return SendTransfer{}, fmt.Errorf("%w: %s", ErrSendDestNotFound, to)
+		// A literal address is a valid destination even when the book has
+		// never seen it; the signing card will flag it as unknown.
+		if addrs := jarvisutil.ScanForAddresses(to); len(addrs) == 1 {
+			dest = addrs[0]
+		} else {
+			return SendTransfer{}, fmt.Errorf("%w: %s", ErrSendDestNotFound, to)
+		}
 	}
 
 	return SendTransfer{

--- a/cmd/util/signing_card.go
+++ b/cmd/util/signing_card.go
@@ -22,6 +22,10 @@ type SigningCard struct {
 	Network string
 
 	Signer ui.StyledText
+	// Wallet is the signing device or key kind ("ledger", "trezor",
+	// "keystore"); shown muted next to the signer so a hardware prompt is
+	// expected rather than a surprise.
+	Wallet string
 	To     ui.StyledText // empty Text for contract creation; see CreateAddress
 	// CreateAddress is the predicted address when the tx deploys a contract.
 	CreateAddress string
@@ -77,6 +81,7 @@ func ShowSigningCard(u ui.UI, c *SigningCard) {
 		c.ClearSign(u)
 	}
 
+	body := c.ClearSign != nil || c.Call != nil || c.RawData != ""
 	switch {
 	case c.Call != nil && c.CollapseCall:
 		u.Subsection(fmt.Sprintf("Call  %s  →  %s   %s",
@@ -92,6 +97,9 @@ func ShowSigningCard(u ui.UI, c *SigningCard) {
 	label := func(s string) ui.TableCell { return ui.TCS(s, ui.SeverityMuted) }
 	rows := [][2]ui.TableCell{}
 	signer := c.Signer.Text
+	if c.Wallet != "" {
+		signer += "   " + c.Wallet
+	}
 	if c.Network != "" {
 		signer += "   " + c.Network
 	}
@@ -141,7 +149,9 @@ func ShowSigningCard(u ui.UI, c *SigningCard) {
 			), ui.SeverityMuted)})
 		}
 	}
-	u.Info("")
+	if body {
+		u.Info("")
+	}
 	u.KeyValueCells(rows)
 
 	if c.Safe != nil && (len(c.Safe.Signatures) > 0 || c.Safe.Threshold > 0) {
@@ -205,6 +215,10 @@ type WarningInput struct {
 	Call         *jarviscommon.FunctionCall
 	DelegateCall bool
 	MultiSend    bool
+	// SignerBalance and MaxCost enable the insufficient-funds warning; either
+	// nil skips it. MaxCost is value + gasLimit × max fee.
+	SignerBalance *big.Int
+	MaxCost       *big.Int
 }
 
 // approvalMethods maps ERC-20/721/1155 approval selectors to the parameter
@@ -228,6 +242,11 @@ func SigningWarnings(in WarningInput) []string {
 	if in.Value != nil && in.Value.Sign() > 0 && in.ToIsContract {
 		out = append(out, fmt.Sprintf("sends %s %s into a contract",
 			jarviscommon.BigToFloatString(in.Value, 18), in.NativeSymbol))
+	}
+	if in.SignerBalance != nil && in.MaxCost != nil && in.SignerBalance.Cmp(in.MaxCost) < 0 {
+		out = append(out, fmt.Sprintf("balance %s %s does not cover value + max gas (%s %s); the tx would be rejected",
+			jarviscommon.CompactAmount(jarviscommon.BigToFloatString(in.SignerBalance, 18)), in.NativeSymbol,
+			jarviscommon.CompactAmount(jarviscommon.BigToFloatString(in.MaxCost, 18)), in.NativeSymbol))
 	}
 	if in.DelegateCall {
 		if in.MultiSend {
@@ -295,18 +314,65 @@ func isMaxUint(raw string) bool {
 	return ok
 }
 
-// FormatGasLine renders the fee parameters of a tx in one line:
-// "max 20.0000 gwei, tip 1.5000 gwei · 85123 gas · ≈ 0.00170246 ETH".
+// FormatGasLine renders the fee parameters of a tx in one line, cost first:
+// "≈ 0.00170246 ETH   (85,123 gas × max 20 gwei, tip 1.5 gwei)".
 func FormatGasLine(legacy bool, gasPrice, feeCap, tipCap *big.Int, gasLimit uint64, symbol string) string {
 	price := feeCap
 	if legacy {
 		price = gasPrice
 	}
-	cost := jarviscommon.BigToFloat(new(big.Int).Mul(new(big.Int).SetUint64(gasLimit), price), 18)
+	cost := jarviscommon.BigToFloat(MaxGasCost(price, gasLimit), 18)
+	gas := jarviscommon.GroupDigits(fmt.Sprintf("%d", gasLimit))
 	if legacy {
-		return fmt.Sprintf("%.4f gwei · %d gas · ≈ %.8f %s",
-			jarviscommon.BigToFloat(gasPrice, 9), gasLimit, cost, symbol)
+		return fmt.Sprintf("≈ %.8f %s   (%s gas × %s gwei)", cost, symbol, gas, gweiText(gasPrice))
 	}
-	return fmt.Sprintf("max %.4f gwei, tip %.4f gwei · %d gas · ≈ %.8f %s",
-		jarviscommon.BigToFloat(feeCap, 9), jarviscommon.BigToFloat(tipCap, 9), gasLimit, cost, symbol)
+	return fmt.Sprintf("≈ %.8f %s   (%s gas × max %s gwei, tip %s gwei)",
+		cost, symbol, gas, gweiText(feeCap), gweiText(tipCap))
+}
+
+// MaxGasCost is gasLimit × price: the most the fee can come to.
+func MaxGasCost(price *big.Int, gasLimit uint64) *big.Int {
+	if price == nil {
+		return new(big.Int)
+	}
+	return new(big.Int).Mul(new(big.Int).SetUint64(gasLimit), price)
+}
+
+// gweiText renders a wei amount in gwei with up to four decimals and no
+// trailing zeros: 20 → "20", 1.5 → "1.5", 0.01234 → "0.0123".
+func gweiText(wei *big.Int) string {
+	s := fmt.Sprintf("%.4f", jarviscommon.BigToFloat(wei, 9))
+	s = strings.TrimRight(s, "0")
+	return strings.TrimSuffix(s, ".")
+}
+
+// ExplainEstimateGasError turns the multi-node error from a failed gas
+// estimation into one sentence the operator can act on. Nodes disagree on
+// wording, so the classification is by keyword; anything unrecognised is
+// reported as the first node's message.
+func ExplainEstimateGasError(err error, from string, balance *big.Int, symbol string) string {
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "insufficient funds") || strings.Contains(lower, "outoffunds") || strings.Contains(lower, "out of funds"):
+		have := "no"
+		if balance != nil {
+			have = jarviscommon.BigToFloatString(balance, 18)
+		}
+		return fmt.Sprintf("Gas estimation failed: %s holds %s %s, not enough for the value plus gas. Fund the wallet or lower the amount.",
+			from, have, symbol)
+	case strings.Contains(lower, "execution reverted") || strings.Contains(lower, "revert"):
+		reason := ""
+		if i := strings.Index(lower, "revert"); i >= 0 {
+			rest := strings.TrimSpace(msg[i+len("revert"):])
+			rest = strings.TrimPrefix(strings.TrimPrefix(rest, "ed"), ":")
+			if line := strings.SplitN(strings.TrimSpace(rest), "\n", 2)[0]; line != "" {
+				reason = " (" + line + ")"
+			}
+		}
+		return "Gas estimation failed: the call reverts against the current chain state" + reason +
+			". The transaction would fail if sent; check the parameters or pass -g <gas limit> to skip estimation."
+	}
+	first := strings.SplitN(strings.TrimPrefix(msg, "couldn't read from any nodes: "), "\n", 2)[0]
+	return "Gas estimation failed: " + first
 }

--- a/cmd/util/signing_card_test.go
+++ b/cmd/util/signing_card_test.go
@@ -227,14 +227,52 @@ func TestShowSigningCardSafeFieldsAndCollapse(t *testing.T) {
 func TestFormatGasLine(t *testing.T) {
 	gwei := big.NewInt(1_000_000_000)
 	legacy := FormatGasLine(true, new(big.Int).Mul(big.NewInt(20), gwei), nil, nil, 21000, "ETH")
-	if legacy != "20.0000 gwei · 21000 gas · ≈ 0.00042000 ETH" {
+	if legacy != "≈ 0.00042000 ETH   (21,000 gas × 20 gwei)" {
 		t.Fatalf("legacy: %q", legacy)
 	}
-	dyn := FormatGasLine(false, nil, new(big.Int).Mul(big.NewInt(20), gwei), new(big.Int).Mul(big.NewInt(2), gwei), 21000, "ETH")
-	if dyn != "max 20.0000 gwei, tip 2.0000 gwei · 21000 gas · ≈ 0.00042000 ETH" {
+	tip := new(big.Int).Div(new(big.Int).Mul(big.NewInt(15), gwei), big.NewInt(10)) // 1.5 gwei
+	dyn := FormatGasLine(false, nil, new(big.Int).Mul(big.NewInt(20), gwei), tip, 85123, "ETH")
+	if dyn != "≈ 0.00170246 ETH   (85,123 gas × max 20 gwei, tip 1.5 gwei)" {
 		t.Fatalf("dynamic: %q", dyn)
 	}
-	if gasCostOnly(dyn) != "≈ 0.00042000 ETH" {
+	if gasCostOnly(dyn) != "≈ 0.00170246 ETH" {
 		t.Fatalf("gasCostOnly: %q", gasCostOnly(dyn))
+	}
+}
+
+func TestInsufficientBalanceWarning(t *testing.T) {
+	eth := big.NewInt(1_000_000_000_000_000_000)
+	in := WarningInput{
+		To:            jarviscommon.Address{Address: cardMe, Desc: "me"},
+		Value:         new(big.Int).Mul(big.NewInt(2), eth),
+		NativeSymbol:  "ETH",
+		SignerBalance: eth,
+		MaxCost:       new(big.Int).Add(new(big.Int).Mul(big.NewInt(2), eth), big.NewInt(420_000_000_000_000)),
+	}
+	got := SigningWarnings(in)
+	if len(got) != 1 || got[0] != "balance 1 ETH does not cover value + max gas (2.0004 ETH); the tx would be rejected" {
+		t.Fatalf("warnings: %q", got)
+	}
+	in.SignerBalance = new(big.Int).Mul(big.NewInt(3), eth)
+	if got := SigningWarnings(in); len(got) != 0 {
+		t.Fatalf("sufficient balance must not warn: %q", got)
+	}
+	in.SignerBalance = nil
+	if got := SigningWarnings(in); len(got) != 0 {
+		t.Fatalf("unknown balance must not warn: %q", got)
+	}
+}
+
+func TestSigningCardShowsWalletKind(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	ShowSigningCard(rec, &SigningCard{
+		Kind:    "EOA transaction",
+		Network: "mainnet",
+		Signer:  ui.StyledText{Text: cardMe + " (hot wallet)"},
+		Wallet:  "ledger",
+		To:      ui.StyledText{Text: cardUSDC + " (USDC)"},
+	})
+	if !rec.HasMessage("Sign with: " + cardMe + " (hot wallet)   ledger   mainnet") {
+		t.Fatalf("wallet kind missing from signer line: %v", rec.Entries())
 	}
 }

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -259,7 +259,11 @@ func HandleApproveOrRevokeOrExecuteMsig(
 	if gasLimit == 0 {
 		gasLimit, err = reader.EstimateExactGas(tc.From, tc.To, 0, tc.Value, data)
 		if err != nil {
-			u.Error("Couldn't estimate gas limit: %s", err)
+			var bal *big.Int
+			if b, berr := reader.GetBalance(tc.From); berr == nil {
+				bal = b
+			}
+			u.Error("%s", ExplainEstimateGasError(err, tc.From, bal, config.Network().GetNativeTokenSymbol()))
 			return
 		}
 	}
@@ -282,7 +286,7 @@ func HandleApproveOrRevokeOrExecuteMsig(
 		return
 	}
 
-	if broadcasted, err := SignAndBroadcast(u, tc.FromAcc, tx, nil, reader, analyzer, a, bc); err != nil && !broadcasted {
+	if broadcasted, err := SignAndBroadcast(u, tc.FromAcc, tx, nil, reader, analyzer, a, bc); err != nil && !broadcasted && !errors.Is(err, ErrUserCancelled) {
 		u.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
 	}
 }
@@ -304,8 +308,14 @@ func SignAndBroadcast(
 	a *abi.ABI,
 	bc TxBroadcaster,
 ) (bool, error) {
+	note := SigningNote{WalletName: fromAcc.Desc, WalletKind: fromAcc.Kind}
+	if reader != nil {
+		if bal, err := reader.GetBalance(fromAcc.Address); err == nil {
+			note.SignerBalance = bal
+		}
+	}
+	mergeSigningNote(note)
 	if err := PromptTxConfirmation(u, analyzer, util.GetJarvisAddress(fromAcc.Address, config.Network()), tx, customABIs, config.Network()); err != nil {
-		u.Error("Aborted!")
 		return false, err
 	}
 

--- a/txanalyzer/analyzer.go
+++ b/txanalyzer/analyzer.go
@@ -175,6 +175,17 @@ func (ta *TxAnalyzer) ParamAsJarvisParamResult(name string, t abi.Type, value in
 	return ta.paramAsJarvisParamResult(name, t, value, nil)
 }
 
+// ParamAsJarvisParamResultFor is ParamAsJarvisParamResult with the token
+// context of contract: when contract is an ERC-20, integer values are
+// annotated with its decimals and symbol so "1000000" echoes as "1 USDC".
+func (ta *TxAnalyzer) ParamAsJarvisParamResultFor(contract string, name string, t abi.Type, value interface{}) ParamResult {
+	var hint *ERC20Info
+	if contract != "" {
+		hint = ta.ctx.ERC20InfoFor(contract)
+	}
+	return ta.paramAsJarvisParamResult(name, t, value, hint)
+}
+
 // rawTopics turns a log's topics into unnamed TopicResults, topic0 first, for
 // logs that no available ABI describes.
 func rawTopics(l *types.Log) []TopicResult {

--- a/txanalyzer/log_test.go
+++ b/txanalyzer/log_test.go
@@ -3,6 +3,7 @@ package txanalyzer
 import (
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -10,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	jarviscommon "github.com/tranvictor/jarvis/common"
 	"github.com/tranvictor/jarvis/networks"
 )
 
@@ -113,5 +115,23 @@ func TestDecodeRevertData(t *testing.T) {
 	}
 	if got := DecodeRevertData(nil, nil); got != "" {
 		t.Fatalf("empty payload: %q", got)
+	}
+}
+
+func TestParamAsJarvisParamResultForAnnotatesTokenAmounts(t *testing.T) {
+	network, _ := networks.GetNetwork("mainnet")
+	ctx := NewAnalysisContext(nil, network)
+	usdc := "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+	ctx.erc20[strings.ToLower(usdc)] = cachedERC20{info: &ERC20Info{Decimal: 6, Symbol: "USDC"}}
+	ta := NewGenericAnalyzerWithContext(ctx)
+
+	uintT, _ := abi.NewType("uint256", "", nil)
+	with := ta.ParamAsJarvisParamResultFor(usdc, "amount", uintT, big.NewInt(1000000))
+	if v := with.Values[0]; v.Kind != jarviscommon.DisplayToken || v.Token == nil || v.Token.Symbol != "USDC" || v.Token.Decimal != 6 {
+		t.Fatalf("expected token-annotated value, got %+v", v)
+	}
+	without := ta.ParamAsJarvisParamResultFor("", "amount", uintT, big.NewInt(1000000))
+	if v := without.Values[0]; v.Kind != jarviscommon.DisplayInteger {
+		t.Fatalf("no contract must mean a plain integer, got %+v", v)
 	}
 }

--- a/util/analyzer.go
+++ b/util/analyzer.go
@@ -13,4 +13,7 @@ type TxAnalyzer interface {
 	AnalyzeMethodCall(a *abi.ABI, data []byte) (method string, params []jarviscommon.ParamResult, err error)
 	AnalyzeOffline(txinfo *jarviscommon.TxInfo, lookupABI jarviscommon.ABIDatabase, customABIs map[string]*abi.ABI, isContract bool) *jarviscommon.TxResult
 	ParamAsJarvisParamResult(name string, t abi.Type, value interface{}) jarviscommon.ParamResult
+	// ParamAsJarvisParamResultFor annotates integer values with the token
+	// context of contract when it is an ERC-20.
+	ParamAsJarvisParamResultFor(contract string, name string, t abi.Type, value interface{}) jarviscommon.ParamResult
 }

--- a/util/convert_util.go
+++ b/util/convert_util.go
@@ -26,11 +26,20 @@ func ConvertToBig(str string, network jarvisnetworks.Network) (*big.Int, error) 
 		if strings.HasPrefix(str, "0x") {
 			return hexutil.DecodeBig(str)
 		}
-		resultBig, ok := big.NewInt(0).SetString(str, 10)
-		if !ok {
-			return nil, fmt.Errorf("can't convert %s to big int", str)
+		resultBig, ok := big.NewInt(0).SetString(strings.ReplaceAll(str, ",", ""), 10)
+		if ok {
+			return resultBig, nil
 		}
-		return resultBig, nil
+		// "1e6" and "1_000_000" are integers written the way people write
+		// them; a fractional value without a token is ambiguous and rejected.
+		if r, ok := new(big.Rat).SetString(strings.ReplaceAll(str, "_", "")); ok {
+			if r.IsInt() {
+				return r.Num(), nil
+			}
+			return nil, fmt.Errorf("%s has a fractional part but no token: write it as raw units or as \"%s %s\" / \"%s <TOKEN>\"",
+				str, str, network.GetNativeTokenSymbol(), str)
+		}
+		return nil, fmt.Errorf("can't convert %s to big int", str)
 	}
 	// Two-token form: "1.5 KNC" or "1.5 ETH".
 	floatStr := parts[0]

--- a/util/convert_util_test.go
+++ b/util/convert_util_test.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tranvictor/jarvis/networks"
+)
+
+func TestConvertToBigAcceptsIntegerSpellings(t *testing.T) {
+	cases := map[string]string{
+		"1000000":   "1000000",
+		"1e6":       "1000000",
+		"1_000_000": "1000000",
+		"1,000,000": "1000000",
+		"0xf4240":   "1000000",
+		"2.5 ETH":   "2500000000000000000",
+		"0.001 ETH": "1000000000000000",
+	}
+	for in, want := range cases {
+		got, err := ConvertToBig(in, networks.EthereumMainnet)
+		if err != nil {
+			t.Fatalf("%q: %s", in, err)
+		}
+		if got.String() != want {
+			t.Errorf("ConvertToBig(%q) = %s, want %s", in, got, want)
+		}
+	}
+	_, err := ConvertToBig("1.5", networks.EthereumMainnet)
+	if err == nil || !strings.Contains(err.Error(), "1.5 ETH") {
+		t.Fatalf("a bare fraction must be rejected with a hint, got %v", err)
+	}
+}
+
+func TestIsDelegationDesignator(t *testing.T) {
+	addr := make([]byte, 20)
+	if !IsDelegationDesignator(append([]byte{0xef, 0x01, 0x00}, addr...)) {
+		t.Fatal("0xef0100||address is a 7702 designator")
+	}
+	if IsDelegationDesignator([]byte{0x60, 0x80, 0x60, 0x40}) || IsDelegationDesignator(nil) {
+		t.Fatal("ordinary bytecode / empty code are not designators")
+	}
+}

--- a/util/display.go
+++ b/util/display.go
@@ -20,6 +20,9 @@ import (
 // Warn (yellow) because sending a call somewhere the address book has never
 // seen is the one address-level fact worth the reader's attention.
 func StyledAddress(addr jarviscommon.Address) ui.StyledText {
+	// The token's decimal count is analyzer bookkeeping, not something the
+	// signer needs to read next to the destination.
+	addr.Decimal = 0
 	text := jarviscommon.PlainAddress(addr)
 	if !jarviscommon.IsKnownAddress(addr) {
 		return ui.StyledText{Text: text, Severity: ui.SeverityWarn}

--- a/util/util.go
+++ b/util/util.go
@@ -675,6 +675,12 @@ func GetABIStringBypassCache(addr string, network networks.Network) (string, err
 	return abiStr, nil
 }
 
+// IsDelegationDesignator reports whether code is an EIP-7702 delegation
+// designator: exactly 0xef0100 followed by a 20-byte address.
+func IsDelegationDesignator(code []byte) bool {
+	return len(code) == 23 && code[0] == 0xef && code[1] == 0x01 && code[2] == 0x00
+}
+
 func IsContract(addr string, network networks.Network) (bool, error) {
 	cacheKey := fmt.Sprintf("%s_%s_is_contract", strings.ToLower(addr), network)
 	_, found := cache.GetCache(cacheKey)
@@ -692,7 +698,10 @@ func IsContract(addr string, network networks.Network) (bool, error) {
 		return false, err
 	}
 
-	isContract := len(code) > 0
+	// An EIP-7702 delegation designator (0xef0100 ‖ address) marks an EOA
+	// that delegates to code; for jarvis's purposes — "does a value transfer
+	// land in a contract?", "does this need an ABI?" — it is still a wallet.
+	isContract := len(code) > 0 && !IsDelegationDesignator(code)
 
 	if isContract {
 		cache.SetCache(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Batch C of the `improved-ui` follow-up, stacked on #119. Everything the operator sees between "I typed the command" and "I said yes/no" on the signing card.

### Signing card

- **Sign with** falls back to the wallet's own name when the address book has no entry (`0x5905… (test wallet)`) and shows the wallet kind muted next to it (`keystore` / `ledger` / `trezor`) so a hardware prompt is expected. Passed through the existing `SigningNote` mechanism; `mergeSigningNote` keeps a Safe-execution note intact.
- Addresses are always EIP-55 checksummed regardless of how the wallet file stored them; the token decimal count (`(USDC - 6)`) no longer leaks into `Send to`.
- **Gas** is cost-first: `≈ 0.00170246 ETH   (85,123 gas × max 20 gwei, tip 1.5 gwei)`. `gasCostOnly` (used by the prompt) follows.
- New warning: `! balance 1 ETH does not cover value + max gas (2.0004 ETH); the tx would be rejected`. `SignAndBroadcast` fetches the signer balance; `WarningInput` gains `SignerBalance`/`MaxCost`; nil skips the check.
- No stacked blank line after the section header when the card has no call body.

### Cancel and errors

- Declining prints `Cancelled — nothing was signed or sent.` and returns `ErrUserCancelled`; `send`, `contract tx`, `safe`, and `cmdutil` callers no longer follow up with "Failed to proceed after signing the tx: user aborted. Aborted."
- `ExplainEstimateGasError` replaces the raw multi-node dump: insufficient funds shows the wallet's actual balance and what to do; a reverting call is named as such with the reason; anything else shows the first node's message.

### Bugs found on the way

- `send --to 0x…` rejected any literal address not already in the address book (`ResolveSendTransfer` only consulted the book). It now accepts a literal address and lets the card flag it as unknown.
- `send -g <limit>` skipped the whole amount-resolution block and would have sent **0**. The block is restructured so the amount is always resolved and only estimation is conditional.
- `IsContract` treated EIP-7702 delegation designators (`0xef0100‖address`) as contracts, so sending to a delegated EOA warned "sends ETH into a contract". Designators are now recognised as wallets.

### Parameter entry

- Integer parameters of an ERC-20 call echo with the token amount: `→ 1000000 (1 USDC)` via a new `TxAnalyzer.ParamAsJarvisParamResultFor(contract, …)`; the lookup is only made for integer types.
- A rejected answer is followed by a muted line listing the accepted forms for that type (`raw integer (1000000), hex (0xf4240), or amount with token (0.5 ETH, 1000 USDC)`).
- `ConvertToBig` accepts `1e6`, `1_000_000`, `1,000,000`; a bare fraction (`1.5`) is rejected with a hint to write `1.5 ETH` / `1.5 <TOKEN>` instead of `can't convert`.

### Tests

`cmd/util`: gas line format, insufficient-balance warning (below / above / unknown), wallet kind on the card, updated prompt echo expectations. `txanalyzer`: token-annotated echo. `util`: integer spellings and fraction rejection, 7702 designator detection.

Verified live with the keystore test wallet: raw destination accepted, card shows `(test wallet)   keystore   mainnet`, `Value 0.001 ETH` with `-g 21000`, balance warning, quiet cancel; without `-g` the estimation failure reads `Gas estimation failed: 0x5905… holds 0 ETH, not enough for the value plus gas.`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

