### PR TITLE
info: print ERC-7730 clear-signed messages when a descriptor matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
   the date alone; `--degen` keeps the raw seconds. The same applies to the
   echo of a typed parameter, so a stale deadline shows as "… ago" before
   signing.
+- When an ERC-7730 descriptor matches, a green **Clear Signed** panel is
+  printed above the ABI call — the same view as at sign time, including
+  inner MultiSend / Safe destinations. No match leaves the output unchanged.
 
 ### Interactive parameter entry
 

--- a/README.md
+++ b/README.md
@@ -194,13 +194,18 @@ Events (3)
   recovered by replaying the call, is the red `reason` line under the
   headline. Events that no ABI describes are listed as `<undecoded>` with
   their raw topics so the event count is always complete.
+- When an ERC-7730 descriptor matches the call (or an inner MultiSend / Safe
+  call), a green **Clear Signed** panel is printed above the ABI **Call**
+  tree — the same view shown at sign time. No match leaves the output
+  unchanged.
 
 ### Signing screen
 
 Every `send`, `tx`, `msig init/approve/execute`, Classic and Safe
 `msig info`, and WalletConnect `eth_sendTransaction` ends in the same
 card. WalletConnect `personal_sign` / typed-data still use a compact
-confirm. The decoded call comes first, the who/where/cost block sits
+confirm. The decoded call comes first (with a green Clear Signed panel
+above it when an ERC-7730 descriptor matches), the who/where/cost block sits
 directly above the prompt, and anything jarvis thinks you should
 double-check is listed as a `!` line right before you answer:
 

--- a/cmd/clearsign.go
+++ b/cmd/clearsign.go
@@ -31,14 +31,14 @@ var clearsignDisableContract string
 
 // clearsignCmd groups the subcommands that operate on the local
 // ERC-7730 descriptor registry. The registry is the source of truth
-// for the clear-signed view shown at sign time by `jarvis send`,
-// `jarvis msig` and `jarvis wc`.
+// for the clear-signed view shown by `jarvis info` and at sign time
+// by `jarvis send`, `jarvis msig` and `jarvis wc`.
 var clearsignCmd = &cobra.Command{
 	Use:   "clearsign",
 	Short: "Manage ERC-7730 clear-signing descriptors used by jarvis",
 	Long: `clearsign manages the on-disk ERC-7730 registry that powers the
-green-bordered "Clear Signed" panel jarvis shows before every
-transaction or typed-data signature.
+green-bordered "Clear Signed" panel jarvis shows on jarvis info
+and before every transaction or typed-data signature.
 
 Descriptors live under ~/.jarvis/erc7730/:
   registry/  — mirror of github.com/ethereum/clear-signing-erc7730-registry

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -66,6 +66,7 @@ var txCmd = &cobra.Command{
 				nil,
 				nil,
 				util.InfoLayout(config.DegenMode),
+				cmdutil.InfoClearSign(config.Network()),
 			)
 			displays[t] = d
 		}

--- a/cmd/util/clearsign_test.go
+++ b/cmd/util/clearsign_test.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"bytes"
+	"testing"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/ui"
+	"github.com/tranvictor/jarvis/util"
+)
+
+func TestRenderContractClearSignRejectsShortCalldata(t *testing.T) {
+	var buf bytes.Buffer
+	u := ui.NewTerminalUIWithWriter(&buf, false)
+	if RenderContractClearSign(u, networks.EthereumMainnet, "0x0000000000000000000000000000000000000001", nil, []byte{1, 2, 3}, nil, nil) {
+		t.Fatal("short calldata must not match")
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("printed %q", buf.String())
+	}
+}
+
+func TestInfoClearSignAttachesCallback(t *testing.T) {
+	d := &util.TxDisplay{}
+	r := &jarviscommon.TxResult{FunctionCall: &jarviscommon.FunctionCall{Method: "approve"}}
+	InfoClearSign(networks.EthereumMainnet)(d, r, nil)
+	if d.ClearSign == nil {
+		t.Fatal("expected ClearSign callback")
+	}
+}
+
+func TestInfoClearSignNilCallDoesNothing(t *testing.T) {
+	d := &util.TxDisplay{}
+	InfoClearSign(networks.EthereumMainnet)(d, &jarviscommon.TxResult{}, nil)
+	if d.ClearSign != nil {
+		t.Fatal("expected no callback when there is no analysed call")
+	}
+}

--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -547,12 +547,35 @@ func renderContractClearSign(
 	network jarvisnetworks.Network,
 	customABIs map[string]*abi.ABI,
 ) {
+	if tx == nil || tx.To() == nil || fc == nil {
+		return
+	}
+	RenderContractClearSign(u, network, tx.To().Hex(), tx.Value(), tx.Data(), fc.Params, customABIs)
+}
+
+// RenderContractClearSign asks the shared ERC-7730 engine for a
+// ClearSignedView of this call and, when one is available, emits it
+// inside a green-bordered box. Returns false when no descriptor
+// applies or the engine errors — callers treat that as "print
+// nothing extra".
+func RenderContractClearSign(
+	u ui.UI,
+	network jarvisnetworks.Network,
+	to string,
+	value *big.Int,
+	data []byte,
+	params []jarviscommon.ParamResult,
+	customABIs map[string]*abi.ABI,
+) bool {
+	if to == "" || len(data) < 4 {
+		return false
+	}
 	var contractABI *abi.ABI
 	if customABIs != nil {
-		contractABI = customABIs[strings.ToLower(tx.To().Hex())]
+		contractABI = customABIs[strings.ToLower(to)]
 	}
 	if contractABI == nil {
-		if a, err := util.GetABI(tx.To().Hex(), network); err == nil {
+		if a, err := util.GetABI(to, network); err == nil {
 			contractABI = a
 		}
 	}
@@ -560,14 +583,59 @@ func renderContractClearSign(
 	view, err := engine.ContractView(
 		context.Background(),
 		network.GetChainID(),
-		tx.To().Hex(),
-		tx.Value(),
-		tx.Data(),
-		fc.Params,
+		to,
+		value,
+		data,
+		params,
 		contractABI,
 	)
 	if err != nil || view == nil {
-		return
+		return false
 	}
 	erc7730.Render(u, view)
+	return true
+}
+
+// InfoClearSign returns an AnalyzeAndPrint hook that attaches the
+// ERC-7730 panel to a TxDisplay. printTxDisplay invokes it above the
+// ABI call on info layouts; PostSign skips it because the signing
+// card already showed the same panel.
+func InfoClearSign(network jarvisnetworks.Network) func(*util.TxDisplay, *jarviscommon.TxResult, map[string]*abi.ABI) {
+	return func(d *util.TxDisplay, result *jarviscommon.TxResult, abis map[string]*abi.ABI) {
+		if d == nil || result == nil || result.FunctionCall == nil {
+			return
+		}
+		fc := result.FunctionCall
+		d.ClearSign = func(u ui.UI) {
+			RenderInfoClearSign(u, network, fc, abis)
+		}
+	}
+}
+
+// RenderInfoClearSign walks the analysed call tree and prints an
+// ERC-7730 panel for every matching call (top-level, then inner
+// MultiSend / Safe execTransaction destinations). Fail-closed: no
+// match prints nothing.
+func RenderInfoClearSign(
+	u ui.UI,
+	network jarvisnetworks.Network,
+	fc *jarviscommon.FunctionCall,
+	customABIs map[string]*abi.ABI,
+) {
+	forEachFunctionCall(fc, func(call *jarviscommon.FunctionCall) {
+		if call.Method == "" {
+			return
+		}
+		RenderContractClearSign(u, network, call.Destination.Address, call.Value, call.Data, call.Params, customABIs)
+	})
+}
+
+func forEachFunctionCall(fc *jarviscommon.FunctionCall, fn func(*jarviscommon.FunctionCall)) {
+	if fc == nil {
+		return
+	}
+	fn(fc)
+	for _, inner := range fc.DecodedFunctionCalls {
+		forEachFunctionCall(inner, fn)
+	}
 }

--- a/util/display.go
+++ b/util/display.go
@@ -558,8 +558,18 @@ func PrintFunctionCall(u ui.UI, d *FunctionCallDisplay) {
 // hash is the transaction hash shown in the headline/footer; pass an empty
 // string to omit it (e.g. when the hash is already shown by the caller).
 func DisplayTxResult(u ui.UI, result *jarviscommon.TxResult, network networks.Network, layout TxLayout, hash string) *TxDisplay {
+	return DisplayTxResultWith(u, result, network, layout, hash, nil)
+}
+
+// DisplayTxResultWith is DisplayTxResult plus an optional step after the
+// view-model is built and before it is printed. jarvis info uses this to
+// attach an ERC-7730 panel without util importing the erc7730 engine.
+func DisplayTxResultWith(u ui.UI, result *jarviscommon.TxResult, network networks.Network, layout TxLayout, hash string, prepare func(*TxDisplay, *jarviscommon.TxResult)) *TxDisplay {
 	d := buildTxDisplay(result, network)
 	d.Hash = hash
+	if prepare != nil {
+		prepare(d, result)
+	}
 	printTxDisplay(u, d, network, layout)
 	return d
 }

--- a/util/display_model.go
+++ b/util/display_model.go
@@ -118,4 +118,9 @@ type TxDisplay struct {
 	// replay could recover one.
 	RevertReason string `json:"revert_reason,omitempty"`
 	Error        string `json:"error,omitempty"`
+
+	// ClearSign renders the ERC-7730 view when a descriptor matched. It is
+	// a callback so this package does not import the erc7730 engine
+	// (that package already imports util). Omitted from JSON.
+	ClearSign func(ui.UI) `json:"-"`
 }

--- a/util/display_tx.go
+++ b/util/display_tx.go
@@ -206,8 +206,9 @@ func (p txPrinter) headline(d *TxDisplay, network networks.Network) string {
 }
 
 // printTxDisplay renders d according to layout. The order is by importance:
-// what happened (headline), what moved (transfers), what was called, what was
-// emitted, and the headline again so the last line on screen is the summary.
+// what happened (headline), what moved (transfers), the ERC-7730 clear-signed
+// reading when a descriptor matched, what was called, what was emitted, and
+// the headline again so the last line on screen is the summary.
 func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network, layout TxLayout) {
 	p := txPrinter{u: u, layout: layout, compact: layout != LayoutInfoFull, width: ui.TerminalWidth()}
 
@@ -243,6 +244,14 @@ func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network, layout TxLa
 	emptyCall := d.FunctionCall != nil && d.FunctionCall.Method == "" &&
 		(d.FunctionCall.Data == "" || d.FunctionCall.Data == "0x") && len(d.FunctionCall.InnerCalls) == 0
 	showCall := d.FunctionCall != nil && !emptyCall && (layout != LayoutPostSign || d.Status == "reverted")
+	// Post-sign already showed the panel on the signing card. Info layouts
+	// print it above the ABI call so the operator gets the same reading
+	// without signing. Leading Info("") matches Subsection spacing; a
+	// no-op callback then looks the same as today's transfers → call gap.
+	if layout != LayoutPostSign && d.ClearSign != nil {
+		u.Info("")
+		d.ClearSign(u)
+	}
 	if showCall {
 		p.printCall(d.FunctionCall)
 		printed = true

--- a/util/display_tx_test.go
+++ b/util/display_tx_test.go
@@ -8,6 +8,7 @@ import (
 
 	jarviscommon "github.com/tranvictor/jarvis/common"
 	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/txanalyzer/erc7730"
 	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util"
 )
@@ -548,6 +549,40 @@ func TestInfoLayoutPrintsClearSignBeforeCall(t *testing.T) {
 	transfers := strings.Index(out, "Transfers")
 	if transfers < 0 || transfers > cs {
 		t.Fatalf("clear-sign panel must sit after transfers:\n%s", out)
+	}
+}
+
+func TestInfoLayoutRendersClearSignedBoxAboveCall(t *testing.T) {
+	var buf bytes.Buffer
+	u := ui.NewTerminalUIWithWriter(&buf, false)
+	util.DisplayTxResultWith(u, swapTxResult(), networks.EthereumMainnet, util.LayoutInfo, hashHex,
+		func(d *util.TxDisplay, _ *jarviscommon.TxResult) {
+			d.ClearSign = func(cu ui.UI) {
+				erc7730.Render(cu, &erc7730.ClearSignedView{
+					InterpolatedIntent: "Swap 1,000 USDC for WETH",
+					Owner:              "Uniswap",
+					ContractName:       "Uniswap V2 Router",
+					Source:             "registry",
+					Fields: []erc7730.FormattedField{
+						{Label: "Amount in", Value: "1,000 USDC"},
+						{Label: "Recipient", Value: "me (0x9642…5D4E)"},
+					},
+				})
+			}
+		})
+	out := buf.String()
+	for _, w := range []string{
+		"Clear Signed · Uniswap (Uniswap V2 Router)",
+		"Swap 1,000 USDC for WETH",
+		"Source: ERC-7730 registry",
+		"Call  swapExactTokensForTokens",
+	} {
+		if !strings.Contains(out, w) {
+			t.Fatalf("missing %q in output:\n%s", w, out)
+		}
+	}
+	if strings.Index(out, "Clear Signed") > strings.Index(out, "Call  swapExactTokensForTokens") {
+		t.Fatalf("clear-signed box must sit above the ABI call:\n%s", out)
 	}
 }
 

--- a/util/display_tx_test.go
+++ b/util/display_tx_test.go
@@ -528,3 +528,53 @@ func TestCompactTransfersAreCapped(t *testing.T) {
 		t.Fatalf("full layout must list every transfer:\n%s", full)
 	}
 }
+
+func TestInfoLayoutPrintsClearSignBeforeCall(t *testing.T) {
+	var buf bytes.Buffer
+	u := ui.NewTerminalUIWithWriter(&buf, false)
+	util.DisplayTxResultWith(u, swapTxResult(), networks.EthereumMainnet, util.LayoutInfo, hashHex,
+		func(d *util.TxDisplay, result *jarviscommon.TxResult) {
+			if result == nil || result.FunctionCall == nil || result.FunctionCall.Method == "" {
+				t.Fatal("prepare should see the analysed call")
+			}
+			d.ClearSign = func(cu ui.UI) { cu.Info("CLEAR-SIGN-MARKER") }
+		})
+	out := buf.String()
+	cs := strings.Index(out, "CLEAR-SIGN-MARKER")
+	call := strings.Index(out, "Call  swapExactTokensForTokens")
+	if cs < 0 || call < 0 || cs > call {
+		t.Fatalf("clear-sign panel must sit above the ABI call:\n%s", out)
+	}
+	transfers := strings.Index(out, "Transfers")
+	if transfers < 0 || transfers > cs {
+		t.Fatalf("clear-sign panel must sit after transfers:\n%s", out)
+	}
+}
+
+func TestPostSignLayoutSkipsClearSign(t *testing.T) {
+	var buf bytes.Buffer
+	u := ui.NewTerminalUIWithWriter(&buf, false)
+	util.DisplayTxResultWith(u, swapTxResult(), networks.EthereumMainnet, util.LayoutPostSign, hashHex,
+		func(d *util.TxDisplay, _ *jarviscommon.TxResult) {
+			d.ClearSign = func(cu ui.UI) { cu.Info("CLEAR-SIGN-MARKER") }
+		})
+	if strings.Contains(buf.String(), "CLEAR-SIGN-MARKER") {
+		t.Fatalf("post-sign must not reprint the clear-sign panel:\n%s", buf.String())
+	}
+}
+
+func TestTxDisplayJSONOmitsClearSign(t *testing.T) {
+	var buf bytes.Buffer
+	u := ui.NewTerminalUIWithWriter(&buf, false)
+	d := util.DisplayTxResultWith(u, swapTxResult(), networks.EthereumMainnet, util.LayoutInfo, hashHex,
+		func(d *util.TxDisplay, _ *jarviscommon.TxResult) {
+			d.ClearSign = func(ui.UI) {}
+		})
+	raw, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "ClearSign") {
+		t.Fatalf("JSON must omit the ClearSign callback: %s", raw)
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -361,6 +361,7 @@ func AnalyzeAndPrint(
 	a *abi.ABI,
 	customABIs map[string]*abi.ABI,
 	layout TxLayout,
+	after ...func(*TxDisplay, *jarviscommon.TxResult, map[string]*abi.ABI),
 ) *TxDisplay {
 	if customABIs == nil {
 		customABIs = map[string]*abi.ABI{}
@@ -376,7 +377,7 @@ func AnalyzeAndPrint(
 	// for; the analyzer reports it from the receipt.
 	if txinfo.Tx.To() == nil {
 		result := analyzer.AnalyzeOffline(&txinfo, GetABI, customABIs, false)
-		return DisplayTxResult(u, result, network, layout, tx)
+		return displayTxResultAfter(u, result, network, layout, tx, customABIs, after)
 	}
 	contractAddress := txinfo.Tx.To().Hex()
 
@@ -411,7 +412,23 @@ func AnalyzeAndPrint(
 	}
 	result := analyzer.AnalyzeOffline(&txinfo, lookup, customABIs, isContract)
 
-	return DisplayTxResult(u, result, network, layout, tx)
+	return displayTxResultAfter(u, result, network, layout, tx, customABIs, after)
+}
+
+func displayTxResultAfter(
+	u ui.UI,
+	result *jarviscommon.TxResult,
+	network networks.Network,
+	layout TxLayout,
+	tx string,
+	customABIs map[string]*abi.ABI,
+	after []func(*TxDisplay, *jarviscommon.TxResult, map[string]*abi.ABI),
+) *TxDisplay {
+	return DisplayTxResultWith(u, result, network, layout, tx, func(d *TxDisplay, result *jarviscommon.TxResult) {
+		for _, fn := range after {
+			fn(d, result, customABIs)
+		}
+	})
 }
 
 func EthTxMonitor(network networks.Network) (*monitor.TxMonitor, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When an ERC-7730 descriptor matches, `jarvis info` now prints the same green **Clear Signed** panel that the signing card shows — above the ABI call tree, not instead of it.

No match (or an engine error) leaves the existing info output unchanged. Post-sign output skips the panel because it was already shown on the signing card.

## Behaviour

- Panel sits after Transfers / Net effect and before **Call**.
- Walks the analysed call tree, so an inner MultiSend or Safe `execTransaction` destination can match even when the top-level wrapper has no descriptor.
- `--json-output` is unchanged (`ClearSign` is a print callback and is omitted from JSON).

## Why `cmd/util`, not `util`

`txanalyzer/erc7730` already imports `util`, so `util` cannot call the engine directly. `AnalyzeAndPrint` takes an optional hook; `jarvis info` attaches `cmdutil.InfoClearSign`.

## Tests

- Info layout prints the panel above the ABI call; post-sign does not.
- JSON marshal still works with the callback attached.
- Short calldata / missing function call fail closed (print nothing).

Live `jarvis info <hash>` against a registry-backed contract was not run in this environment (no local `~/.jarvis/erc7730` cache). The printer path is covered by the tests above.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

