### PR TITLE
classic msig and wallet add: signing card, structured summary, Choose paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,12 +123,21 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
   once instead of aliases as separate entries.
 - `jarvis wallet add` offers the wallet kinds as a numbered menu with their
   derivation path or what will be asked next, instead of asking you to type
-  one of five words.
+  one of five words. Hardware-wallet address paging uses the same numbered
+  menu (`next page` / `previous page` / `custom derivation path`) instead of
+  typed keywords mixed with 0-based indices.
 - `jarvis wallet list` is a table (Address / Kind / Description);
   `jarvis addr` / `whois` drop the dashed rule and the `(Unknown)` label;
   `jarvis network list` is a table of names, chain IDs and RPC **hosts**
   (never the full URL, so default Infura keys stay off the screen);
   `jarvis msig chains list` uses the same table primitive.
+- Classic `msig info` / `approve` use the same signing card as Safe (decoded
+  call, Multisig / Tx ID / Status / Signed by) instead of the old bordered
+  box; the following EOA confirm/revoke/execute card collapses the inner
+  call. Classic `msig summary` lists only the pending queue (id, destination,
+  value, sigs, status) rather than every historical tx id. Confirmation and
+  execution log scans use the same `Spinner` as other waits instead of a
+  raw `\r` percentage.
 - `jarvis version` leads with `jarvis <version>` and the GitHub URL, then
   the existing Kyber contact lines.
 - `--from` help points at `jarvis wallet list` (there is no `jarvis acc`);

--- a/README.md
+++ b/README.md
@@ -197,10 +197,11 @@ Events (3)
 
 ### Signing screen
 
-Every `send`, `tx`, `msig init/approve/execute` and WalletConnect request
-ends in the same card. The decoded call comes first, the who/where/cost
-block sits directly above the prompt, and anything jarvis thinks you
-should double-check is listed as a `!` line right before you answer:
+Every `send`, `tx`, `msig init/approve/execute`, Classic and Safe
+`msig info`, and WalletConnect request ends in the same card. The decoded
+call comes first, the who/where/cost block sits directly above the prompt,
+and anything jarvis thinks you should double-check is listed as a `!` line
+right before you answer:
 
 ```
 ================ EOA transaction =================
@@ -225,7 +226,10 @@ native value sent into a contract, calldata jarvis could not decode,
 unlimited ERC-20 approvals, `setApprovalForAll`, approvals to unknown
 spenders, and Safe `DELEGATECALL` operations. Safe cards add the Safe
 address, operation, nonce, `safeTxHash` and the list of collected
-signatures. `-Y` / `--yes` skips the prompt but still prints the card.
+signatures. Classic cards add the multisig, on-chain tx id, confirmation
+progress and the list of confirmers; approving then collapses the inner
+`confirmTransaction` call the same way a Safe execution collapses
+`execTransaction`. `-Y` / `--yes` skips the prompt but still prints the card.
 
 After signing, a live status line replaces the silent wait
 (`⠋ in mempool, waiting to be mined…  0:12`), and once mined jarvis prints
@@ -307,7 +311,7 @@ of multisig you're talking to.
 | `jarvis msig approve`  | yes | yes | Add your approval. Auto-executes when threshold is met. |
 | `jarvis msig execute`  | yes | yes | Broadcast the on-chain execution. |
 | `jarvis msig info`     | yes | yes | Show a specific pending tx with decoded calldata. |
-| `jarvis msig summary`  | yes | yes | List all pending txs for the multisig. |
+| `jarvis msig summary`  | yes | yes | List pending txs (Classic: on-chain queue with id / to / sigs / status; Safe: Transaction Service queue). |
 | `jarvis msig gov`      | yes | yes | Show owners / threshold / version / nonce. |
 | `jarvis msig bapprove` | yes | yes | Batch-approve many pending txs in one shot. Safe refs may be Safe-app URLs, `multisig_<safe>_<hash>` tokens, or `<chain>:<safe>:<hash>` triples. |
 | `jarvis msig revoke`   | yes | **no** | Classic-only; errors with a clear message on Safe addresses. |

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -67,44 +67,74 @@ automatically based on an on-chain probe of the address.`,
 			appUI.Error("Couldn't get number of transactions of the multisig: %s", err)
 			return
 		}
-		appUI.Info("Number of transactions: %d", noTxs)
+		requirement, err := multisigContract.VoteRequirement()
+		if err != nil {
+			appUI.Error("Couldn't get msig requirement: %s", err)
+			return
+		}
+		owners, err := multisigContract.Owners()
+		if err != nil {
+			appUI.Error("Couldn't get owners of the multisig: %s", err)
+			return
+		}
+
+		network := config.Network()
+		msigJarvis := util.GetJarvisAddress(msigAddress, network)
+		appUI.Section("Classic multisig")
+		appUI.Info("Address          : %s", appUI.Style(util.StyledAddress(msigJarvis)))
+		appUI.Info("Vote requirement : %d/%d", requirement, len(owners))
+		appUI.Info("On-chain txs     : %d", noTxs)
+
+		type pendingRow struct {
+			id        int64
+			to        string
+			value     *big.Int
+			confirmed int
+			status    string
+		}
+		pending := []pendingRow{}
 		noExecuted := 0
-		noConfirmed := 0
 		noError := 0
-		nonExecutedConfirmedIds := []int64{}
+		progress := appUI.Spinner(fmt.Sprintf("Checking 0/%d…", noTxs))
 		for i := int64(0); i < noTxs; i++ {
-			executed, err := multisigContract.IsExecuted(big.NewInt(i))
+			progress.Update(fmt.Sprintf("Checking %d/%d…", i+1, noTxs))
+			to, value, _, executed, confirmations, err := multisigContract.TransactionInfo(big.NewInt(i))
 			if err != nil {
-				appUI.Error("%d. error: %s", i, err)
 				noError++
 				continue
 			}
 			if executed {
-				appUI.Success("%d. executed", i)
 				noExecuted++
-				noConfirmed++
 				continue
 			}
-			confirmed, err := multisigContract.IsConfirmed(big.NewInt(i))
-			if err != nil {
-				appUI.Error("%d. error: %s", i, err)
-				noError++
-				continue
-			}
-			if confirmed {
-				appUI.Warn("%d. confirmed - not yet executed", i)
-				nonExecutedConfirmedIds = append(nonExecutedConfirmedIds, i)
-				noConfirmed++
-				continue
-			}
-			appUI.Info("%d. unconfirmed", i)
+			pending = append(pending, pendingRow{
+				id:        i,
+				to:        to,
+				value:     value,
+				confirmed: len(confirmations),
+				status:    cmdutil.ClassicSummaryStatus(len(confirmations), requirement, false),
+			})
 		}
-		appUI.Info("------------")
-		appUI.Info("Total executed txs: %d", noExecuted)
-		appUI.Info("Total confirmed but NOT executed txs: %d. IDs: %v", noConfirmed-noExecuted, nonExecutedConfirmedIds)
-		appUI.Info("Total unconfirmed txs: %d", int(noTxs)-noConfirmed)
+		progress.Stop(ui.StyledText{})
+		appUI.Info("Executed         : %d", noExecuted)
 		if noError > 0 {
 			appUI.Warn("Txs with query errors (excluded from counts above): %d", noError)
+		}
+
+		appUI.Section(fmt.Sprintf("Pending Classic transactions: %d", len(pending)))
+		if len(pending) == 0 {
+			appUI.Info("Queue is empty.")
+			return
+		}
+		for _, p := range pending {
+			toJarvis := util.GetJarvisAddress(p.to, network)
+			progressLabel := fmt.Sprintf("%d/%d", p.confirmed, requirement)
+			appUI.Info("  #%d  sigs %s  status %s", p.id, progressLabel, p.status)
+			appUI.Info("       to     %s", appUI.Style(util.StyledAddress(toJarvis)))
+			if p.value != nil && p.value.Sign() > 0 {
+				amount := jarviscommon.CompactAmount(jarviscommon.BigToFloatString(p.value, network.GetNativeTokenDecimal()))
+				appUI.Info("       value  %s %s", amount, network.GetNativeTokenSymbol())
+			}
 		}
 	},
 }
@@ -153,7 +183,20 @@ or msig tx id / init tx hash for Classic targets.`,
 			return
 		}
 
-		cmdutil.AnalyzeAndShowMsigTxInfo(appUI, multisigContract, txid, config.Network(), cmdutil.DefaultABIResolver{}, tc.Analyzer) //nolint:dogsled
+		_, _, confirmed, executed, err := cmdutil.AnalyzeAndShowMsigTxInfo(appUI, multisigContract, txid, config.Network(), cmdutil.DefaultABIResolver{}, tc.Analyzer)
+		if err != nil {
+			return
+		}
+		switch {
+		case executed:
+			appUI.Success("Status: executed.")
+		case confirmed:
+			appUI.Success("Status: threshold met — ready to execute.")
+			appUI.Info("  jarvis msig execute %s %s%s", msigAddress, txid.String(), networkFlag())
+		default:
+			appUI.Info("Status: pending — needs more approval(s).")
+			appUI.Info("  jarvis msig approve %s %s%s", msigAddress, txid.String(), networkFlag())
+		}
 	},
 }
 
@@ -365,10 +408,6 @@ type msigTxHistory struct {
 
 const logsChunkSize = 9000
 
-func clearProgressLine() {
-	fmt.Fprintf(os.Stdout, "\r%s\r", strings.Repeat(" ", 80))
-}
-
 func queryMsigTxHistory(ethReader *reader.EthReader, msigABI *abi.ABI, msigAddr string, txID *big.Int, fromBlock int64, network jarvisnetworks.Network, executed bool, numConfirmations int) *msigTxHistory {
 	history := &msigTxHistory{}
 	txIDHash := ethcommon.BigToHash(txID)
@@ -385,6 +424,7 @@ func queryMsigTxHistory(ethReader *reader.EthReader, msigABI *abi.ABI, msigAddr 
 	addrs := []string{msigAddr}
 
 	// Phase 1: find all Confirmation events, stop as soon as we have enough
+	progress := appUI.Spinner("Querying confirmation logs…")
 	for start := fromBlock; start <= latestBlock && len(history.confirmations) < numConfirmations; start += logsChunkSize {
 		end := start + logsChunkSize - 1
 		if end > latestBlock {
@@ -392,11 +432,11 @@ func queryMsigTxHistory(ethReader *reader.EthReader, msigABI *abi.ABI, msigAddr 
 		}
 
 		pct := int(float64(start-fromBlock) / float64(totalBlocks) * 100)
-		fmt.Fprintf(os.Stdout, "\r  Querying confirmation logs... %d%%", pct)
+		progress.Update(fmt.Sprintf("Querying confirmation logs… %d%%", pct))
 
 		logs, err := ethReader.GetLogs(int(start), int(end), addrs, confirmTopic)
 		if err != nil {
-			clearProgressLine()
+			progress.Stop(ui.StyledText{})
 			appUI.Warn("Couldn't query confirmation logs: %s", err)
 			return history
 		}
@@ -412,7 +452,7 @@ func queryMsigTxHistory(ethReader *reader.EthReader, msigABI *abi.ABI, msigAddr 
 
 		time.Sleep(200 * time.Millisecond)
 	}
-	clearProgressLine()
+	progress.Stop(ui.StyledText{})
 
 	// Phase 2: find the Execution event if the tx is executed.
 	// Execution can only happen at or after the last confirmation, so
@@ -430,6 +470,7 @@ func queryMsigTxHistory(ethReader *reader.EthReader, msigABI *abi.ABI, msigAddr 
 		execTopic := msigABI.Events["Execution"].ID.Hex()
 		execTotal := latestBlock - execFrom + 1
 
+		progress = appUI.Spinner("Querying execution logs…")
 		for start := execFrom; start <= latestBlock && history.executionTxHash == ""; start += logsChunkSize {
 			end := start + logsChunkSize - 1
 			if end > latestBlock {
@@ -437,11 +478,11 @@ func queryMsigTxHistory(ethReader *reader.EthReader, msigABI *abi.ABI, msigAddr 
 			}
 
 			pct := int(float64(start-execFrom) / float64(execTotal) * 100)
-			fmt.Fprintf(os.Stdout, "\r  Querying execution logs... %d%%", pct)
+			progress.Update(fmt.Sprintf("Querying execution logs… %d%%", pct))
 
 			execLogs, err := ethReader.GetLogs(int(start), int(end), addrs, execTopic)
 			if err != nil {
-				clearProgressLine()
+				progress.Stop(ui.StyledText{})
 				appUI.Warn("Couldn't query execution logs: %s", err)
 				return history
 			}
@@ -454,7 +495,7 @@ func queryMsigTxHistory(ethReader *reader.EthReader, msigABI *abi.ABI, msigAddr 
 
 			time.Sleep(200 * time.Millisecond)
 		}
-		clearProgressLine()
+		progress.Stop(ui.StyledText{})
 	}
 
 	return history
@@ -841,7 +882,11 @@ func approveClassicRef(cm *walletarmy.WalletManager, a *abi.ABI, r *batchResult)
 		return
 	}
 
-	_, numConf, confirmed, executed := cmdutil.AnalyzeAndShowMsigTxInfo(appUI, multisigContract, txid, network, cmdutil.DefaultABIResolver{}, cm.Analyzer(network))
+	_, numConf, confirmed, executed, err := cmdutil.AnalyzeAndShowMsigTxInfo(appUI, multisigContract, txid, network, cmdutil.DefaultABIResolver{}, cm.Analyzer(network))
+	if err != nil {
+		r.status, r.reason = "failed", err.Error()
+		return
+	}
 	if executed {
 		appUI.Warn("Already executed. Skip.")
 		r.history = queryMsigTxHistory(cm.Reader(network), a, msigHex, txid, initBlock, network, true, numConf)
@@ -898,6 +943,7 @@ func approveClassicRef(cm *walletarmy.WalletManager, a *abi.ABI, r *batchResult)
 				appUI.Error("Couldn't build tx: %s", buildError)
 				return buildError
 			}
+			cmdutil.SetClassicSigningNote()
 			err = cmdutil.PromptTxConfirmation(
 				appUI,
 				cm.Analyzer(network),

--- a/cmd/safe_display.go
+++ b/cmd/safe_display.go
@@ -133,7 +133,7 @@ func buildSafeSigningCard(
 }
 
 // decodeSafeCalldata runs the analyzer over the SafeTx payload. It mirrors
-// cmd/util.AnalyzeAndShowMsigTxInfo: fetch the destination ABI through the
+// cmd/util.decodeClassicCalldata: fetch the destination ABI through the
 // resolver (honoring --custom-abi and --erc20) and let the analyzer decode
 // recursively. Returns nil when no analyzer is available or no ABI could be
 // found for a non-MultiSend destination.

--- a/cmd/util/classic_msig_card.go
+++ b/cmd/util/classic_msig_card.go
@@ -1,0 +1,151 @@
+package util
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/config"
+	"github.com/tranvictor/jarvis/msig"
+	jarvisnetworks "github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/ui"
+	"github.com/tranvictor/jarvis/util"
+)
+
+// decodeClassicCalldata runs the analyzer over a Classic msig inner call.
+// It mirrors decodeSafeCalldata: fetch the destination ABI through the
+// resolver (honoring --custom-abi and --erc20) and let the analyzer decode
+// recursively. Returns nil when there is no analyzer or no data.
+func decodeClassicCalldata(
+	to string,
+	value *big.Int,
+	data []byte,
+	network jarvisnetworks.Network,
+	resolver ABIResolver,
+	analyzer util.TxAnalyzer,
+) *jarviscommon.FunctionCall {
+	if analyzer == nil || len(data) == 0 {
+		return nil
+	}
+	customABIs := map[string]*abi.ABI{}
+	if resolver != nil {
+		if destAbi, err := resolver.ConfigToABI(to, config.ForceERC20ABI, config.CustomABI, network); err == nil {
+			customABIs[strings.ToLower(to)] = destAbi
+		}
+	}
+	return analyzer.AnalyzeFunctionCallRecursively(util.GetABI, value, to, data, customABIs)
+}
+
+func buildClassicMsigCard(
+	msigAddr string,
+	txid *big.Int,
+	to string,
+	value *big.Int,
+	data []byte,
+	executed bool,
+	confirmations []string,
+	threshold int64,
+	network jarvisnetworks.Network,
+	fc *jarviscommon.FunctionCall,
+) *SigningCard {
+	toJarvis := util.GetJarvisAddress(to, network)
+	card := &SigningCard{
+		Kind:    "Classic multisig transaction",
+		Network: network.GetName(),
+		To:      util.StyledAddress(toJarvis),
+		Classic: &ClassicCardFields{
+			TxID:          txid.String(),
+			Multisig:      util.StyledAddress(util.GetJarvisAddress(msigAddr, network)),
+			Executed:      executed,
+			Confirmations: len(confirmations),
+			Threshold:     uint64(threshold),
+		},
+	}
+	if value != nil && value.Sign() > 0 {
+		card.Value = jarviscommon.BigToFloatString(value, network.GetNativeTokenDecimal()) +
+			" " + network.GetNativeTokenSymbol()
+	}
+	for _, c := range confirmations {
+		card.Classic.Signatures = append(card.Classic.Signatures, util.StyledAddress(util.GetJarvisAddress(c, network)))
+	}
+
+	warn := WarningInput{
+		To:             toJarvis,
+		Value:          value,
+		NativeSymbol:   network.GetNativeTokenSymbol(),
+		NativeDecimals: network.GetNativeTokenDecimal(),
+		HasData:        len(data) > 0,
+		Call:           fc,
+	}
+	if len(data) > 0 {
+		if isContract, err := util.IsContract(to, network); err == nil {
+			warn.ToIsContract = isContract
+		}
+		if fc != nil && fc.Method != "" {
+			card.Call = util.NewFunctionCallDisplay(fc, network)
+		} else {
+			card.RawData = "0x" + ethcommon.Bytes2Hex(data)
+		}
+	}
+	card.Warnings = SigningWarnings(warn)
+	return card
+}
+
+// AnalyzeAndShowMsigTxInfo fetches a Classic Gnosis transaction by ID, decodes
+// the inner call once, and prints it as a signing card (same shape as Safe
+// `msig info`). The returned FunctionCall is the decode used on the card.
+func AnalyzeAndShowMsigTxInfo(
+	u ui.UI,
+	multisigContract *msig.MultisigContract,
+	txid *big.Int,
+	network jarvisnetworks.Network,
+	resolver ABIResolver,
+	analyzer util.TxAnalyzer,
+) (fc *jarviscommon.FunctionCall, numConfirmations int, confirmed bool, executed bool, err error) {
+	var address string
+	var value *big.Int
+	var data []byte
+	var confirmations []string
+	address, value, data, executed, confirmations, err = multisigContract.TransactionInfo(txid)
+	if err != nil {
+		u.Error("Couldn't get tx info: %s", err)
+		return
+	}
+
+	requirement, err := multisigContract.VoteRequirement()
+	if err != nil {
+		u.Error("Couldn't get msig requirement: %s", err)
+		return
+	}
+
+	numConfirmations = len(confirmations)
+	confirmed = numConfirmations >= int(requirement)
+	fc = decodeClassicCalldata(address, value, data, network, resolver, analyzer)
+	ShowSigningCard(u, buildClassicMsigCard(
+		multisigContract.Address, txid, address, value, data,
+		executed, confirmations, requirement, network, fc,
+	))
+	return
+}
+
+// SetClassicSigningNote collapses the following EOA confirm/revoke/execute
+// card: the inner Classic transaction was just shown.
+func SetClassicSigningNote() {
+	SetNextSigningNote(SigningNote{
+		CollapseCallNote: "(Classic transaction shown above)",
+	})
+}
+
+// ClassicSummaryStatus is the pending-queue label for one Classic tx id.
+func ClassicSummaryStatus(confirmed int, required int64, executed bool) string {
+	if executed {
+		return "executed"
+	}
+	if required > 0 && int64(confirmed) >= required {
+		return "ready to execute"
+	}
+	return "pending"
+}

--- a/cmd/util/classic_msig_card_test.go
+++ b/cmd/util/classic_msig_card_test.go
@@ -1,0 +1,25 @@
+package util
+
+import "testing"
+
+func TestClassicSummaryStatus(t *testing.T) {
+	cases := []struct {
+		confirmed int
+		required  int64
+		executed  bool
+		want      string
+	}{
+		{0, 2, true, "executed"},
+		{2, 2, false, "ready to execute"},
+		{3, 2, false, "ready to execute"},
+		{1, 2, false, "pending"},
+		{0, 0, false, "pending"},
+	}
+	for _, c := range cases {
+		got := ClassicSummaryStatus(c.confirmed, c.required, c.executed)
+		if got != c.want {
+			t.Errorf("ClassicSummaryStatus(%d, %d, %v) = %q, want %q",
+				c.confirmed, c.required, c.executed, got, c.want)
+		}
+	}
+}

--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -153,6 +153,9 @@ type SigningNote struct {
 	// ExecutesSafeTxHash marks the tx as the execTransaction of a Safe tx the
 	// user has just reviewed, so the card links to it and collapses the call.
 	ExecutesSafeTxHash string
+	// CollapseCallNote, when set, collapses the next EOA card's call with this
+	// muted suffix (the inner Classic/Safe tx was just shown).
+	CollapseCallNote string
 	// WalletName and WalletKind describe the signing account; the name fills
 	// in for an address-book entry when there is none, the kind is shown
 	// next to the signer.
@@ -174,6 +177,9 @@ func mergeSigningNote(n SigningNote) {
 	}
 	if nextSigningNote.ExecutesSafeTxHash == "" {
 		nextSigningNote.ExecutesSafeTxHash = n.ExecutesSafeTxHash
+	}
+	if nextSigningNote.CollapseCallNote == "" {
+		nextSigningNote.CollapseCallNote = n.CollapseCallNote
 	}
 	if nextSigningNote.WalletName == "" {
 		nextSigningNote.WalletName = n.WalletName
@@ -321,6 +327,10 @@ func buildEOASigningCard(
 		// Safe params were already shown on the Safe card; only the EOA facts
 		// remain on this one.
 		card.Safe.Operation, card.Safe.SafeNonce, card.Safe.SafeTxHash = "", "", ""
+	}
+	if note != nil && note.CollapseCallNote != "" {
+		card.CollapseCall = true
+		card.CollapseNote = note.CollapseCallNote
 	}
 
 	card.Warnings = SigningWarnings(warn)

--- a/cmd/util/signing_card.go
+++ b/cmd/util/signing_card.go
@@ -18,7 +18,7 @@ import (
 // Addresses on this screen are always complete: the card is the last place a
 // lookalike address can be caught.
 type SigningCard struct {
-	Kind    string // "EOA transaction", "Safe proposal", "Safe approval", "Safe execution"
+	Kind    string // "EOA transaction", "Safe proposal", "Safe approval", "Safe execution", "Classic multisig transaction"
 	Network string
 
 	Signer ui.StyledText
@@ -33,15 +33,20 @@ type SigningCard struct {
 	Gas           string // "max 20.0 gwei, tip 1.5 gwei · 85,123 gas · ≈ 0.0017 ETH"; empty hides
 	Nonce         string
 
-	Safe *SafeCardFields
+	Safe    *SafeCardFields
+	Classic *ClassicCardFields
 
 	// Call is the decoded calldata. Nil when there is none or it could not be
 	// analyzed; RawData is shown instead when set.
 	Call    *util.FunctionCallDisplay
 	RawData string
 	// CollapseCall prints the call as a single header line. Used when the
-	// same call was fully displayed moments ago (Safe approve → execute).
+	// same call was fully displayed moments ago (Safe approve → execute,
+	// Classic info → confirm).
 	CollapseCall bool
+	// CollapseNote is the muted suffix on a collapsed call header. Empty
+	// means "(Safe transaction shown above)".
+	CollapseNote string
 
 	// ClearSign renders the ERC-7730 view when a descriptor matched. It is
 	// a callback so this package does not depend on the erc7730 engine.
@@ -71,6 +76,17 @@ type SafeCardFields struct {
 	Executes string
 }
 
+// ClassicCardFields are the Gnosis Classic tx parameters that have no EOA
+// equivalent: the on-chain tx id, confirmation progress, and confirmer list.
+type ClassicCardFields struct {
+	TxID          string
+	Multisig      ui.StyledText
+	Executed      bool
+	Confirmations int
+	Threshold     uint64
+	Signatures    []ui.StyledText
+}
+
 // ShowSigningCard prints the card. Order is chosen so that what the reader
 // must verify sits directly above the prompt: the call first, then the
 // summary block, then the warnings.
@@ -84,9 +100,13 @@ func ShowSigningCard(u ui.UI, c *SigningCard) {
 	body := c.ClearSign != nil || c.Call != nil || c.RawData != ""
 	switch {
 	case c.Call != nil && c.CollapseCall:
+		note := c.CollapseNote
+		if note == "" {
+			note = "(Safe transaction shown above)"
+		}
 		u.Subsection(fmt.Sprintf("Call  %s  →  %s   %s",
 			c.Call.Method, u.Style(c.Call.Destination),
-			u.Style(ui.StyledText{Text: "(Safe transaction shown above)", Severity: ui.SeverityMuted})))
+			u.Style(ui.StyledText{Text: note, Severity: ui.SeverityMuted})))
 	case c.Call != nil:
 		util.PrintFunctionCall(u, c.Call)
 	case c.RawData != "":
@@ -105,13 +125,18 @@ func ShowSigningCard(u ui.UI, c *SigningCard) {
 	}
 	if c.Signer.Text != "" {
 		rows = append(rows, [2]ui.TableCell{label("Sign with"), ui.TCS(signer, c.Signer.Severity)})
+	} else if c.Network != "" {
+		rows = append(rows, [2]ui.TableCell{label("Network"), ui.TC(c.Network)})
 	}
 	if c.CreateAddress != "" {
 		rows = append(rows, [2]ui.TableCell{label("Creates"), ui.TC(c.CreateAddress)})
 	} else if c.To.Text != "" {
 		toLabel := "Send to"
-		if c.Safe != nil {
+		switch {
+		case c.Safe != nil:
 			toLabel = "Safe calls"
+		case c.Classic != nil:
+			toLabel = "Calls"
 		}
 		rows = append(rows, [2]ui.TableCell{label(toLabel), ui.TCS(c.To.Text, c.To.Severity)})
 	}
@@ -149,19 +174,44 @@ func ShowSigningCard(u ui.UI, c *SigningCard) {
 			), ui.SeverityMuted)})
 		}
 	}
+	if cl := c.Classic; cl != nil {
+		if cl.Multisig.Text != "" {
+			rows = append(rows, [2]ui.TableCell{label("Multisig"), ui.TCS(cl.Multisig.Text, cl.Multisig.Severity)})
+		}
+		if cl.TxID != "" {
+			rows = append(rows, [2]ui.TableCell{label("Tx ID"), ui.TC("#" + cl.TxID)})
+		}
+		status, sev := "pending", ui.SeverityWarn
+		switch {
+		case cl.Executed:
+			status, sev = "executed", ui.SeveritySuccess
+		case cl.Threshold > 0 && uint64(cl.Confirmations) >= cl.Threshold:
+			status, sev = fmt.Sprintf("ready to execute (%d/%d)", cl.Confirmations, cl.Threshold), ui.SeveritySuccess
+		case cl.Threshold > 0:
+			status = fmt.Sprintf("pending (%d/%d)", cl.Confirmations, cl.Threshold)
+		}
+		rows = append(rows, [2]ui.TableCell{label("Status"), ui.TCS(status, sev)})
+	}
 	if body {
 		u.Info("")
 	}
 	u.KeyValueCells(rows)
 
-	if c.Safe != nil && (len(c.Safe.Signatures) > 0 || c.Safe.Threshold > 0) {
-		heading := fmt.Sprintf("Signed by (%d)", len(c.Safe.Signatures))
-		if c.Safe.Threshold > 0 {
-			heading = fmt.Sprintf("Signed by (%d of %d required)", len(c.Safe.Signatures), c.Safe.Threshold)
+	sigs, thresh := []ui.StyledText(nil), uint64(0)
+	switch {
+	case c.Safe != nil && (len(c.Safe.Signatures) > 0 || c.Safe.Threshold > 0):
+		sigs, thresh = c.Safe.Signatures, c.Safe.Threshold
+	case c.Classic != nil && (len(c.Classic.Signatures) > 0 || c.Classic.Threshold > 0):
+		sigs, thresh = c.Classic.Signatures, c.Classic.Threshold
+	}
+	if len(sigs) > 0 || thresh > 0 {
+		heading := fmt.Sprintf("Signed by (%d)", len(sigs))
+		if thresh > 0 {
+			heading = fmt.Sprintf("Signed by (%d of %d required)", len(sigs), thresh)
 		}
 		u.Info("")
 		u.Info("%s", u.Style(ui.StyledText{Text: heading, Severity: ui.SeverityMuted}))
-		for i, s := range c.Safe.Signatures {
+		for i, s := range sigs {
 			u.Indent().Info("%d. %s", i+1, u.Style(s))
 		}
 	}

--- a/cmd/util/signing_card_test.go
+++ b/cmd/util/signing_card_test.go
@@ -275,6 +275,64 @@ func TestSigningWarningsHonourNativeDecimals(t *testing.T) {
 	}
 }
 
+func TestShowSigningCardClassicFields(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	fc := &jarviscommon.FunctionCall{
+		Destination: cardAddr(cardUSDC, "USDC"), Method: "transfer",
+		Params: []jarviscommon.ParamResult{addrParam("to", cardMe, "me"), uintParam("amount", "1000")},
+	}
+	ShowSigningCard(rec, &SigningCard{
+		Kind:    "Classic multisig transaction",
+		Network: "mainnet",
+		To:      util.StyledAddress(cardAddr(cardUSDC, "USDC")),
+		Value:   "1.5 ETH",
+		Call:    util.NewFunctionCallDisplay(fc, nil),
+		Classic: &ClassicCardFields{
+			TxID:          "42",
+			Multisig:      util.StyledAddress(cardAddr(cardMe, "Treasury")),
+			Confirmations: 1,
+			Threshold:     2,
+			Signatures:    []ui.StyledText{util.StyledAddress(cardAddr(cardMe, "me"))},
+		},
+	})
+	for _, w := range []string{
+		"Classic multisig transaction",
+		"Calls: " + cardUSDC + " (USDC)",
+		"Multisig: " + cardMe + " (Treasury)",
+		"Tx ID: #42",
+		"Status: pending (1/2)",
+		"Network: mainnet",
+		"Signed by (1 of 2 required)",
+		"1. " + cardMe + " (me)",
+	} {
+		if !rec.HasMessage(w) {
+			t.Fatalf("missing %q in %v", w, rec.Entries())
+		}
+	}
+	if rec.HasMessage("Safe calls:") {
+		t.Fatalf("Classic card must not use the Safe destination label: %v", rec.Entries())
+	}
+}
+
+func TestShowSigningCardClassicCollapseNote(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	ShowSigningCard(rec, &SigningCard{
+		Kind: "EOA transaction",
+		Call: util.NewFunctionCallDisplay(&jarviscommon.FunctionCall{
+			Destination: cardAddr(cardMe, "Treasury"), Method: "confirmTransaction",
+			Params: []jarviscommon.ParamResult{uintParam("transactionId", "42")},
+		}, nil),
+		CollapseCall: true,
+		CollapseNote: "(Classic transaction shown above)",
+	})
+	if !rec.HasMessage("Call  confirmTransaction  →  " + cardMe + " (Treasury)   (Classic transaction shown above)") {
+		t.Fatalf("collapsed Classic note missing: %v", rec.Entries())
+	}
+	if rec.HasMessage("transactionId  42") {
+		t.Fatalf("collapsed call must not print params: %v", rec.Entries())
+	}
+}
+
 func TestSigningCardShowsWalletKind(t *testing.T) {
 	rec := ui.NewRecordingUI()
 	ShowSigningCard(rec, &SigningCard{

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -27,120 +26,6 @@ import (
 	"github.com/tranvictor/jarvis/util"
 	utilreader "github.com/tranvictor/jarvis/util/reader"
 )
-
-func printBorderedContent(u ui.UI, title string, lines []string) {
-	maxWidth := ui.VisibleWidth(title)
-	for _, line := range lines {
-		if w := ui.VisibleWidth(line); w > maxWidth {
-			maxWidth = w
-		}
-	}
-
-	hLine := strings.Repeat("─", maxWidth+2)
-	boldTitle := u.Style(ui.StyledText{Text: title, Severity: ui.SeverityCritical})
-	titlePad := strings.Repeat(" ", maxWidth-ui.VisibleWidth(title))
-
-	u.Info("")
-	u.Info("┌%s┐", hLine)
-	u.Info("│ %s%s │", boldTitle, titlePad)
-	u.Info("├%s┤", hLine)
-	for _, line := range lines {
-		pad := strings.Repeat(" ", maxWidth-ui.VisibleWidth(line))
-		u.Info("│ %s%s │", line, pad)
-	}
-	u.Info("└%s┘", hLine)
-}
-
-// AnalyzeAndShowMsigTxInfo fetches a multisig transaction by ID, decodes and
-// displays its intent, confirmation status, and list of confirmers.
-func AnalyzeAndShowMsigTxInfo(
-	u ui.UI,
-	multisigContract *msig.MultisigContract,
-	txid *big.Int,
-	network jarvisnetworks.Network,
-	resolver ABIResolver,
-	analyzer util.TxAnalyzer,
-) (fc *jarviscommon.FunctionCall, numConfirmations int, confirmed bool, executed bool) {
-	address, value, data, executed, confirmations, err := multisigContract.TransactionInfo(txid)
-	if err != nil {
-		u.Error("Couldn't get tx info: %s", err)
-		return
-	}
-
-	requirement, err := multisigContract.VoteRequirement()
-	if err != nil {
-		u.Error("Couldn't get msig requirement: %s", err)
-		return
-	}
-
-	numConfirmations = len(confirmations)
-	confirmed = numConfirmations >= int(requirement)
-
-	colorsEnabled := u.Style(ui.StyledText{Text: "x", Severity: ui.SeveritySuccess}) != "x"
-	var buf bytes.Buffer
-	bui := ui.NewTerminalUIWithWriter(&buf, colorsEnabled)
-
-	msigStyled := util.StyledAddress(util.GetJarvisAddress(multisigContract.Address, network))
-	targetStyled := util.StyledAddress(util.GetJarvisAddress(address, network))
-
-	// ── Metadata card (From / To / status / signers) ────────────────────────
-	// Only plain-text lines go into bui so the bordered card stays clean.
-	// The decoded function call is displayed separately below the card where
-	// its own table can use the full terminal width without being nested.
-	bui.Info("From  : %s", bui.Style(msigStyled))
-	bui.Info("To    : %s", bui.Style(targetStyled))
-	if value != nil && value.Sign() > 0 {
-		bui.Info("Value : %f %s",
-			jarviscommon.BigToFloat(value, network.GetNativeTokenDecimal()),
-			network.GetNativeTokenSymbol(),
-		)
-	}
-
-	bui.Info("")
-	executedStr := bui.Style(ui.StyledText{Text: "false", Severity: ui.SeverityWarn})
-	if executed {
-		executedStr = bui.Style(ui.StyledText{Text: "true", Severity: ui.SeveritySuccess})
-	}
-	confirmedStr := bui.Style(ui.StyledText{Text: fmt.Sprintf("false (%d/%d)", len(confirmations), requirement), Severity: ui.SeverityWarn})
-	if confirmed {
-		confirmedStr = bui.Style(ui.StyledText{Text: fmt.Sprintf("true (%d/%d)", len(confirmations), requirement), Severity: ui.SeveritySuccess})
-	}
-	bui.Info("Executed: %s | Confirmed: %s", executedStr, confirmedStr)
-	if len(confirmations) > 0 {
-		bui.Info("Signers:")
-		for i, c := range confirmations {
-			confirmerAddr := util.StyledAddress(util.GetJarvisAddress(c, network))
-			bui.Info("  %d. %s", i+1, bui.Style(confirmerAddr))
-		}
-	}
-
-	content := strings.TrimRight(buf.String(), "\n")
-	lines := strings.Split(content, "\n")
-	title := fmt.Sprintf("Multisig Transaction #%s", txid.String())
-	printBorderedContent(u, title, lines)
-
-	// ── Decoded function call (rendered directly, full-width) ─────────────
-	if len(data) > 0 {
-		destAbi, err := resolver.ConfigToABI(address, config.ForceERC20ABI, config.CustomABI, network)
-		if err != nil {
-			u.Error("Couldn't get abi of destination address: %s", err)
-		} else {
-			fc = util.AnalyzeMethodCallAndPrint(
-				u,
-				analyzer,
-				value,
-				address,
-				data,
-				map[string]*abi.ABI{
-					strings.ToLower(address): destAbi,
-				},
-				network,
-			)
-		}
-	}
-
-	return
-}
 
 // classicMsigABI returns the ABI for packing Gnosis Classic multisig calls.
 // It prefers the verified explorer ABI when available and falls back to the
@@ -236,7 +121,10 @@ func HandleApproveOrRevokeOrExecuteMsig(
 		return
 	}
 
-	fc, _, _, executed := AnalyzeAndShowMsigTxInfo(u, multisigContract, txid, config.Network(), tc.Resolver, analyzer)
+	fc, _, _, executed, err := AnalyzeAndShowMsigTxInfo(u, multisigContract, txid, config.Network(), tc.Resolver, analyzer)
+	if err != nil {
+		return
+	}
 
 	if postProcess != nil && postProcess(fc) != nil {
 		return
@@ -286,6 +174,7 @@ func HandleApproveOrRevokeOrExecuteMsig(
 		return
 	}
 
+	SetClassicSigningNote()
 	if broadcasted, err := SignAndBroadcast(u, tc.FromAcc, tx, nil, reader, analyzer, a, bc); err != nil && !broadcasted && !errors.Is(err, ErrUserCancelled) {
 		u.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
 	}

--- a/cmd/wallet.go
+++ b/cmd/wallet.go
@@ -58,12 +58,12 @@ func getAccDescsFromHW(hw HW, t string, path string) (*types.AccDesc, error) {
 }
 
 func handleHW(hw HW, t string) {
-	var accs []*types.AccDesc
 	var accDesc *types.AccDesc
 	var err error
 
 	batch := 0
 	for {
+		page := make([]*types.AccDesc, 0, WALLET_PAGING)
 		for i := 0; i < WALLET_PAGING; i++ {
 			var pathTemplate string
 			switch t {
@@ -79,32 +79,26 @@ func handleHW(hw HW, t string) {
 			if err != nil {
 				return
 			}
-			accs = append(accs, acc)
+			page = append(page, acc)
 		}
-		for i, acc := range accs {
-			appUI.Info("%d. %s (%s)", i, acc.Address, acc.Derpath)
-		}
-
-		index := cmdutil.PromptIndex(appUI, "Please enter the wallet index you want to add (0, 1, 2,..., next, back, custom)", 0, len(accs)-1)
-		if index == cmdutil.NEXT {
-			batch += 1
+		labels, next, back, custom := hwChooseOptions(page, batch)
+		choice := appUI.Choose("Which address do you want to add?", labels)
+		switch {
+		case choice == next:
+			batch++
 			continue
-		} else if index == cmdutil.BACK {
-			if batch > 0 {
-				batch -= 1
-			} else {
-				appUI.Warn("It can't be back. Continue with path 0")
-			}
+		case back >= 0 && choice == back:
+			batch--
 			continue
-		} else if index == cmdutil.CUSTOM {
+		case choice == custom:
 			path := cmdutil.PromptInput(appUI, "Please enter custom derivation path (eg: m/44'/60'/0'/88)")
 			accDesc, err = getAccDescsFromHW(hw, t, path)
 			if err != nil {
 				return
 			}
 			appUI.Info("%s (%s)", accDesc.Address, accDesc.Derpath)
-		} else {
-			accDesc = accs[index]
+		default:
+			accDesc = page[choice]
 		}
 
 		des := cmdutil.PromptInput(appUI, "Please enter description of this wallet, it will be used to search your wallet by keywords")
@@ -117,6 +111,26 @@ func handleHW(hw HW, t string) {
 		}
 		return
 	}
+}
+
+// hwChooseOptions builds the numbered menu for one page of hardware-wallet
+// addresses. next / back / custom are 0-based indices into labels; back is
+// -1 when this is the first page.
+func hwChooseOptions(page []*types.AccDesc, batch int) (labels []string, next, back, custom int) {
+	labels = make([]string, 0, len(page)+3)
+	for _, a := range page {
+		labels = append(labels, fmt.Sprintf("%s  %s", a.Address, a.Derpath))
+	}
+	next = len(labels)
+	labels = append(labels, "next page")
+	back = -1
+	if batch > 0 {
+		back = len(labels)
+		labels = append(labels, "previous page")
+	}
+	custom = len(labels)
+	labels = append(labels, "custom derivation path")
+	return labels, next, back, custom
 }
 
 func handleLedger(version string) {

--- a/cmd/wallet_test.go
+++ b/cmd/wallet_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tranvictor/jarvis/accounts/types"
+)
+
+func TestHwChooseOptionsFirstPage(t *testing.T) {
+	page := []*types.AccDesc{
+		{Address: "0xaaa", Derpath: "m/44'/60'/0'/0"},
+		{Address: "0xbbb", Derpath: "m/44'/60'/0'/1"},
+	}
+	labels, next, back, custom := hwChooseOptions(page, 0)
+	want := []string{
+		"0xaaa  m/44'/60'/0'/0",
+		"0xbbb  m/44'/60'/0'/1",
+		"next page",
+		"custom derivation path",
+	}
+	if !reflect.DeepEqual(labels, want) {
+		t.Fatalf("labels = %v, want %v", labels, want)
+	}
+	if next != 2 || back != -1 || custom != 3 {
+		t.Fatalf("indices next=%d back=%d custom=%d", next, back, custom)
+	}
+}
+
+func TestHwChooseOptionsLaterPageHasPrevious(t *testing.T) {
+	page := []*types.AccDesc{{Address: "0xccc", Derpath: "m/44'/60'/0'/5"}}
+	labels, next, back, custom := hwChooseOptions(page, 1)
+	want := []string{
+		"0xccc  m/44'/60'/0'/5",
+		"next page",
+		"previous page",
+		"custom derivation path",
+	}
+	if !reflect.DeepEqual(labels, want) {
+		t.Fatalf("labels = %v, want %v", labels, want)
+	}
+	if next != 1 || back != 2 || custom != 3 {
+		t.Fatalf("indices next=%d back=%d custom=%d", next, back, custom)
+	}
+}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -214,6 +214,6 @@ type UI interface {
 
 	// Writer returns an io.Writer that prepends the current indentation
 	// to every line. Use this when calling functions that take io.Writer
-	// directly (e.g. capturing output into a buffer for a bordered box).
+	// directly.
 	Writer() io.Writer
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the leftovers called out in #123: Classic `msig` and hardware-wallet add now use the same UI primitives as Safe / the rest of the redesign.

### Classic `msig info` / `approve`

- The old bordered From/To/Executed box is gone. Classic txs render on the same signing card as Safe (`Calls`, Multisig, Tx ID, Status, Signed by), with the inner call decoded **once**.
- Approving / revoking / executing then shows a collapsed EOA card: `(Classic transaction shown above)`, matching Safe `execTransaction`.
- `msig info` prints the same next-step hints as Safe (`jarvis msig approve` / `execute`). Fetch errors no longer fall through into those hints or into a confirm.

### Classic `msig summary`

- Header: address, vote requirement, on-chain tx count, executed count (spinner while scanning).
- Lists **pending** txs only (id, sigs, status, destination, value) instead of a per-id executed/unconfirmed dump. Empty queue is one line.

### `wallet add` hardware paging

- Each page of 5 addresses is a numbered `Choose` menu: `address  path`, `next page`, `previous page` (after the first page), `custom derivation path`.
- Pages no longer accumulate, so indices stay 1-based and stable.

### Confirmation-log progress

- `Querying confirmation logs…` / `Querying execution logs…` use `Spinner` (empty final line) instead of a raw `\r` percentage.

### Tests

- Classic card transcript + collapsed `(Classic transaction shown above)` note
- `ClassicSummaryStatus`
- `hwChooseOptions` first page vs later page

Stacks on #123 (`cursor/ui-final-pass-3023`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

