### PR TITLE
final pass: native decimals, list commands, help/cancel wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,8 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
   `jarvis network list` is a table of names, chain IDs and RPC **hosts**
   (never the full URL, so default Infura keys stay off the screen);
   `jarvis msig chains list` uses the same table primitive.
-- `jarvis version` is two lines (`jarvis <version>` + the GitHub URL).
+- `jarvis version` leads with `jarvis <version>` and the GitHub URL, then
+  the existing Kyber contact lines.
 - `--from` help points at `jarvis wallet list` (there is no `jarvis acc`);
   `--gasprice` no longer mentions ethgasstation.info; `info --json-output`
   describes this command; `-x/--degen` says what it expands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,25 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 - `jarvis wallet add` offers the wallet kinds as a numbered menu with their
   derivation path or what will be asked next, instead of asking you to type
   one of five words.
+- `jarvis wallet list` is a table (Address / Kind / Description);
+  `jarvis addr` / `whois` drop the dashed rule and the `(Unknown)` label;
+  `jarvis network list` is a table of names, chain IDs and RPC **hosts**
+  (never the full URL, so default Infura keys stay off the screen);
+  `jarvis msig chains list` uses the same table primitive.
+- `jarvis version` is two lines (`jarvis <version>` + the GitHub URL).
+- `--from` help points at `jarvis wallet list` (there is no `jarvis acc`);
+  `--gasprice` no longer mentions ethgasstation.info; `info --json-output`
+  describes this command; `-x/--degen` says what it expands.
+- `contract encode --help` is a short parameter summary instead of a
+  50-line spec; `contract read` output uses the same param tree as a call
+  body, not a bordered table per return value.
+- Signing warnings and inner-call `value` labels use the network's native
+  decimals/symbol (not hardcoded 18 / ETH). Safe cards drop the raw-wei
+  parenthetical. Cancelling any confirm prints
+  `Cancelled — nothing was signed or sent.`
+- `send --from <safe>` no longer reprints Safe address/version/threshold
+  before the signing card (those are on the card). Classic `msig init`
+  gas-estimation failures use the same explained error as `send`.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,13 @@ Continue with the remaining 1 transaction(s)? [Y/n]
 - The process exits with status 1 when any item failed; skipped items alone
   keep it at 0.
 
+### Directories
+
+`jarvis wallet list`, `jarvis network list` and `jarvis msig chains list`
+are bordered tables. `network list` prints RPC **hostnames** only so a
+default Infura/Alchemy key never lands on the screen; full URLs live
+under `jarvis node list <network>`.
+
 ## Multisig: Gnosis Classic and Gnosis Safe
 
 Jarvis has first-class support for both Gnosis Classic (on-chain

--- a/cmd/address.go
+++ b/cmd/address.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/spf13/cobra"
 
+	jarviscommon "github.com/tranvictor/jarvis/common"
 	"github.com/tranvictor/jarvis/util"
 )
 
 var addressCmd = &cobra.Command{
 	Use:   "addr",
 	Short: "Find at max 10 matching addresses",
-	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		para := strings.Join(args, " ")
 		// GetMatchingAddresses's third return is match scores, not an
@@ -21,13 +21,11 @@ var addressCmd = &cobra.Command{
 		// slice is non-nil.
 		addrs, names, _ := util.GetMatchingAddresses(para)
 		if len(addrs) == 0 {
-			appUI.Warn("No matching addresses found for \"%s\"", para)
+			appUI.Warn("No matching addresses found for %q", para)
 			return
 		}
-		appUI.Info("Found %d matching address(es):", len(addrs))
-		appUI.Info("-----------------------")
 		for i, addr := range addrs {
-			appUI.Info("%d. %s (%s)", i+1, addr, names[i])
+			appUI.Info("%d. %s", i+1, jarviscommon.NameFirst(jarviscommon.Address{Address: addr, Desc: names[i]}, true))
 		}
 	},
 }

--- a/cmd/common_flags.go
+++ b/cmd/common_flags.go
@@ -18,7 +18,7 @@ func networkFlag() string {
 
 func AddCommonFlagsToTransactionalCmds(c *cobra.Command) {
 	c.PersistentFlags().
-		Float64VarP(&config.GasPrice, "gasprice", "p", 0, "Gas price in gwei. If default value is used, we will use https://ethgasstation.info/ to get fast gas price. The gas price to be used in the tx is gas price + extra gas price")
+		Float64VarP(&config.GasPrice, "gasprice", "p", 0, "Gas price in gwei. 0 = suggested by the network's explorer or nodes. The tx uses gasprice + extraprice")
 	c.PersistentFlags().
 		Float64VarP(&config.TipGas, "tipgas", "s", 0, "tip in gwei, will be use in dynamic fee tx, default value get from node.")
 	c.PersistentFlags().
@@ -32,7 +32,7 @@ func AddCommonFlagsToTransactionalCmds(c *cobra.Command) {
 	c.PersistentFlags().
 		Uint64VarP(&config.Nonce, "nonce", "n", 0, "Nonce of the from account. If default value is used, we will use the next available nonce of from account")
 	c.PersistentFlags().
-		StringVarP(&config.From, "from", "f", "", "Account to use to send the transaction. It can be ethereum address or a hint string to look it up in the list of account. See jarvis acc for all of the registered accounts")
+		StringVarP(&config.From, "from", "f", "", "Account to send from: an address or a keyword (see jarvis wallet list)")
 	c.PersistentFlags().
 		BoolVarP(&config.DontBroadcast, "dry", "d", false, "Will not broadcast the tx, only show signed tx.")
 	c.PersistentFlags().

--- a/cmd/contract.go
+++ b/cmd/contract.go
@@ -26,58 +26,11 @@ var composeDataContractCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return cmdutil.CommonFunctionCallPreprocess(appUI, cmd, args)
 	},
-	Long: `
-Param rules:
-	All params are passed to this command as strings and will be treated
-	with the following seperated groups:
-	1. Array params
-		An array param must be wrapped with [ ], spaces around the string
-		will be trimmed. In side [ ], each element must separated by ","
-		character. Each element will be parsed with the "type conversion"
-		rule which is explained in the later section.
-	2. Non array params
-		A non array param will be passed as string, spaces around the
-		string will be trimmed. Each element will be parsed with the
-		"type conversion" rule which is explained in the later section.
-
-	Type conversion rules:
-	1. string
-		string element must be wrapped by " ". The content inside " " will
-		then be used as the string param.
-
-	2. int, uint
-		int and uint element can be in base 10 or 16. If it is in base 16,
-		it must begin with 0x.
-
-		further more, you can put an erc20 token symbol behind (after
-		exactly 1 space) the number, Jarvis will convert it to the big
-		number according to the token's decimal. In this case, the
-		number can be float.
-
-		For example:
-		8.8 KNC => 8800000000000000000 (17 zeroes).
-		10.5 KNC token => 10500000000000000000.
-
-	3. bool
-		bool element must be either "true" or "false" ( without quotes), all
-		other alternative boolean value string are invalid. Eg. T, F, True,
-		False, nil are invalid.
-
-	4. address
-		address element can be either hex address or a string without " ".
-		If it is a string, Jarvis will look it up in the address book
-		and take the most relevant address.
-
-	5. hash
-		hash element must be represented in hex form without quotes.
-
-	6. bytes
-		bytes element must be represented in hex form without quotes. If
-		0x is provided, it will be interpreted as empty bytes array.
-
-	7. fixed length bytes
-		Not supported yet
-	`,
+	Long: `Encode calldata for a verified contract method. Parameters are
+collected interactively (or via --prefills). Integers accept hex, raw
+units, or an amount with a token ("0.5 ETH", "1000 USDC"); addresses
+accept hex or an address-book name; arrays are comma-separated in
+brackets: [a, b, c].`,
 	Run: func(cmd *cobra.Command, args []string) {
 		tc, _ := cmdutil.TxContextFrom(cmd)
 
@@ -123,7 +76,6 @@ var txContractCmd = &cobra.Command{
 	Use:              "tx [tx hashes]",
 	Aliases:          []string{"write"},
 	Short:            "do transaction to interact with smart contracts",
-	Long:             ` `,
 	TraverseChildren: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return cmdutil.CommonTxPreprocess(appUI, cmd, args)
@@ -212,12 +164,11 @@ func handleReadOneFunctionOnContract(r readerPkg.Reader, analyzer util.TxAnalyze
 	}
 
 	appUI.Info("Output:")
-	var result []util.ParamDisplay
+	var results []jarviscommon.ParamResult
 	for i, output := range method.Outputs {
-		oneOutputParamResult := analyzer.ParamAsJarvisParamResult(output.Name, output.Type, ps[i])
-		result = append(result, util.DisplayParam(appUI, oneOutputParamResult))
+		results = append(results, analyzer.ParamAsJarvisParamResult(output.Name, output.Type, ps[i]))
 	}
-	return result, nil
+	return util.DisplayParams(appUI, results), nil
 }
 
 type contractReadResultJSON struct {
@@ -247,7 +198,6 @@ func (b *batchcontractReadResultJSON) Write(filepath string) {
 var readContractCmd = &cobra.Command{
 	Use:              "read",
 	Short:            "read smart contracts (faster than etherscan)",
-	Long:             ` `,
 	TraverseChildren: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return cmdutil.CommonFunctionCallPreprocess(appUI, cmd, args)
@@ -292,7 +242,7 @@ var readContractCmd = &cobra.Command{
 						Result: result,
 					})
 				}
-				appUI.Info("---------------------------------------------------")
+				appUI.Info("")
 			}
 		} else {
 			resultJSON := contractReadResultJSON{

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -75,7 +75,7 @@ var txCmd = &cobra.Command{
 func init() {
 	txCmd.PersistentFlags().BoolVarP(&config.ForceERC20ABI, "erc20-abi", "e", false, "Use ERC20 ABI where possible.")
 	txCmd.PersistentFlags().StringVarP(&config.CustomABI, "abi", "c", "", "Custom abi. It can be either an address, a path to an abi file or an url to an abi. If it is an address, the abi of that address from etherscan will be queried. This param only takes effect if erc20-abi param is not true.")
-	txCmd.PersistentFlags().StringVarP(&config.JSONOutputFile, "json-output", "o", "", "write output of contract read to json file")
+	txCmd.PersistentFlags().StringVarP(&config.JSONOutputFile, "json-output", "o", "", "write the analysed transaction display to a JSON file")
 
 	rootCmd.AddCommand(txCmd)
 }

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -196,12 +196,8 @@ the on-chain transaction count.`,
 			return
 		}
 		for i, owner := range owners {
-			_, name, err := util.GetMatchingAddress(owner)
-			if err != nil {
-				appUI.Info("%d. %s (Unknown)", i+1, owner)
-			} else {
-				appUI.Info("%d. %s (%s)", i+1, owner, name)
-			}
+			ja := util.GetJarvisAddress(owner, config.Network())
+			appUI.Info("%d. %s", i+1, jarviscommon.NameFirst(ja, true))
 		}
 		voteRequirement, err := multisigContract.VoteRequirement()
 		if err != nil {
@@ -227,7 +223,7 @@ func getMsigContractFromParams(args []string, resolver cmdutil.ABIResolver) (msi
 	addr, name, err := resolver.GetMatchingAddress(args[0])
 	var msigName string
 	if err != nil {
-		msigName = "Unknown"
+		msigName = ""
 		addresses := util.ScanForAddresses(args[0])
 		if len(addresses) == 0 {
 			appUI.Error("Couldn't find any address for \"%s\"", args[0])
@@ -240,19 +236,26 @@ func getMsigContractFromParams(args []string, resolver cmdutil.ABIResolver) (msi
 	}
 	a, err := resolver.GetABI(msigAddress, config.Network())
 	if err != nil {
-		appUI.Error("Couldn't get ABI of %s from etherscan", msigAddress)
+		appUI.Error("Couldn't get ABI of %s from the block explorer", msigAddress)
 		return "", err
 	}
 	isGnosisMultisig, err := util.IsGnosisMultisig(a)
+	labelled := func() string {
+		ja := util.GetJarvisAddress(msigAddress, config.Network())
+		if msigName != "" {
+			ja.Desc = msigName
+		}
+		return jarviscommon.NameFirst(ja, true)
+	}
 	if err != nil {
-		appUI.Error("Checking failed, %s (%s) is not a contract", msigAddress, msigName)
+		appUI.Error("Checking failed, %s is not a contract", labelled())
 		return "", err
 	}
 	if !isGnosisMultisig {
-		appUI.Error("%s (%s) is not a Gnosis multisig or not with a version I understand.", msigAddress, msigName)
+		appUI.Error("%s is not a Gnosis Classic or Safe multisig (or not a version jarvis understands).", labelled())
 		return "", fmt.Errorf("not gnosis multisig")
 	}
-	appUI.Info("Multisig: %s (%s)", msigAddress, msigName)
+	appUI.Info("Multisig: %s", labelled())
 	return msigAddress, nil
 }
 
@@ -1217,7 +1220,11 @@ the Safe, so the positional Safe address and --network become optional.`,
 		if gasLimit == 0 {
 			gasLimit, err = reader.EstimateExactGas(tc.From, tc.To, 0, tc.Value, txdata)
 			if err != nil {
-				appUI.Error("Couldn't estimate gas limit: %s", err)
+				var bal *big.Int
+				if b, berr := reader.GetBalance(tc.From); berr == nil {
+					bal = b
+				}
+				appUI.Error("%s", cmdutil.ExplainEstimateGasError(err, tc.From, bal, config.Network().GetNativeTokenSymbol()))
 				return
 			}
 		}

--- a/cmd/msig_chains.go
+++ b/cmd/msig_chains.go
@@ -48,14 +48,19 @@ var listChainsMsigCmd = &cobra.Command{
 			}
 		}
 		appUI.Info("%d chains known:", len(entries))
-		fmt.Printf("%-10s  %-10s  %s\n", "chainID", "shortName", "txService")
+		rows := make([][]string, 0, len(entries))
 		for _, ci := range entries {
 			svc := ci.TransactionService
 			if svc == "" {
 				svc = "(no tx service)"
 			}
-			fmt.Printf("%-10d  %-10s  %s\n", ci.ChainID, ci.ShortName, svc)
+			rows = append(rows, []string{
+				fmt.Sprintf("%d", ci.ChainID),
+				ci.ShortName,
+				svc,
+			})
 		}
+		appUI.Table([]string{"chainID", "shortName", "txService"}, rows)
 	},
 }
 

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 
 	cmdutil "github.com/tranvictor/jarvis/cmd/util"
 	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util"
 )
 
@@ -261,28 +263,67 @@ needs --safe-tx-file to keep proposals in a local file instead.`,
 var listNetworkCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Show all of supported networks",
-	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		nets := networks.GetSupportedNetworks()
-		for i, n := range nets {
+		sort.Slice(nets, func(i, j int) bool { return nets[i].GetName() < nets[j].GetName() })
+		rows := make([][]string, 0, len(nets))
+		var hasOverride bool
+		for _, n := range nets {
 			nodes, err := util.GetNodes(n)
 			if err != nil {
-				appUI.Error("Error: %s", err)
+				appUI.Error("%s: %s", n.GetName(), err)
 				continue
 			}
-			appUI.Info("%d. Name: %s, Chain ID: %d", i+1, n.GetName(), n.GetChainID())
-			if src := networks.CustomNetworkFile(n.GetName()); src != "" {
-				appUI.Info("    Override: %s", src)
+			hosts := make([]string, 0, len(nodes))
+			seen := map[string]bool{}
+			for _, node := range nodes {
+				h := nodeHost(node)
+				if h == "" || seen[h] {
+					continue
+				}
+				seen[h] = true
+				hosts = append(hosts, h)
 			}
-			appUI.Info("    RPC nodes:")
-			for key, node := range nodes {
-				appUI.Info("    - %s: %s", key, node)
+			sort.Strings(hosts)
+			alias := strings.Join(n.GetAlternativeNames(), ", ")
+			rpc := ""
+			if len(hosts) == 1 {
+				rpc = hosts[0]
+			} else if len(hosts) > 1 {
+				rpc = fmt.Sprintf("%s +%d", hosts[0], len(hosts)-1)
+			}
+			src := ""
+			if networks.CustomNetworkFile(n.GetName()) != "" {
+				src = "override"
+				hasOverride = true
+			}
+			rows = append(rows, []string{n.GetName(), fmt.Sprintf("%d", n.GetChainID()), alias, rpc, src})
+		}
+		headers := []string{"Network", "Chain ID", "Alias", "RPC"}
+		if hasOverride {
+			headers = append(headers, "Source")
+		} else {
+			for i := range rows {
+				rows[i] = rows[i][:4]
 			}
 		}
-
-		appUI.Info("\nIf you want to add more networks to the list, use following command:\n> jarvis network add")
-		appUI.Info("\nIf you want to delete a network, just delete the corresponding json file in ~/.jarvis/networks/.")
+		appUI.Table(headers, rows)
+		appUI.Info("%s", appUI.Style(ui.StyledText{
+			Text:     "full URLs: jarvis node list <network>   add a chain: jarvis network add",
+			Severity: ui.SeverityMuted,
+		}))
 	},
+}
+
+// nodeHost is the hostname of an RPC URL, so listing networks never echoes
+// an embedded API key from a default Infura/Alchemy path.
+func nodeHost(raw string) string {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	return u.Host
 }
 
 var networkCmd = &cobra.Command{

--- a/cmd/network_test.go
+++ b/cmd/network_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNodeHostStripsPathAndKey(t *testing.T) {
+	cases := map[string]string{
+		"https://ropsten.infura.io/v3/247128ae36b6444d944d4c3793c8e3f5": "ropsten.infura.io",
+		" https://rpc2-testnet.bitfi.xyz":                               "rpc2-testnet.bitfi.xyz",
+		"http://127.0.0.1:8545":                                         "127.0.0.1:8545",
+		"not-a-url":                                                     "not-a-url",
+	}
+	for in, want := range cases {
+		got := nodeHost(in)
+		if got != want {
+			t.Errorf("nodeHost(%q) = %q, want %q", in, got, want)
+		}
+		if strings.Contains(got, "247128ae") {
+			t.Errorf("nodeHost leaked the API key: %q", got)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,7 +132,7 @@ func Execute() {
 		"degen",
 		"x",
 		false,
-		"Set to enable degen prints such as detailed contract calls, nonces... Default false",
+		"show full addresses, uncollapsed arrays, gas/nonce details and the event table",
 	)
 
 	rootCmd.PersistentFlags().BoolVarP(

--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -182,7 +182,7 @@ approve' and any owner can finalise via 'jarvis msig execute'.`,
 			prompt:    "Sign and submit this Safe proposal (off-chain, no gas)?",
 		})
 		if !cmdutil.ConfirmSigningCard(appUI, card) {
-			appUI.Warn("Aborted by user.")
+			cmdutil.WarnCancelled(appUI)
 			return
 		}
 
@@ -368,7 +368,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 		}
 
 		if !config.YesToAllPrompt && !appUI.Confirm("Sign approval (off-chain, no gas)?", true) {
-			appUI.Warn("Aborted by user.")
+			cmdutil.WarnCancelled(appUI)
 			return
 		}
 

--- a/cmd/safe_display.go
+++ b/cmd/safe_display.go
@@ -100,21 +100,21 @@ func buildSafeSigningCard(
 		card.Signer = util.StyledAddress(util.GetJarvisAddress(opt.signer, network))
 	}
 	if stx.Value != nil && stx.Value.Sign() > 0 {
-		card.Value = fmt.Sprintf("%s %s (%s wei)",
-			jarviscommon.BigToFloatString(stx.Value, network.GetNativeTokenDecimal()),
-			network.GetNativeTokenSymbol(), stx.Value.String())
+		card.Value = jarviscommon.BigToFloatString(stx.Value, network.GetNativeTokenDecimal()) +
+			" " + network.GetNativeTokenSymbol()
 	}
 	for _, sig := range opt.sigs {
 		card.Safe.Signatures = append(card.Safe.Signatures, signerLine(sig))
 	}
 
 	warn := cmdutil.WarningInput{
-		To:           toJarvis,
-		Value:        stx.Value,
-		NativeSymbol: network.GetNativeTokenSymbol(),
-		HasData:      len(stx.Data) > 0,
-		DelegateCall: stx.Operation == safe.OpDelegateCall,
-		MultiSend:    isMultiSend,
+		To:             toJarvis,
+		Value:          stx.Value,
+		NativeSymbol:   network.GetNativeTokenSymbol(),
+		NativeDecimals: network.GetNativeTokenDecimal(),
+		HasData:        len(stx.Data) > 0,
+		DelegateCall:   stx.Operation == safe.OpDelegateCall,
+		MultiSend:      isMultiSend,
 	}
 	if len(stx.Data) > 0 {
 		if isContract, err := util.IsContract(stx.To.Hex(), network); err == nil {
@@ -123,7 +123,7 @@ func buildSafeSigningCard(
 		fc := decodeSafeCalldata(stx, tc, opt.extraABIs)
 		if fc != nil {
 			warn.Call = fc
-			card.Call = util.NewFunctionCallDisplay(fc)
+			card.Call = util.NewFunctionCallDisplay(fc, network)
 		} else {
 			card.RawData = "0x" + ethcommon.Bytes2Hex(stx.Data)
 		}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -436,7 +436,7 @@ exact addresses start with 0x.`,
 
 		tipGas := 0.0
 		if txType == types.LegacyTxType && config.TipGas > 0 {
-			appUI.Warn("We are doing legacy tx hence we ignore tip gas parameter.")
+			appUI.Warn("Legacy tx: ignoring --tipgas (EIP-1559 tips apply only to type-2 txs).")
 		} else if txType == types.DynamicFeeTxType {
 			tipGas = config.TipGas
 			if tipGas == 0 {
@@ -597,15 +597,6 @@ func sendFromSafe(
 	bc cmdutil.TxBroadcaster,
 	safeContract *safe.SafeContract,
 ) {
-	appUI.Section("Safe info")
-	appUI.Info("Safe address : %s", safeContract.Address)
-	if v, err := safeContract.Version(); err == nil {
-		appUI.Info("Safe version : %s", v)
-	}
-	if t, err := safeContract.Threshold(); err == nil {
-		appUI.Info("Threshold    : %d", t)
-	}
-
 	owners, err := safeContract.Owners()
 	if err != nil {
 		appUI.Error("getting safe owners failed: %s", err)
@@ -683,7 +674,6 @@ func sendFromSafe(
 		appUI.Error("Couldn't determine the next safe nonce: %s", err)
 		return
 	}
-	appUI.Info("SafeTx nonce: %d", safeNonce)
 
 	domainSep, err := safeContract.DomainSeparator()
 	if err != nil {
@@ -708,7 +698,7 @@ func sendFromSafe(
 		prompt: "Sign and submit this Safe proposal (off-chain, no gas)?",
 	})
 	if !cmdutil.ConfirmSigningCard(appUI, card) {
-		appUI.Warn("Aborted by user.")
+		cmdutil.WarnCancelled(appUI)
 		return
 	}
 

--- a/cmd/util/fill_tx_params.go
+++ b/cmd/util/fill_tx_params.go
@@ -56,7 +56,7 @@ func FillSigningTxParams(u ui.UI, tc *TxContext, network jarvisnetworks.Network)
 
 	if tc.TxType == types.LegacyTxType {
 		if config.TipGas > 0 && u != nil {
-			u.Warn("We are doing legacy tx hence we ignore tip gas parameter.")
+			u.Warn("Legacy tx: ignoring --tipgas (EIP-1559 tips apply only to type-2 txs).")
 		}
 	} else if tc.TxType == types.DynamicFeeTxType {
 		if config.TipGas == 0 {

--- a/cmd/util/fill_tx_params_test.go
+++ b/cmd/util/fill_tx_params_test.go
@@ -123,7 +123,7 @@ func TestFillSigningTxParamsLegacyIgnoresTip(t *testing.T) {
 	if tc.TxType != types.LegacyTxType || tc.TipGas != 0 {
 		t.Fatalf("type=%d tip=%v, want legacy with tip ignored", tc.TxType, tc.TipGas)
 	}
-	if !rec.HasMessage("ignore tip gas") {
+	if !rec.HasMessage("ignoring --tipgas") {
 		t.Fatal("expected a warning that tip gas is ignored")
 	}
 }

--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -190,6 +190,13 @@ func mergeSigningNote(n SigningNote) {
 // Nothing has been signed or sent at that point; callers should exit quietly.
 var ErrUserCancelled = errors.New("cancelled by user")
 
+// WarnCancelled is the one-line message for a declined confirm. Callers that
+// prompt outside PromptTxConfirmation should use this so every cancel reads
+// the same.
+func WarnCancelled(u ui.UI) {
+	u.Warn("Cancelled — nothing was signed or sent.")
+}
+
 // PromptTxConfirmation displays the signing card for tx and asks the user to
 // confirm before signing. Returns an error if the user aborts.
 func PromptTxConfirmation(
@@ -208,7 +215,7 @@ func PromptTxConfirmation(
 		return err
 	}
 	if !ConfirmSigningCard(u, card) {
-		u.Warn("Cancelled — nothing was signed or sent.")
+		WarnCancelled(u)
 		return ErrUserCancelled
 	}
 	return nil
@@ -262,7 +269,8 @@ func buildEOASigningCard(
 			card.RawData = "0x" + ethcommon.Bytes2Hex(tx.Data())
 		}
 		card.Warnings = SigningWarnings(WarningInput{
-			Value: tx.Value(), NativeSymbol: symbol, SignerBalance: balance, MaxCost: maxCost,
+			Value: tx.Value(), NativeSymbol: symbol, NativeDecimals: network.GetNativeTokenDecimal(),
+			SignerBalance: balance, MaxCost: maxCost,
 		})
 		card.Prompt = fmt.Sprintf("Sign and broadcast contract creation (%s)?", gasCostOnly(card.Gas))
 		return card, nil
@@ -283,7 +291,8 @@ func buildEOASigningCard(
 	}
 	warn := WarningInput{
 		To: to, ToIsContract: isContract, Value: tx.Value(), NativeSymbol: symbol,
-		HasData: len(tx.Data()) > 0, SignerBalance: balance, MaxCost: maxCost,
+		NativeDecimals: network.GetNativeTokenDecimal(),
+		HasData:        len(tx.Data()) > 0, SignerBalance: balance, MaxCost: maxCost,
 	}
 
 	var fc *jarviscommon.FunctionCall
@@ -291,7 +300,7 @@ func buildEOASigningCard(
 		fc = analyzer.AnalyzeFunctionCallRecursively(util.GetABI, tx.Value(), toHex, tx.Data(), customABIs)
 		warn.Call = fc
 		if fc != nil {
-			card.Call = util.NewFunctionCallDisplay(fc)
+			card.Call = util.NewFunctionCallDisplay(fc, network)
 		}
 		// ERC-7730 clear-signing layer: when a descriptor matches the
 		// destination contract, the curated view is rendered above the raw

--- a/cmd/util/signing_card.go
+++ b/cmd/util/signing_card.go
@@ -211,14 +211,27 @@ type WarningInput struct {
 	ToIsContract bool
 	Value        *big.Int
 	NativeSymbol string
-	HasData      bool
-	Call         *jarviscommon.FunctionCall
-	DelegateCall bool
-	MultiSend    bool
+	// NativeDecimals is the native token's decimal count; 0 means 18.
+	NativeDecimals uint64
+	HasData        bool
+	Call           *jarviscommon.FunctionCall
+	DelegateCall   bool
+	MultiSend      bool
 	// SignerBalance and MaxCost enable the insufficient-funds warning; either
 	// nil skips it. MaxCost is value + gasLimit × max fee.
 	SignerBalance *big.Int
 	MaxCost       *big.Int
+}
+
+func (in WarningInput) nativeDecimals() uint64 {
+	if in.NativeDecimals == 0 {
+		return 18
+	}
+	return in.NativeDecimals
+}
+
+func (in WarningInput) nativeAmount(v *big.Int) string {
+	return jarviscommon.CompactAmount(jarviscommon.BigToFloatString(v, in.nativeDecimals()))
 }
 
 // approvalMethods maps ERC-20/721/1155 approval selectors to the parameter
@@ -241,12 +254,12 @@ func SigningWarnings(in WarningInput) []string {
 	}
 	if in.Value != nil && in.Value.Sign() > 0 && in.ToIsContract {
 		out = append(out, fmt.Sprintf("sends %s %s into a contract",
-			jarviscommon.BigToFloatString(in.Value, 18), in.NativeSymbol))
+			in.nativeAmount(in.Value), in.NativeSymbol))
 	}
 	if in.SignerBalance != nil && in.MaxCost != nil && in.SignerBalance.Cmp(in.MaxCost) < 0 {
 		out = append(out, fmt.Sprintf("balance %s %s does not cover value + max gas (%s %s); the tx would be rejected",
-			jarviscommon.CompactAmount(jarviscommon.BigToFloatString(in.SignerBalance, 18)), in.NativeSymbol,
-			jarviscommon.CompactAmount(jarviscommon.BigToFloatString(in.MaxCost, 18)), in.NativeSymbol))
+			in.nativeAmount(in.SignerBalance), in.NativeSymbol,
+			in.nativeAmount(in.MaxCost), in.NativeSymbol))
 	}
 	if in.DelegateCall {
 		if in.MultiSend {

--- a/cmd/util/signing_card_test.go
+++ b/cmd/util/signing_card_test.go
@@ -134,7 +134,7 @@ func TestShowSigningCardOrderAndFullAddresses(t *testing.T) {
 		To:       util.StyledAddress(cardAddr(cardUSDC, "USDC")),
 		Gas:      "max 20.0000 gwei, tip 1.5000 gwei · 85123 gas · ≈ 0.00170246 ETH",
 		Nonce:    "42",
-		Call:     util.NewFunctionCallDisplay(fc),
+		Call:     util.NewFunctionCallDisplay(fc, nil),
 		Warnings: SigningWarnings(WarningInput{To: cardAddr(cardUSDC, "USDC"), HasData: true, Call: fc}),
 		Prompt:   "Sign and broadcast (≈ 0.00170246 ETH)?",
 	}
@@ -208,7 +208,7 @@ func TestShowSigningCardSafeFieldsAndCollapse(t *testing.T) {
 	rec = ui.NewRecordingUI()
 	exec := &SigningCard{
 		Kind:         "Safe execution",
-		Call:         util.NewFunctionCallDisplay(&jarviscommon.FunctionCall{Destination: cardAddr(cardRouter, "Safe"), Method: "execTransaction", Params: []jarviscommon.ParamResult{uintParam("value", "0")}}),
+		Call:         util.NewFunctionCallDisplay(&jarviscommon.FunctionCall{Destination: cardAddr(cardRouter, "Safe"), Method: "execTransaction", Params: []jarviscommon.ParamResult{uintParam("value", "0")}}, nil),
 		CollapseCall: true,
 		Safe:         &SafeCardFields{Executes: "0xabc"},
 	}
@@ -260,6 +260,18 @@ func TestInsufficientBalanceWarning(t *testing.T) {
 	in.SignerBalance = nil
 	if got := SigningWarnings(in); len(got) != 0 {
 		t.Fatalf("unknown balance must not warn: %q", got)
+	}
+}
+
+func TestSigningWarningsHonourNativeDecimals(t *testing.T) {
+	// 8-decimal native: 1.5 units into a contract must not be rendered as if 18.
+	in := WarningInput{
+		To: cardAddr(cardRouter, "Router"), ToIsContract: true,
+		Value: big.NewInt(150_000_000), NativeSymbol: "TKN", NativeDecimals: 8,
+	}
+	got := SigningWarnings(in)
+	if len(got) != 1 || got[0] != "sends 1.5 TKN into a contract" {
+		t.Fatalf("8-decimal native: %q", got)
 	}
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,6 +12,8 @@ var versionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		appUI.Info("jarvis %s", VERSION)
 		appUI.Info("https://github.com/tranvictor/jarvis")
+		appUI.Info("Contact: @tranvictor on Telegram or victor@kyber.network")
+		appUI.Info("At Kyber, our objective is to grow as a respected team in crypto world")
 	},
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,11 +9,9 @@ var VERSION string = "dev"
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show jarvis version",
-	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		appUI.Info("Version: %s", VERSION)
-		appUI.Info("Contact author at: @tranvictor on Telegram or victor@kyber.network")
-		appUI.Info("At Kyber, our objective is to grow as a respected team in crypto world")
+		appUI.Info("jarvis %s", VERSION)
+		appUI.Info("https://github.com/tranvictor/jarvis")
 	},
 }
 

--- a/cmd/wallet.go
+++ b/cmd/wallet.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tranvictor/jarvis/accounts"
 	"github.com/tranvictor/jarvis/accounts/types"
 	cmdutil "github.com/tranvictor/jarvis/cmd/util"
+	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util/account/ledgereum"
 	"github.com/tranvictor/jarvis/util/account/trezoreum"
 )
@@ -183,19 +184,19 @@ func handleAddKeystoreGivenPath(keystorePath string) error {
 	}
 	accDesc.Address = address
 	appUI.Info("This keystore is with %s", address)
-	des := cmdutil.PromptInput(appUI, "Please enter description of this wallet, I will look at it to get the wallet for you later based on your search keywords")
+	des := cmdutil.PromptInput(appUI, "Please enter a description — used later to find this wallet by keyword")
 	accDesc.Desc = des
 	if err = accounts.StoreAccountRecord(*accDesc); err != nil {
-		appUI.Error("I couldn't store your wallet info: %s. Abort.", err)
+		appUI.Error("Couldn't store your wallet info: %s. Abort.", err)
 		return err
 	}
-	appUI.Success("I created ~/.jarvis/%s.json to store the keystore info. That file contains the path of your keystore file so please don't move your keystore file later.", address)
-	appUI.Info("Your wallet is added successfully. You can check your list of wallets using the following command:\n> jarvis wallet list")
+	appUI.Success("Created ~/.jarvis/%s.json. Keep the keystore file where it is; that record stores its path.", address)
+	appUI.Info("Added. Check the list with: jarvis wallet list")
 	return nil
 }
 
 func handleAddKeystore() {
-	appUI.Warn("Keystore is convenient but not so safe. I recommend you to use it only for unimportant frequent tasks.")
+	appUI.Warn("A keystore is convenient but less safe than a hardware wallet; keep it for low-value frequent tasks.")
 	keystorePath := cmdutil.PromptFilePath(appUI, "Please enter the path to your keystore file")
 	handleAddKeystoreGivenPath(keystorePath)
 }
@@ -239,11 +240,12 @@ func walletKindLabels() []string {
 var listWalletCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Show all of your wallets",
-	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		accs := accounts.GetAccounts()
-		appUI.Info("You have %d wallets:", len(accs))
-
+		if len(accs) == 0 {
+			appUI.Warn("No wallets yet. Add one with: jarvis wallet add")
+			return
+		}
 		type accountInfo struct {
 			addr string
 			acc  types.AccDesc
@@ -255,10 +257,12 @@ var listWalletCmd = &cobra.Command{
 		sort.Slice(accountList, func(i, j int) bool {
 			return accountList[i].acc.Desc < accountList[j].acc.Desc
 		})
-		for index, item := range accountList {
-			appUI.Info("%d. %s: %s (%s)", index+1, item.addr, item.acc.Kind, item.acc.Desc)
+		rows := make([][]string, 0, len(accountList))
+		for _, item := range accountList {
+			rows = append(rows, []string{item.addr, item.acc.Kind, item.acc.Desc})
 		}
-		appUI.Info("\nIf you want to add more wallets to the list, use following command:\n> jarvis wallet add")
+		appUI.Table([]string{"Address", "Kind", "Description"}, rows)
+		appUI.Info("%s", appUI.Style(ui.StyledText{Text: "jarvis wallet add — register another", Severity: ui.SeverityMuted}))
 	},
 }
 

--- a/cmd/whois.go
+++ b/cmd/whois.go
@@ -5,27 +5,27 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util"
 )
 
 var whoisCmd = &cobra.Command{
 	Use:   "whois",
 	Short: "Show name of one or multiple addresses",
-	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		para := strings.Join(args, " ")
 		addresses := util.ScanForAddresses(para)
 		if len(addresses) == 0 {
 			appUI.Error("Couldn't find any addresses in the params")
-		} else {
-			for _, address := range addresses {
-				addrs, names, _ := util.GetExactAddressFromDatabases(address)
-				if len(addrs) == 0 {
-					appUI.Info("%s: %s", address, "not found")
-					continue
-				}
-				appUI.Info("%s: %s", addrs[0], names[0])
+			return
+		}
+		for _, address := range addresses {
+			addrs, names, _ := util.GetExactAddressFromDatabases(address)
+			if len(addrs) == 0 {
+				appUI.Info("%s  %s", address, appUI.Style(ui.StyledText{Text: "not in address book", Severity: ui.SeverityMuted}))
+				continue
 			}
+			appUI.Info("%s  %s", addrs[0], names[0])
 		}
 	},
 }

--- a/common/printer.go
+++ b/common/printer.go
@@ -180,7 +180,7 @@ func PlainAddress(addr Address) string {
 	if addr.Decimal != 0 {
 		return fmt.Sprintf("%s (%s - %d)", addr.Address, addr.Desc, addr.Decimal)
 	}
-	if addr.Desc != "" {
+	if addr.Desc != "" && addr.Desc != "unknown" {
 		return fmt.Sprintf("%s (%s)", addr.Address, addr.Desc)
 	}
 	return addr.Address
@@ -205,9 +205,8 @@ func ShortAddress(hex string) string {
 }
 
 // NameFirst formats an address for dense, read-only views. Known addresses
-// lead with their name and put the hex in parentheses; unknown ones lead with
-// the hex followed by "(unknown)". full selects the complete hex over the
-// ShortAddress form.
+// lead with their name and put the hex in parentheses; unknown ones are the
+// hex alone. full selects the complete hex over the ShortAddress form.
 func NameFirst(addr Address, full bool) string {
 	if addr.Address == "" {
 		return ""

--- a/common/printer_test.go
+++ b/common/printer_test.go
@@ -53,6 +53,16 @@ func TestIsKnownAddress(t *testing.T) {
 	}
 }
 
+func TestPlainAddressOmitsUnknown(t *testing.T) {
+	hex := "0x9642b23Ed1E01Df1092B92641051881a322F5D4E"
+	if got := PlainAddress(Address{Address: hex, Desc: "unknown"}); got != hex {
+		t.Fatalf("unknown desc leaked: %q", got)
+	}
+	if got := PlainAddress(Address{Address: hex, Desc: "me"}); got != hex+" (me)" {
+		t.Fatalf("known desc dropped: %q", got)
+	}
+}
+
 func TestGroupDigitsAndReadableNumber(t *testing.T) {
 	cases := map[string]string{
 		"1000000000":  "1,000,000,000",

--- a/util/display.go
+++ b/util/display.go
@@ -89,14 +89,14 @@ func buildParamDisplay(param jarviscommon.ParamResult) ParamDisplay {
 	return d
 }
 
-func buildFunctionCallDisplay(fc *jarviscommon.FunctionCall, nested bool) *FunctionCallDisplay {
+func buildFunctionCallDisplay(fc *jarviscommon.FunctionCall, nested bool, network networks.Network) *FunctionCallDisplay {
 	d := &FunctionCallDisplay{
 		Destination: StyledAddress(fc.Destination),
 		Error:       fc.Error,
 		Method:      fc.Method,
 	}
-	if nested && fc.Value != nil {
-		d.Value = fmt.Sprintf("%f ETH", jarviscommon.BigToFloat(fc.Value, 18))
+	if nested && fc.Value != nil && fc.Value.Sign() > 0 {
+		d.Value = nativeValueText(fc.Value, network)
 	}
 	// Only carried when the method couldn't be resolved — a decoded call already
 	// shows everything the calldata contains.
@@ -107,7 +107,7 @@ func buildFunctionCallDisplay(fc *jarviscommon.FunctionCall, nested bool) *Funct
 		d.Params = append(d.Params, buildParamDisplay(param))
 	}
 	for _, inner := range fc.DecodedFunctionCalls {
-		d.InnerCalls = append(d.InnerCalls, buildFunctionCallDisplay(inner, true))
+		d.InnerCalls = append(d.InnerCalls, buildFunctionCallDisplay(inner, true, network))
 	}
 	return d
 }
@@ -129,7 +129,16 @@ func buildLogDisplay(log jarviscommon.LogResult) LogDisplay {
 	return d
 }
 
-func buildTxDisplay(result *jarviscommon.TxResult) *TxDisplay {
+func nativeValueText(v *big.Int, network networks.Network) string {
+	dec, sym := uint64(18), "ETH"
+	if network != nil {
+		dec = network.GetNativeTokenDecimal()
+		sym = network.GetNativeTokenSymbol()
+	}
+	return jarviscommon.BigToFloatString(v, dec) + " " + sym
+}
+
+func buildTxDisplay(result *jarviscommon.TxResult, network networks.Network) *TxDisplay {
 	d := &TxDisplay{
 		Status:       result.Status,
 		From:         styledParamAddress(result.From),
@@ -149,7 +158,7 @@ func buildTxDisplay(result *jarviscommon.TxResult) *TxDisplay {
 		return d
 	}
 	if result.FunctionCall != nil {
-		d.FunctionCall = buildFunctionCallDisplay(result.FunctionCall, false)
+		d.FunctionCall = buildFunctionCallDisplay(result.FunctionCall, false, network)
 	}
 	d.Transfers = buildTransfers(result.Logs)
 	d.NetEffect = buildNetEffect(d.Transfers, d.From)
@@ -417,36 +426,9 @@ func flattenParamRows(d ParamDisplay, indent string) [][]ui.TableCell {
 // table. Consecutive scalar params share a group; each complex param
 // (tuple / array) gets its own group.
 func printParamList(u ui.UI, params []ParamDisplay) {
-	var groups [][][]ui.TableCell
-	var scalarGroup [][]ui.TableCell
-
-	flushScalars := func() {
-		if len(scalarGroup) > 0 {
-			groups = append(groups, scalarGroup)
-			scalarGroup = nil
-		}
-	}
-
-	for _, p := range params {
-		rows := flattenParamRows(p, "")
-		if len(rows) == 0 {
-			continue
-		}
-		if p.Values != nil {
-			scalarGroup = append(scalarGroup, rows...)
-		} else {
-			flushScalars()
-			groups = append(groups, rows)
-		}
-	}
-
-	flushScalars()
-
-	if len(groups) > 0 {
-		u.PrintTable(&ui.Table{
-			Headers: []string{"Parameter", "Value"},
-			Groups:  groups,
-		})
+	p := txPrinter{u: u, layout: LayoutInfoFull, compact: false}
+	for _, line := range p.paramLines(params) {
+		u.Info("%s", line)
 	}
 }
 
@@ -535,9 +517,8 @@ func DisplayParam(u ui.UI, param jarviscommon.ParamResult) ParamDisplay {
 }
 
 // DisplayParams builds view-models for a slice of ABI parameters and renders
-// them together in one pass: all scalar params appear in a single table and
-// complex params (tuples, arrays) are printed below it. This avoids the
-// fragmented output produced by calling DisplayParam once per param.
+// them as aligned name/value/type lines with tuples and arrays expanded as a
+// tree — the same form as a function-call body.
 func DisplayParams(u ui.UI, params []jarviscommon.ParamResult) []ParamDisplay {
 	displays := make([]ParamDisplay, len(params))
 	for i, p := range params {
@@ -551,16 +532,17 @@ func DisplayParams(u ui.UI, params []jarviscommon.ParamResult) []ParamDisplay {
 // function call (and any recursively decoded inner calls) and writes it to u
 // as an indented tree with full addresses and nothing collapsed — the form
 // used wherever the reader is about to sign what they see.
-func DisplayFunctionCall(u ui.UI, fc *jarviscommon.FunctionCall) *FunctionCallDisplay {
-	d := buildFunctionCallDisplay(fc, false)
+func DisplayFunctionCall(u ui.UI, fc *jarviscommon.FunctionCall, network networks.Network) *FunctionCallDisplay {
+	d := buildFunctionCallDisplay(fc, false, network)
 	PrintFunctionCall(u, d)
 	return d
 }
 
 // NewFunctionCallDisplay builds the view-model for a decoded call without
-// printing it.
-func NewFunctionCallDisplay(fc *jarviscommon.FunctionCall) *FunctionCallDisplay {
-	return buildFunctionCallDisplay(fc, false)
+// printing it. network supplies the native token for inner-call value labels;
+// nil falls back to 18-decimal ETH.
+func NewFunctionCallDisplay(fc *jarviscommon.FunctionCall, network networks.Network) *FunctionCallDisplay {
+	return buildFunctionCallDisplay(fc, false, network)
 }
 
 // PrintFunctionCall renders an already-built call view-model in full detail.
@@ -576,7 +558,7 @@ func PrintFunctionCall(u ui.UI, d *FunctionCallDisplay) {
 // hash is the transaction hash shown in the headline/footer; pass an empty
 // string to omit it (e.g. when the hash is already shown by the caller).
 func DisplayTxResult(u ui.UI, result *jarviscommon.TxResult, network networks.Network, layout TxLayout, hash string) *TxDisplay {
-	d := buildTxDisplay(result)
+	d := buildTxDisplay(result, network)
 	d.Hash = hash
 	printTxDisplay(u, d, network, layout)
 	return d

--- a/util/display_test.go
+++ b/util/display_test.go
@@ -190,46 +190,41 @@ func TestNestedLayerUIRepresentation(t *testing.T) {
 	params := nestedLayerFixture(t)
 	util.DisplayParams(rec, params)
 
-	entries := rec.Entries()
-	tableRows := filterTableEntries(entries)
-
-	// The table should start with a header and contain the expected groups
-	// separated by "---" dividers.
-	expected := []string{
-		"Parameter | Value",
-		// Group 1: scalar params
-		"num (uint256) | 1000",
-		"account (address) | 0x9642b23Ed1E01Df1092B92641051881a322F5D4E (unknown)",
-		"---",
-		// Group 2: secondLayer
-		"secondLayer (TestNestedReturnSecondLayer) | ",
-		"  id (uint256) | 10",
-		"  layers ((uint256,address,string)[]) | ",
-		"    [0] index (uint256) | 1",
-		"        owner (address) | 0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97 (unknown)",
-		"        text (string) | Hello 1",
-		"    [1] index (uint256) | 2",
-		"        owner (address) | 0x9642b23Ed1E01Df1092B92641051881a322F5D4E (unknown)",
-		"        text (string) | Hello 2",
-		"---",
-		// Group 3: value
-		"value (TestNestedReturnSomeValues) | ",
-		"  firstVal (uint256) | 16",
-		"  secondVal (uint256) | 30",
-		"  addrVal (address) | 0x559432E18b281731c054cD703D4B49872BE4ed53 (unknown)",
+	var got []string
+	for _, e := range rec.Entries() {
+		if e.Method == "Info" {
+			got = append(got, e.Value)
+		}
 	}
-
-	if len(tableRows) != len(expected) {
-		t.Errorf("expected %d table entries, got %d", len(expected), len(tableRows))
-		for i, row := range tableRows {
+	expected := []string{
+		"num          1000  uint256",
+		"account      0x9642b23Ed1E01Df1092B92641051881a322F5D4E  address",
+		"secondLayer  TestNestedReturnSecondLayer",
+		"├─ id      10  uint256",
+		"└─ layers  [2 items]  (uint256,address,string)[]",
+		"   ├─ [0]",
+		"   │  ├─ index  1  uint256",
+		"   │  ├─ owner  0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97  address",
+		"   │  └─ text   Hello 1  string",
+		"   └─ [1]",
+		"      ├─ index  2  uint256",
+		"      ├─ owner  0x9642b23Ed1E01Df1092B92641051881a322F5D4E  address",
+		"      └─ text   Hello 2  string",
+		"value        TestNestedReturnSomeValues",
+		"├─ firstVal   16  uint256",
+		"├─ secondVal  30  uint256",
+		"└─ addrVal    0x559432E18b281731c054cD703D4B49872BE4ed53  address",
+	}
+	if len(got) != len(expected) {
+		t.Errorf("expected %d lines, got %d", len(expected), len(got))
+		for i, row := range got {
 			t.Logf("  [%d] %q", i, row)
 		}
 		t.FailNow()
 	}
-
 	for i, want := range expected {
-		if tableRows[i] != want {
-			t.Errorf("row %d:\n  want: %q\n   got: %q", i, want, tableRows[i])
+		if got[i] != want {
+			t.Errorf("row %d:\n  want: %q\n   got: %q", i, want, got[i])
 		}
 	}
 }
@@ -237,16 +232,6 @@ func TestNestedLayerUIRepresentation(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-func filterTableEntries(entries []ui.Entry) []string {
-	var rows []string
-	for _, e := range entries {
-		if e.Method == "Table" {
-			rows = append(rows, e.Value)
-		}
-	}
-	return rows
-}
 
 func assertParam(t *testing.T, d util.ParamDisplay, name, typ string) {
 	t.Helper()
@@ -305,7 +290,7 @@ func TestUndecodedCallShowsContractAndData(t *testing.T) {
 		DecodedFunctionCalls: []*jarviscommon.FunctionCall{inner},
 	}
 
-	d := util.DisplayFunctionCall(rec, outer)
+	d := util.DisplayFunctionCall(rec, outer, networks.EthereumMainnet)
 
 	if d.InnerCalls[0].Data != "0xdeadbeef0000000000000000000000000000000000000000000000000000000000000001" {
 		t.Errorf("inner Data not carried into the view-model: %q", d.InnerCalls[0].Data)
@@ -330,5 +315,22 @@ func TestUndecodedCallShowsContractAndData(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("output missing %q:\n%s", want, joined)
 		}
+	}
+}
+
+func TestInnerCallValueUsesNetworkToken(t *testing.T) {
+	inner := &jarviscommon.FunctionCall{
+		Destination: jarviscommon.Address{Address: "0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97"},
+		Method:      "doSomething",
+		Value:       big.NewInt(1_500_000_000_000_000_000),
+	}
+	outer := &jarviscommon.FunctionCall{
+		Destination:          jarviscommon.Address{Address: "0x9642b23Ed1E01Df1092B92641051881a322F5D4E", Desc: "MultiSend"},
+		Method:               "multiSend",
+		DecodedFunctionCalls: []*jarviscommon.FunctionCall{inner},
+	}
+	d := util.NewFunctionCallDisplay(outer, networks.BSCMainnet)
+	if got := d.InnerCalls[0].Value; got != "1.5 BNB" {
+		t.Fatalf("inner value = %q, want 1.5 BNB", got)
 	}
 }

--- a/util/util.go
+++ b/util/util.go
@@ -346,7 +346,7 @@ func AnalyzeMethodCallAndPrint(
 ) (fc *jarviscommon.FunctionCall) {
 	fc = analyzer.AnalyzeFunctionCallRecursively(
 		GetABI, value, destination, data, customABIs)
-	DisplayFunctionCall(u, fc)
+	DisplayFunctionCall(u, fc, network)
 	return fc
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A walkthrough of `improved-ui` after batches A–D. The core flows (`info`, signing card, batch) are in good shape. This PR covers the leftover operator-visible issues: one real correctness bug, directory commands that still looked pre-redesign, and stale help/cancel copy.

### Correctness

- Signing warnings (`sends X ETH into a contract`, insufficient-funds) and inner-call `value` labels hardcoded 18-decimal ETH. They now use the network's native decimals/symbol (`1.5 BNB` on BSC). `WarningInput.NativeDecimals` of 0 still means 18 so existing tests stay valid.
- `PlainAddress` no longer appends `(unknown)` — that leftover from the analyzer leaked into full layouts, JSON, and `contract read`.

### Directory commands

- `jarvis wallet list` is a table (Address / Kind / Description). Empty state is one line.
- `jarvis addr` / `whois` drop the dashed rule and `(Unknown)`; unknown whois hits read `not in address book`.
- `jarvis network list` is a compact table of name / chain ID / alias / first RPC **host** (`eth.drpc.org +3`). Full URLs (and the Infura keys that lived in them) stay behind `jarvis node list`. Leading-space URLs are trimmed.
- `jarvis msig chains list` uses the same table primitive instead of `fmt.Printf`.

### Help, cancel, voice

- `--from` pointed at a nonexistent `jarvis acc`; `--gasprice` cited ethgasstation.info; `info --json-output` was copy-pasted from `contract read`; `-x/--degen` said “degen prints”.
- `contract encode --help` is a short parameter summary; `contract read` output is the same name/value tree as a call body instead of a bordered table per return, and the `---` batch separators are gone.
- `jarvis version` leads with `jarvis <version>` and the GitHub URL, then the existing Kyber contact lines.
- Every user-initiated cancel (signing card, Safe proposal/approval, `send --from <safe>`) prints `Cancelled — nothing was signed or sent.`
- Wallet-add keystore path drops first-person “I created / I recommend”.
- Classic `msig gov` / ABI errors use `NameFirst` instead of `(Unknown)` / “from etherscan”.
- Classic `msig init` gas-estimation failures go through `ExplainEstimateGasError`.
- Safe cards drop the raw-wei parenthetical on `Value`. `send --from <safe>` no longer reprints Safe address/version/threshold before the card (those are on the card).
- Legacy tip-gas warning: `Legacy tx: ignoring --tipgas (EIP-1559 tips apply only to type-2 txs).`

### Left as-is (not this PR)

These are still worth a follow-up if you want parity everywhere, but they are larger / signing-path-adjacent:

- Classic `msig info` / `approve` still uses the old bordered box, then the signing card on approve (duplicate decode). Safe paths already use the card.
- Classic `msig summary` is still a per-id line dump; Safe summary is structured.
- Hardware-wallet paging in `wallet add` still uses `PromptIndex` rather than `Choose`.
- Classic confirmation-log progress still writes `\r` instead of `Spinner`.

### Tests

`cmd`: `TestNodeHostStripsPathAndKey`. `cmd/util`: native-decimals warning, updated tip-gas wording. `common`: `PlainAddress` omits `unknown`. `util`: `contract read` tree transcript, inner-call value uses `BNB` on BSC.

Verified: `jarvis version`, `wallet list`, `network list` (no Infura keys, hosts only), `send --help` (`--from` / `--gasprice`), `info --json-output`, `contract encode --help`, `msig chains list`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

