### PR TITLE
final check: WC signing cards, msig new Choose, help and Classic gov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,8 +141,17 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 - `jarvis version` leads with `jarvis <version>` and the GitHub URL, then
   the existing Kyber contact lines.
 - `--from` help points at `jarvis wallet list` (there is no `jarvis acc`);
-  `--gasprice` no longer mentions ethgasstation.info; `info --json-output`
-  describes this command; `-x/--degen` says what it expands.
+  `--gasprice` no longer mentions ethgasstation.info; `--abi` fetches from
+  the block explorer (not “etherscan”); `--amount` is native-token units,
+  not hard-coded ETH. `info --json-output` describes this command;
+  `-x/--degen` says what it expands.
+- `msig new` picks Safe vs Classic with the same numbered menu as
+  `wallet add`. Classic `msig gov` uses a `Section` header and
+  “On-chain txs” (the old “transaction inited” line is gone).
+- WalletConnect Classic/Safe `eth_sendTransaction` uses the same signing
+  card as `msig init` (inner Classic call + collapsed EOA wrap, or Safe
+  proposal card). Compact colon-block confirms remain only as a fallback
+  when the UI is not a full terminal, and for `personal_sign` / typed data.
 - `contract encode --help` is a short parameter summary instead of a
   50-line spec; `contract read` output uses the same param tree as a call
   body, not a bordered table per return value.

--- a/README.md
+++ b/README.md
@@ -198,10 +198,11 @@ Events (3)
 ### Signing screen
 
 Every `send`, `tx`, `msig init/approve/execute`, Classic and Safe
-`msig info`, and WalletConnect request ends in the same card. The decoded
-call comes first, the who/where/cost block sits directly above the prompt,
-and anything jarvis thinks you should double-check is listed as a `!` line
-right before you answer:
+`msig info`, and WalletConnect `eth_sendTransaction` ends in the same
+card. WalletConnect `personal_sign` / typed-data still use a compact
+confirm. The decoded call comes first, the who/where/cost block sits
+directly above the prompt, and anything jarvis thinks you should
+double-check is listed as a `!` line right before you answer:
 
 ```
 ================ EOA transaction =================

--- a/cmd/common_flags.go
+++ b/cmd/common_flags.go
@@ -16,6 +16,9 @@ func networkFlag() string {
 	return " --network " + config.Network().GetName()
 }
 
+const customABIFlagHelp = "Custom ABI: a contract address (fetched from the block explorer), a path to an ABI file, or a URL. Ignored when --erc20-abi is set."
+const nativeAmountFlagHelp = "Amount of native token to send with the transaction, in token units not wei."
+
 func AddCommonFlagsToTransactionalCmds(c *cobra.Command) {
 	c.PersistentFlags().
 		Float64VarP(&config.GasPrice, "gasprice", "p", 0, "Gas price in gwei. 0 = suggested by the network's explorer or nodes. The tx uses gasprice + extraprice")

--- a/cmd/contract.go
+++ b/cmd/contract.go
@@ -295,8 +295,8 @@ func init() {
 	txContractCmd.PersistentFlags().StringVarP(&config.PrefillStr, "prefills", "I", "", "Prefill params string. Each param is separated by | char. If the param is \"?\", user input will be prompted.")
 	txContractCmd.PersistentFlags().Uint64VarP(&config.MethodIndex, "method-index", "M", 0, "Index of the method in alphabeth sorted method list of the contract. Index counts from 1.")
 	txContractCmd.PersistentFlags().BoolVarP(&config.ForceERC20ABI, "erc20-abi", "e", false, "Use ERC20 ABI where possible.")
-	txContractCmd.PersistentFlags().StringVarP(&config.CustomABI, "abi", "c", "", "Custom abi. It can be either an address, a path to an abi file or an url to an abi. If it is an address, the abi of that address from etherscan will be queried. This param only takes effect if erc20-abi param is not true.")
-	txContractCmd.Flags().StringVarP(&config.RawValue, "amount", "v", "0", "Amount of eth to send. It is in eth value, not wei.")
+	txContractCmd.PersistentFlags().StringVarP(&config.CustomABI, "abi", "c", "", customABIFlagHelp)
+	txContractCmd.Flags().StringVarP(&config.RawValue, "amount", "v", "0", nativeAmountFlagHelp)
 	txContractCmd.MarkFlagRequired("from")
 	contractCmd.AddCommand(txContractCmd)
 
@@ -306,7 +306,7 @@ func init() {
 	readContractCmd.PersistentFlags().BoolVarP(&config.ForceERC20ABI, "erc20-abi", "e", false, "Use ERC20 ABI where possible.")
 	readContractCmd.PersistentFlags().Int64VarP(&config.AtBlock, "block", "b", -1, "Specify the block to read at. Default value indicates reading at latest state of the chain.")
 	readContractCmd.PersistentFlags().StringVarP(&config.JSONOutputFile, "json-output", "o", "", "write output of contract read to json file")
-	readContractCmd.PersistentFlags().StringVarP(&config.CustomABI, "abi", "c", "", "Custom abi. It can be either an address, a path to an abi file or an url to an abi. If it is an address, the abi of that address from etherscan will be queried. This param only takes effect if erc20-abi param is not true.")
+	readContractCmd.PersistentFlags().StringVarP(&config.CustomABI, "abi", "c", "", customABIFlagHelp)
 	contractCmd.AddCommand(readContractCmd)
 	rootCmd.AddCommand(contractCmd)
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -74,7 +74,7 @@ var txCmd = &cobra.Command{
 
 func init() {
 	txCmd.PersistentFlags().BoolVarP(&config.ForceERC20ABI, "erc20-abi", "e", false, "Use ERC20 ABI where possible.")
-	txCmd.PersistentFlags().StringVarP(&config.CustomABI, "abi", "c", "", "Custom abi. It can be either an address, a path to an abi file or an url to an abi. If it is an address, the abi of that address from etherscan will be queried. This param only takes effect if erc20-abi param is not true.")
+	txCmd.PersistentFlags().StringVarP(&config.CustomABI, "abi", "c", "", customABIFlagHelp)
 	txCmd.PersistentFlags().StringVarP(&config.JSONOutputFile, "json-output", "o", "", "write the analysed transaction display to a JSON file")
 
 	rootCmd.AddCommand(txCmd)

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -232,28 +232,30 @@ the on-chain transaction count.`,
 			return
 		}
 
-		appUI.Info("Owner list:")
+		appUI.Section("Classic governance")
 		owners, err := multisigContract.Owners()
 		if err != nil {
 			appUI.Error("Couldn't get owners of the multisig: %s", err)
 			return
 		}
+		appUI.Info("Address          : %s", appUI.Style(util.StyledAddress(util.GetJarvisAddress(msigAddress, config.Network()))))
+		appUI.Info("Owners (%d):", len(owners))
 		for i, owner := range owners {
 			ja := util.GetJarvisAddress(owner, config.Network())
-			appUI.Info("%d. %s", i+1, jarviscommon.NameFirst(ja, true))
+			appUI.Info("  %d. %s", i+1, appUI.Style(util.StyledAddress(ja)))
 		}
 		voteRequirement, err := multisigContract.VoteRequirement()
 		if err != nil {
 			appUI.Error("Couldn't get vote requirements of the multisig: %s", err)
 			return
 		}
-		appUI.Info("Vote requirement: %d/%d", voteRequirement, len(owners))
+		appUI.Info("Vote requirement : %d/%d", voteRequirement, len(owners))
 		noTxs, err := multisigContract.NOTransactions()
 		if err != nil {
 			appUI.Error("Couldn't get number of transactions of the multisig: %s", err)
 			return
 		}
-		appUI.Info("Number of transaction inited: %d", noTxs)
+		appUI.Info("On-chain txs     : %d", noTxs)
 	},
 }
 
@@ -1049,13 +1051,13 @@ func resolveNewMsigType() (cmdutil.MultisigType, error) {
 	if config.PrefillStr != "" {
 		return cmdutil.MultisigClassic, nil
 	}
-	appUI.Info("Which multisig to deploy?")
-	appUI.Info("1. Gnosis Safe (recommended)")
-	appUI.Info("2. Gnosis Classic")
-	switch cmdutil.PromptIndex(appUI, "Please choose [1, 2]", 1, 2) {
-	case 1:
+	switch appUI.Choose("Which multisig to deploy?", []string{
+		"Gnosis Safe (recommended)",
+		"Gnosis Classic",
+	}) {
+	case 0:
 		return cmdutil.MultisigSafe, nil
-	case 2:
+	case 1:
 		return cmdutil.MultisigClassic, nil
 	default:
 		return cmdutil.MultisigUnknown, fmt.Errorf("no multisig type selected")
@@ -1344,9 +1346,9 @@ func init() {
 	}
 	for _, c := range writeCmds {
 		AddCommonFlagsToTransactionalCmds(c)
-		c.Flags().StringVarP(&config.RawValue, "amount", "v", "0", "Amount of eth to send. It is in native token value, not wei.")
+		c.Flags().StringVarP(&config.RawValue, "amount", "v", "0", nativeAmountFlagHelp)
 		c.PersistentFlags().BoolVarP(&config.ForceERC20ABI, "erc20-abi", "e", false, "Use ERC20 ABI where possible.")
-		c.PersistentFlags().StringVarP(&config.CustomABI, "abi", "c", "", "Custom abi. It can be either an address, a path to an abi file or an url to an abi. If it is an address, the abi of that address from etherscan will be queried. This param only takes effect if erc20-abi param is not true.")
+		c.PersistentFlags().StringVarP(&config.CustomABI, "abi", "c", "", customABIFlagHelp)
 	}
 
 	AddCommonFlagsToTransactionalCmds(newMsigCmd)

--- a/cmd/safe_display.go
+++ b/cmd/safe_display.go
@@ -3,17 +3,11 @@ package cmd
 // Human-readable Safe info, confirmation, and signer printers.
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	cmdutil "github.com/tranvictor/jarvis/cmd/util"
-	jarviscommon "github.com/tranvictor/jarvis/common"
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/safe"
-	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util"
 )
 
@@ -44,143 +38,39 @@ func showSafeInfo(s *safe.SafeContract) {
 type safeCardOptions struct {
 	kind      string // "Safe proposal", "Safe approval", "Safe execution", "Safe transaction"
 	extraABIs map[string]*abi.ABI
-	sigs      []safe.OwnerSig // owners that already signed; rendered under the card
-	threshold uint64          // 0 = unknown; otherwise "n of m required"
-	signer    string          // EOA that will sign, if any
+	sigs      []safe.OwnerSig
+	threshold uint64
+	signer    string
 	prompt    string
 }
 
-// showSafeTxToConfirm displays a SafeTx as a read-only card (no prompt).
-// Pass tc so we can reach the network reader, analyzer, and ABI resolver;
-// pass nil to fall back to a raw-hex display.
 func showSafeTxToConfirm(stx *safe.SafeTx, hash [32]byte, tc *cmdutil.TxContext) {
 	cmdutil.ShowSigningCard(appUI, buildSafeSigningCard(stx, hash, tc, safeCardOptions{kind: "Safe transaction"}))
 }
 
-// buildSafeSigningCard assembles the SigningCard for a SafeTx: the SafeTx
-// parameters in the order Safe wallet UIs show them (so users can sanity-check
-// side by side), the calldata decoded through jarvis's analyzer pipeline, and
-// the derived warnings. extraABIs matter for batches: the calls inside a
-// MultiSend payload frequently target contracts the block explorer can't give
-// an ABI for, and jarvis already knows their signatures because it just
-// encoded them from the tx builder batch.
 func buildSafeSigningCard(
 	stx *safe.SafeTx,
 	hash [32]byte,
 	tc *cmdutil.TxContext,
 	opt safeCardOptions,
 ) *cmdutil.SigningCard {
-	network := config.Network()
-	// util.GetJarvisAddress runs through util.NewEnrichedResolver, which
-	// transparently fetches verified contract names (and follows proxies)
-	// from the block explorer on first miss.
-	toJarvis := util.GetJarvisAddress(stx.To.Hex(), network)
-	isMultiSend := jarviscommon.IsMultiSendCallData(stx.Data)
-
-	card := &cmdutil.SigningCard{
-		Kind:    opt.kind,
-		Network: network.GetName(),
-		To:      util.StyledAddress(toJarvis),
-		Prompt:  opt.prompt,
-		Safe: &cmdutil.SafeCardFields{
-			Operation:      operationLabel(stx.Operation),
-			DelegateCall:   stx.Operation == safe.OpDelegateCall,
-			MultiSend:      isMultiSend,
-			SafeNonce:      stx.Nonce.String(),
-			SafeTxHash:     "0x" + ethcommon.Bytes2Hex(hash[:]),
-			SafeTxGas:      stx.SafeTxGas.String(),
-			BaseGas:        stx.BaseGas.String(),
-			GasPrice:       stx.GasPrice.String(),
-			GasToken:       stx.GasToken.Hex(),
-			RefundReceiver: stx.RefundReceiver.Hex(),
-			Threshold:      opt.threshold,
-		},
+	var resolver cmdutil.ABIResolver
+	var analyzer util.TxAnalyzer
+	if tc != nil {
+		resolver = tc.Resolver
+		analyzer = tc.Analyzer
 	}
-	if opt.signer != "" {
-		card.Signer = util.StyledAddress(util.GetJarvisAddress(opt.signer, network))
-	}
-	if stx.Value != nil && stx.Value.Sign() > 0 {
-		card.Value = jarviscommon.BigToFloatString(stx.Value, network.GetNativeTokenDecimal()) +
-			" " + network.GetNativeTokenSymbol()
-	}
-	for _, sig := range opt.sigs {
-		card.Safe.Signatures = append(card.Safe.Signatures, signerLine(sig))
-	}
-
-	warn := cmdutil.WarningInput{
-		To:             toJarvis,
-		Value:          stx.Value,
-		NativeSymbol:   network.GetNativeTokenSymbol(),
-		NativeDecimals: network.GetNativeTokenDecimal(),
-		HasData:        len(stx.Data) > 0,
-		DelegateCall:   stx.Operation == safe.OpDelegateCall,
-		MultiSend:      isMultiSend,
-	}
-	if len(stx.Data) > 0 {
-		if isContract, err := util.IsContract(stx.To.Hex(), network); err == nil {
-			warn.ToIsContract = isContract
-		}
-		fc := decodeSafeCalldata(stx, tc, opt.extraABIs)
-		if fc != nil {
-			warn.Call = fc
-			card.Call = util.NewFunctionCallDisplay(fc, network)
-		} else {
-			card.RawData = "0x" + ethcommon.Bytes2Hex(stx.Data)
-		}
-	}
-	card.Warnings = cmdutil.SigningWarnings(warn)
-	return card
+	return cmdutil.BuildSafeSigningCard(stx, hash, config.Network(), resolver, analyzer, cmdutil.SafeCardOptions{
+		Kind:      opt.kind,
+		Prompt:    opt.prompt,
+		Signer:    opt.signer,
+		ExtraABIs: opt.extraABIs,
+		Sigs:      opt.sigs,
+		Threshold: opt.threshold,
+	})
 }
 
-// decodeSafeCalldata runs the analyzer over the SafeTx payload. It mirrors
-// cmd/util.decodeClassicCalldata: fetch the destination ABI through the
-// resolver (honoring --custom-abi and --erc20) and let the analyzer decode
-// recursively. Returns nil when no analyzer is available or no ABI could be
-// found for a non-MultiSend destination.
-func decodeSafeCalldata(stx *safe.SafeTx, tc *cmdutil.TxContext, extraABIs map[string]*abi.ABI) *jarviscommon.FunctionCall {
-	if tc == nil || tc.Resolver == nil || tc.Analyzer == nil {
-		return nil
-	}
-	customABIs := map[string]*abi.ABI{}
-	for addr, a := range extraABIs {
-		customABIs[strings.ToLower(addr)] = a
-	}
-	destAbi, err := tc.Resolver.ConfigToABI(
-		stx.To.Hex(), config.ForceERC20ABI, config.CustomABI, config.Network(),
-	)
-	if err != nil {
-		// MultiSend / MultiSendCallOnly is unverified on many explorers, so a
-		// failure here is expected for batches and must not abort the decode:
-		// the analyzer has a built-in multiSend ABI to fall back on.
-		if len(customABIs) == 0 && !jarviscommon.IsMultiSendCallData(stx.Data) {
-			return nil
-		}
-	} else if _, taken := customABIs[strings.ToLower(stx.To.Hex())]; !taken {
-		customABIs[strings.ToLower(stx.To.Hex())] = destAbi
-	}
-	return tc.Analyzer.AnalyzeFunctionCallRecursively(
-		util.GetABI, stx.Value, stx.To.Hex(), stx.Data, customABIs,
-	)
-}
-
-// signerLine renders one owner signature, tagged "[on-chain]" when it was an
-// approveHash rather than an off-chain signature.
-func signerLine(s safe.OwnerSig) ui.StyledText {
-	jarvisAddr := util.GetJarvisAddress(s.Owner.Hex(), config.Network())
-	tag := "[off-chain]"
-	if safe.IsOnChainApproval(s.Sig) {
-		tag = "[on-chain] "
-	}
-	st := util.StyledAddress(jarvisAddr)
-	st.Text = tag + " " + st.Text
-	return st
-}
-
-// showSafeSigners renders the list of owners that have already signed,
-// resolving each address through the jarvis address book so names show up
-// the same way `jarvis msig` displays confirmation lists. Entries produced
-// by OnChainApprovalSig (v=0) are tagged "[on-chain]" so users can tell at a
-// glance which owners approved via approveHash rather than off-chain signing.
+// showSafeSigners renders the list of owners that have already signed.
 func showSafeSigners(label string, sigs []safe.OwnerSig) {
 	if len(sigs) == 0 {
 		appUI.Info("%s: (none yet)", label)
@@ -194,16 +84,5 @@ func showSafeSigners(label string, sigs []safe.OwnerSig) {
 			tag = "[on-chain] "
 		}
 		appUI.Info("  %d. %s %s", i+1, tag, appUI.Style(util.StyledAddress(jarvisAddr)))
-	}
-}
-
-func operationLabel(op safe.Operation) string {
-	switch op {
-	case safe.OpCall:
-		return "CALL (0)"
-	case safe.OpDelegateCall:
-		return "DELEGATECALL (1)"
-	default:
-		return fmt.Sprintf("UNKNOWN (%d)", op)
 	}
 }

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -588,8 +588,8 @@ func detectSafeForSend(
 // SafeTx (native transfer or ERC20 transfer) targeting --to with the
 // given amount, signs the EIP-712 safeTxHash with the single local
 // wallet that's also a Safe owner, and submits the proposal to the Safe
-// Transaction Service. The print-out matches `jarvis safe init` so the
-// follow-up commands (approve / execute) are immediately discoverable.
+// Transaction Service. Follow-up commands (approve / execute) are printed
+// the same way as `jarvis msig init`.
 func sendFromSafe(
 	reader utilreader.Reader,
 	analyzer util.TxAnalyzer,
@@ -740,8 +740,8 @@ func sendFromSafe(
 
 func init() {
 	AddCommonFlagsToTransactionalCmds(sendCmd)
-	sendCmd.Flags().StringVarP(&to, "to", "t", "", "Account to send eth to. It can be ethereum address or a hint string to look it up in the address database. See jarvis addr for all of the known addresses")
-	sendCmd.Flags().StringVarP(&value, "amount", "v", "0", "Amount of eth to send. It is in eth/token value, not wei/twei. If a float number is passed, it will be interpreted as ETH, otherwise, it must be in the form of `float|ALL address` or `float|ALL name`. In the later case, `name` will be used to look for the token address. Eg. 0.01, 0.01 knc, 0.01 0xdd974d5c2e2928dea5f71b9825b8b646686bd200, ALL KNC are valid values.")
+	sendCmd.Flags().StringVarP(&to, "to", "t", "", "Account to send to. It can be an address or a keyword (see jarvis addr)")
+	sendCmd.Flags().StringVarP(&value, "amount", "v", "0", "Amount to send, in token units not wei. A bare number is the network native token; otherwise amount token (e.g. 0.01, 0.01 knc, ALL KNC).")
 	sendCmd.Flags().StringVarP(&data, "data", "D", "", "Data to send along with the transaction. It is in hex format.")
 	sendCmd.MarkFlagRequired("to")
 	sendCmd.MarkFlagRequired("amount")

--- a/cmd/util/classic_msig_card.go
+++ b/cmd/util/classic_msig_card.go
@@ -57,12 +57,14 @@ func buildClassicMsigCard(
 		Network: network.GetName(),
 		To:      util.StyledAddress(toJarvis),
 		Classic: &ClassicCardFields{
-			TxID:          txid.String(),
 			Multisig:      util.StyledAddress(util.GetJarvisAddress(msigAddr, network)),
 			Executed:      executed,
 			Confirmations: len(confirmations),
 			Threshold:     uint64(threshold),
 		},
+	}
+	if txid != nil {
+		card.Classic.TxID = txid.String()
 	}
 	if value != nil && value.Sign() > 0 {
 		card.Value = jarviscommon.BigToFloatString(value, network.GetNativeTokenDecimal()) +
@@ -129,6 +131,21 @@ func AnalyzeAndShowMsigTxInfo(
 		executed, confirmations, requirement, network, fc,
 	))
 	return
+}
+
+// BuildClassicProposalCard is the inner Classic call a WalletConnect dApp
+// (or similar) wants the msig to submit. There is no on-chain tx id yet.
+func BuildClassicProposalCard(
+	msigAddr, to string,
+	value *big.Int,
+	data []byte,
+	threshold int64,
+	network jarvisnetworks.Network,
+	resolver ABIResolver,
+	analyzer util.TxAnalyzer,
+) *SigningCard {
+	fc := decodeClassicCalldata(to, value, data, network, resolver, analyzer)
+	return buildClassicMsigCard(msigAddr, nil, to, value, data, false, nil, threshold, network, fc)
 }
 
 // SetClassicSigningNote collapses the following EOA confirm/revoke/execute

--- a/cmd/util/safe_signing_card.go
+++ b/cmd/util/safe_signing_card.go
@@ -1,0 +1,147 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/config"
+	jarvisnetworks "github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/safe"
+	"github.com/tranvictor/jarvis/ui"
+	"github.com/tranvictor/jarvis/util"
+)
+
+// SafeCardOptions are the per-flow choices when building a Safe signing card.
+type SafeCardOptions struct {
+	Kind      string // "Safe proposal", "Safe approval", "Safe execution", "Safe transaction"
+	Prompt    string
+	Signer    string // EOA that will sign, if any
+	ExtraABIs map[string]*abi.ABI
+	Sigs      []safe.OwnerSig
+	Threshold uint64 // 0 = unknown; otherwise "n of m required"
+}
+
+// BuildSafeSigningCard assembles the SigningCard for a SafeTx. extraABIs
+// matter for batches: inner MultiSend calls often target contracts the
+// explorer cannot name, and jarvis already knows those signatures.
+func BuildSafeSigningCard(
+	stx *safe.SafeTx,
+	hash [32]byte,
+	network jarvisnetworks.Network,
+	resolver ABIResolver,
+	analyzer util.TxAnalyzer,
+	opt SafeCardOptions,
+) *SigningCard {
+	toJarvis := util.GetJarvisAddress(stx.To.Hex(), network)
+	isMultiSend := jarviscommon.IsMultiSendCallData(stx.Data)
+
+	card := &SigningCard{
+		Kind:    opt.Kind,
+		Network: network.GetName(),
+		To:      util.StyledAddress(toJarvis),
+		Prompt:  opt.Prompt,
+		Safe: &SafeCardFields{
+			Operation:      safeOperationLabel(stx.Operation),
+			DelegateCall:   stx.Operation == safe.OpDelegateCall,
+			MultiSend:      isMultiSend,
+			SafeNonce:      stx.Nonce.String(),
+			SafeTxHash:     "0x" + ethcommon.Bytes2Hex(hash[:]),
+			SafeTxGas:      stx.SafeTxGas.String(),
+			BaseGas:        stx.BaseGas.String(),
+			GasPrice:       stx.GasPrice.String(),
+			GasToken:       stx.GasToken.Hex(),
+			RefundReceiver: stx.RefundReceiver.Hex(),
+			Threshold:      opt.Threshold,
+		},
+	}
+	if opt.Signer != "" {
+		card.Signer = util.StyledAddress(util.GetJarvisAddress(opt.Signer, network))
+	}
+	if stx.Value != nil && stx.Value.Sign() > 0 {
+		card.Value = jarviscommon.BigToFloatString(stx.Value, network.GetNativeTokenDecimal()) +
+			" " + network.GetNativeTokenSymbol()
+	}
+	for _, sig := range opt.Sigs {
+		card.Safe.Signatures = append(card.Safe.Signatures, safeSignerLine(sig, network))
+	}
+
+	warn := WarningInput{
+		To:             toJarvis,
+		Value:          stx.Value,
+		NativeSymbol:   network.GetNativeTokenSymbol(),
+		NativeDecimals: network.GetNativeTokenDecimal(),
+		HasData:        len(stx.Data) > 0,
+		DelegateCall:   stx.Operation == safe.OpDelegateCall,
+		MultiSend:      isMultiSend,
+	}
+	if len(stx.Data) > 0 {
+		if isContract, err := util.IsContract(stx.To.Hex(), network); err == nil {
+			warn.ToIsContract = isContract
+		}
+		fc := decodeSafeCalldata(stx, network, resolver, analyzer, opt.ExtraABIs)
+		if fc != nil {
+			warn.Call = fc
+			card.Call = util.NewFunctionCallDisplay(fc, network)
+		} else {
+			card.RawData = "0x" + ethcommon.Bytes2Hex(stx.Data)
+		}
+	}
+	card.Warnings = SigningWarnings(warn)
+	return card
+}
+
+func decodeSafeCalldata(
+	stx *safe.SafeTx,
+	network jarvisnetworks.Network,
+	resolver ABIResolver,
+	analyzer util.TxAnalyzer,
+	extraABIs map[string]*abi.ABI,
+) *jarviscommon.FunctionCall {
+	if analyzer == nil {
+		return nil
+	}
+	customABIs := map[string]*abi.ABI{}
+	for addr, a := range extraABIs {
+		customABIs[strings.ToLower(addr)] = a
+	}
+	if resolver != nil {
+		destAbi, err := resolver.ConfigToABI(
+			stx.To.Hex(), config.ForceERC20ABI, config.CustomABI, network,
+		)
+		if err != nil {
+			if len(customABIs) == 0 && !jarviscommon.IsMultiSendCallData(stx.Data) {
+				return nil
+			}
+		} else if _, taken := customABIs[strings.ToLower(stx.To.Hex())]; !taken {
+			customABIs[strings.ToLower(stx.To.Hex())] = destAbi
+		}
+	}
+	return analyzer.AnalyzeFunctionCallRecursively(
+		util.GetABI, stx.Value, stx.To.Hex(), stx.Data, customABIs,
+	)
+}
+
+func safeSignerLine(s safe.OwnerSig, network jarvisnetworks.Network) ui.StyledText {
+	st := util.StyledAddress(util.GetJarvisAddress(s.Owner.Hex(), network))
+	tag := "[off-chain]"
+	if safe.IsOnChainApproval(s.Sig) {
+		tag = "[on-chain] "
+	}
+	st.Text = tag + " " + st.Text
+	return st
+}
+
+func safeOperationLabel(op safe.Operation) string {
+	switch op {
+	case safe.OpCall:
+		return "CALL (0)"
+	case safe.OpDelegateCall:
+		return "DELEGATECALL (1)"
+	default:
+		return fmt.Sprintf("UNKNOWN (%d)", op)
+	}
+}

--- a/cmd/util/signing_card_test.go
+++ b/cmd/util/signing_card_test.go
@@ -333,6 +333,24 @@ func TestShowSigningCardClassicCollapseNote(t *testing.T) {
 	}
 }
 
+func TestShowSigningCardClassicProposalOmitsTxID(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	ShowSigningCard(rec, &SigningCard{
+		Kind: "Classic multisig transaction",
+		To:   util.StyledAddress(cardAddr(cardUSDC, "USDC")),
+		Classic: &ClassicCardFields{
+			Multisig:  util.StyledAddress(cardAddr(cardMe, "Treasury")),
+			Threshold: 2,
+		},
+	})
+	if rec.HasMessage("Tx ID:") {
+		t.Fatalf("proposal card must not invent a tx id: %v", rec.Entries())
+	}
+	if !rec.HasMessage("Classic multisig transaction") || !rec.HasMessage("Multisig: "+cardMe+" (Treasury)") {
+		t.Fatalf("proposal card missing: %v", rec.Entries())
+	}
+}
+
 func TestSigningCardShowsWalletKind(t *testing.T) {
 	rec := ui.NewRecordingUI()
 	ShowSigningCard(rec, &SigningCard{

--- a/cmd/wallet.go
+++ b/cmd/wallet.go
@@ -101,13 +101,13 @@ func handleHW(hw HW, t string) {
 			accDesc = page[choice]
 		}
 
-		des := cmdutil.PromptInput(appUI, "Please enter description of this wallet, it will be used to search your wallet by keywords")
+		des := cmdutil.PromptInput(appUI, "Please enter a description — used later to find this wallet by keyword")
 		accDesc.Desc = des
 		if err = accounts.StoreAccountRecord(*accDesc); err != nil {
 			appUI.Error("Couldn't store your wallet info: %s. Abort.", err)
 		} else {
 			appUI.Success("Created ~/.jarvis/%s.json to store the wallet info.", accDesc.Address)
-			appUI.Info("Your wallet is added successfully. You can check your list of wallets using the following command:\n> jarvis wallet list")
+			appUI.Info("Added. Check the list with: jarvis wallet list")
 		}
 		return
 	}

--- a/walletconnect/gateways/classic.go
+++ b/walletconnect/gateways/classic.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
@@ -190,28 +191,8 @@ func (g *ClassicGateway) SendTransaction(
 		priceGwei, tipGwei, outerData, g.network.GetChainID(),
 	)
 
-	g.ui.Info("Multisig : %s", shortLabel(g.addr.Hex(), g.network))
-	g.ui.Info("Owner    : %s", ownerAddr)
-	g.ui.Info("To       : %s", shortLabel(innerTo.Hex(), g.network))
-	if innerValue.Sign() > 0 {
-		g.ui.Info("Value    : %s %s",
-			jarviscommon.BigToFloat(innerValue, g.network.GetNativeTokenDecimal()),
-			g.network.GetNativeTokenSymbol())
-	}
-	if len(innerData) > 0 {
-		preview := ethcommon.Bytes2Hex(innerData)
-		if len(preview) > 80 {
-			preview = preview[:80] + "…"
-		}
-		g.ui.Info("Data     : 0x%s", preview)
-	}
-	g.ui.Info("Outer gas: %d @ %v gwei", gasLimit, priceGwei)
-
-	if !g.ui.Confirm(
-		"Wrap this call in submitTransaction and broadcast it from the owner wallet?",
-		true,
-	) {
-		return "", walletconnect.ErrUserRejected
+	if err := g.promptClassicConfirm(ethTx, innerTo.Hex(), innerValue, innerData, msigABI); err != nil {
+		return "", err
 	}
 
 	ac, err := g.unlock()
@@ -245,6 +226,60 @@ func (g *ClassicGateway) SendTransaction(
 		go g.waitAndAnalyze(fullUI, signedTx)
 	}
 	return hash, nil
+}
+
+func (g *ClassicGateway) promptClassicConfirm(
+	ethTx *types.Transaction,
+	innerTo string,
+	innerValue *big.Int,
+	innerData []byte,
+	msigABI *abi.ABI,
+) error {
+	if fullUI, ok := g.ui.(jarvisui.UI); ok {
+		analyzer := txanalyzer.NewGenericAnalyzer(g.reader, g.network)
+		threshold, _ := g.msig.VoteRequirement()
+		inner := cmdutil.BuildClassicProposalCard(
+			g.addr.Hex(), innerTo, innerValue, innerData,
+			threshold, g.network, g.resolver, analyzer,
+		)
+		cmdutil.ShowSigningCard(fullUI, inner)
+		cmdutil.SetNextSigningNote(cmdutil.SigningNote{
+			CollapseCallNote: "(Classic transaction shown above)",
+			WalletName:       g.owner.Desc,
+			WalletKind:       g.owner.Kind,
+		})
+		customABIs := map[string]*abi.ABI{strings.ToLower(g.addr.Hex()): msigABI}
+		if a, err := g.resolver.ConfigToABI(innerTo, false, "", g.network); err == nil && a != nil {
+			customABIs[strings.ToLower(innerTo)] = a
+		}
+		fromAddr := util.GetJarvisAddress(g.owner.Address, g.network)
+		if err := cmdutil.PromptTxConfirmation(fullUI, analyzer, fromAddr, ethTx, customABIs, g.network); err != nil {
+			return walletconnect.ErrUserRejected
+		}
+		return nil
+	}
+	g.ui.Info("Multisig : %s", shortLabel(g.addr.Hex(), g.network))
+	g.ui.Info("Owner    : %s", g.owner.Address)
+	g.ui.Info("To       : %s", shortLabel(innerTo, g.network))
+	if innerValue.Sign() > 0 {
+		g.ui.Info("Value    : %s %s",
+			jarviscommon.BigToFloat(innerValue, g.network.GetNativeTokenDecimal()),
+			g.network.GetNativeTokenSymbol())
+	}
+	if len(innerData) > 0 {
+		preview := ethcommon.Bytes2Hex(innerData)
+		if len(preview) > 80 {
+			preview = preview[:80] + "…"
+		}
+		g.ui.Info("Data     : 0x%s", preview)
+	}
+	if !g.ui.Confirm(
+		"Wrap this call in submitTransaction and broadcast it from the owner wallet?",
+		true,
+	) {
+		return walletconnect.ErrUserRejected
+	}
+	return nil
 }
 
 func (g *ClassicGateway) waitAndAnalyze(

--- a/walletconnect/gateways/safe.go
+++ b/walletconnect/gateways/safe.go
@@ -12,6 +12,8 @@ import (
 	jarviscommon "github.com/tranvictor/jarvis/common"
 	jarvisnetworks "github.com/tranvictor/jarvis/networks"
 	"github.com/tranvictor/jarvis/safe"
+	"github.com/tranvictor/jarvis/txanalyzer"
+	jarvisui "github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util/account"
 	"github.com/tranvictor/jarvis/walletconnect"
 )
@@ -166,26 +168,8 @@ func (g *SafeGateway) SendTransaction(
 	stx := safe.NewSafeTx(to, value, data, safe.OpCall, nonce)
 	hash := stx.SafeTxHash(domainSep)
 
-	g.ui.Info("Safe       : %s", shortLabel(g.addr.Hex(), g.network))
-	g.ui.Info("Owner      : %s", g.owner.Address)
-	g.ui.Info("To         : %s", shortLabel(to.Hex(), g.network))
-	if value.Sign() > 0 {
-		g.ui.Info("Value      : %s %s",
-			jarviscommon.BigToFloat(value, g.network.GetNativeTokenDecimal()),
-			g.network.GetNativeTokenSymbol())
-	}
-	g.ui.Info("Nonce      : %d", nonce)
-	if len(data) > 0 {
-		preview := ethcommon.Bytes2Hex(data)
-		if len(preview) > 80 {
-			preview = preview[:80] + "…"
-		}
-		g.ui.Info("Data       : 0x%s", preview)
-	}
-	g.ui.Info("safeTxHash : 0x%s", hex.EncodeToString(hash[:]))
-
-	if !g.ui.Confirm("Sign this Safe proposal and submit to the transaction service?", true) {
-		return "", walletconnect.ErrUserRejected
+	if err := g.promptSafeConfirm(stx, hash); err != nil {
+		return "", err
 	}
 
 	ac, err := g.unlock()
@@ -217,6 +201,49 @@ func (g *SafeGateway) SendTransaction(
 	// explorer link; that link won't resolve until the Safe executes,
 	// but giving the dApp something well-formed keeps its UI happy.
 	return "0x" + hex.EncodeToString(hash[:]), nil
+}
+
+func (g *SafeGateway) promptSafeConfirm(stx *safe.SafeTx, hash [32]byte) error {
+	if fullUI, ok := g.ui.(jarvisui.UI); ok {
+		rd, err := jarvisNetReader(g.network)
+		if err != nil {
+			return fmt.Errorf("reader for signing card: %w", err)
+		}
+		analyzer := txanalyzer.NewGenericAnalyzer(rd, g.network)
+		threshold, _ := g.safe.Threshold()
+		card := cmdutil.BuildSafeSigningCard(stx, hash, g.network, g.resolver, analyzer, cmdutil.SafeCardOptions{
+			Kind:      "Safe proposal",
+			Prompt:    "Sign this Safe proposal and submit to the transaction service?",
+			Signer:    g.owner.Address,
+			Threshold: threshold,
+		})
+		if !cmdutil.ConfirmSigningCard(fullUI, card) {
+			cmdutil.WarnCancelled(fullUI)
+			return walletconnect.ErrUserRejected
+		}
+		return nil
+	}
+	g.ui.Info("Safe       : %s", shortLabel(g.addr.Hex(), g.network))
+	g.ui.Info("Owner      : %s", g.owner.Address)
+	g.ui.Info("To         : %s", shortLabel(stx.To.Hex(), g.network))
+	if stx.Value != nil && stx.Value.Sign() > 0 {
+		g.ui.Info("Value      : %s %s",
+			jarviscommon.BigToFloat(stx.Value, g.network.GetNativeTokenDecimal()),
+			g.network.GetNativeTokenSymbol())
+	}
+	g.ui.Info("Nonce      : %s", stx.Nonce.String())
+	if len(stx.Data) > 0 {
+		preview := ethcommon.Bytes2Hex(stx.Data)
+		if len(preview) > 80 {
+			preview = preview[:80] + "…"
+		}
+		g.ui.Info("Data       : 0x%s", preview)
+	}
+	g.ui.Info("safeTxHash : 0x%s", hex.EncodeToString(hash[:]))
+	if !g.ui.Confirm("Sign this Safe proposal and submit to the transaction service?", true) {
+		return walletconnect.ErrUserRejected
+	}
+	return nil
 }
 
 func (g *SafeGateway) unlock() (*account.Account, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Walkthrough of `improved-ui` after #123 and #124 merged. The core `info` / signing-card / Classic msig / batch flows look complete. This PR is the leftover operator-visible nits, plus the one README lie: WalletConnect `eth_sendTransaction` still used the old colon-block confirm.

### WalletConnect

- Classic: inner call on the Classic signing card, then the EOA `submitTransaction` card collapsed with `(Classic transaction shown above)` — same shape as `msig approve`.
- Safe: `ConfirmSigningCard` on a Safe proposal card (decoded call, nonce, `safeTxHash`).
- Compact colon-block + `Confirm` remains only when the UI is not a full terminal, and for `personal_sign` / typed data.

### Smaller leftovers

- `msig new` uses `Choose` for Safe vs Classic (same numbered menu as `wallet add`).
- `--abi` help says “block explorer”, not etherscan. `--amount` is native-token units; `send --amount` no longer says a bare number is ETH.
- Classic `msig gov` gets a `Section` header and “On-chain txs” (the “transaction inited” typo is gone).
- Hardware-wallet `wallet add` success copy matches the keystore path.
- Stale `jarvis safe init` comment on `send --from <safe>`.

### Left as-is (not this PR)

These are still uneven if you want the redesign everywhere, but they are larger or not signing-path:

- WalletConnect `personal_sign` / `eth_signTypedData_v4` (compact confirm + optional ERC-7730 box).
- ERC-7730 native amounts still assume 18 / ETH.
- `network add` wizard, `addr` list, `version` block, `contract encode` preamble.
- Safe `msig approve` still shows the card then a separate confirm so already-signed owners can review without being asked to sign again.
- Declining Safe auto-exec after an approval already landed still says “Skipping execution” rather than “Cancelled — nothing was signed” (the approval *was* signed).

### Tests

Classic proposal card omits Tx ID. Existing `cmd`, `cmd/util`, `walletconnect/gateways` tests pass.

Verified locally: `jarvis --help`, `version` (Kyber lines intact), `send --help` (`--amount` / `--to`), `info --help` (`--abi`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

