### PR TITLE
info: drop the hardware-wallet hint from the ERC-7730 panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,9 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
   echo of a typed parameter, so a stale deadline shows as "… ago" before
   signing.
 - When an ERC-7730 descriptor matches, a green **Clear Signed** panel is
-  printed above the ABI call — the same view as at sign time, including
-  inner MultiSend / Safe destinations. No match leaves the output unchanged.
+  printed above the ABI call — the same fields as at sign time, including
+  inner MultiSend / Safe destinations, but without the hardware-wallet
+  comparison hint. No match leaves the output unchanged.
 
 ### Interactive parameter entry
 

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ Events (3)
   their raw topics so the event count is always complete.
 - When an ERC-7730 descriptor matches the call (or an inner MultiSend / Safe
   call), a green **Clear Signed** panel is printed above the ABI **Call**
-  tree — the same view shown at sign time. No match leaves the output
-  unchanged.
+  tree — the same fields shown at sign time, without the hardware-wallet
+  comparison hint. No match leaves the output unchanged.
 
 ### Signing screen
 

--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -567,6 +567,19 @@ func RenderContractClearSign(
 	params []jarviscommon.ParamResult,
 	customABIs map[string]*abi.ABI,
 ) bool {
+	return renderMatchedContract(u, network, to, value, data, params, customABIs, erc7730.Render)
+}
+
+func renderMatchedContract(
+	u ui.UI,
+	network jarvisnetworks.Network,
+	to string,
+	value *big.Int,
+	data []byte,
+	params []jarviscommon.ParamResult,
+	customABIs map[string]*abi.ABI,
+	paint func(ui.UI, *erc7730.ClearSignedView),
+) bool {
 	if to == "" || len(data) < 4 {
 		return false
 	}
@@ -592,7 +605,7 @@ func RenderContractClearSign(
 	if err != nil || view == nil {
 		return false
 	}
-	erc7730.Render(u, view)
+	paint(u, view)
 	return true
 }
 
@@ -626,7 +639,7 @@ func RenderInfoClearSign(
 		if call.Method == "" {
 			return
 		}
-		RenderContractClearSign(u, network, call.Destination.Address, call.Value, call.Data, call.Params, customABIs)
+		renderMatchedContract(u, network, call.Destination.Address, call.Value, call.Data, call.Params, customABIs, erc7730.RenderInfo)
 	})
 }
 

--- a/txanalyzer/erc7730/render.go
+++ b/txanalyzer/erc7730/render.go
@@ -7,9 +7,12 @@ import (
 	"github.com/tranvictor/jarvis/ui"
 )
 
+const signingHint = "Compare with your hardware wallet screen before approving."
+
 // Render writes view inside a green-bordered BoxedSection followed by
 // a green-bordered fields table — the standard jarvis "clear signed"
-// presentation. Callers wrap their existing per-tx printing with a
+// presentation for a signing review, including the hardware-wallet
+// comparison hint. Callers wrap their existing per-tx printing with a
 // Render() call when the engine returns a non-nil view.
 //
 // Render is a no-op when view is nil so call sites can write:
@@ -18,6 +21,17 @@ import (
 //	    erc7730.Render(u, v)
 //	}
 func Render(u ui.UI, view *ClearSignedView) {
+	render(u, view, true)
+}
+
+// RenderInfo is Render without the hardware-wallet comparison hint.
+// jarvis info is looking at a tx, not asking the operator to approve
+// one, so that line does not belong there.
+func RenderInfo(u ui.UI, view *ClearSignedView) {
+	render(u, view, false)
+}
+
+func render(u ui.UI, view *ClearSignedView, signing bool) {
 	if view == nil {
 		return
 	}
@@ -45,7 +59,9 @@ func Render(u ui.UI, view *ClearSignedView) {
 		}
 		c.Info("")
 		c.Info(provenanceLine(view))
-		c.Info("Compare with your hardware wallet screen before approving.")
+		if signing {
+			c.Info(signingHint)
+		}
 		if view.Warning != "" {
 			c.Warn(view.Warning)
 		}

--- a/txanalyzer/erc7730/render_test.go
+++ b/txanalyzer/erc7730/render_test.go
@@ -1,0 +1,51 @@
+package erc7730
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/tranvictor/jarvis/ui"
+)
+
+func sampleView() *ClearSignedView {
+	return &ClearSignedView{
+		InterpolatedIntent: "Swap 1,000 USDC for WETH",
+		Owner:              "Uniswap",
+		ContractName:       "Uniswap V2 Router",
+		Source:             "registry",
+		Fields: []FormattedField{
+			{Label: "Amount in", Value: "1,000 USDC"},
+		},
+	}
+}
+
+func TestRenderIncludesSigningHint(t *testing.T) {
+	var buf bytes.Buffer
+	Render(ui.NewTerminalUIWithWriter(&buf, false), sampleView())
+	out := buf.String()
+	if !strings.Contains(out, signingHint) {
+		t.Fatalf("signing render must include the hardware-wallet hint:\n%s", out)
+	}
+}
+
+func TestRenderInfoOmitsSigningHint(t *testing.T) {
+	var buf bytes.Buffer
+	RenderInfo(ui.NewTerminalUIWithWriter(&buf, false), sampleView())
+	out := buf.String()
+	if !strings.Contains(out, "Clear Signed · Uniswap (Uniswap V2 Router)") {
+		t.Fatalf("info render must still show the panel:\n%s", out)
+	}
+	if strings.Contains(out, signingHint) || strings.Contains(out, "hardware wallet") {
+		t.Fatalf("info render must not include the hardware-wallet hint:\n%s", out)
+	}
+}
+
+func TestRenderNilIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	Render(ui.NewTerminalUIWithWriter(&buf, false), nil)
+	RenderInfo(ui.NewTerminalUIWithWriter(&buf, false), nil)
+	if buf.Len() != 0 {
+		t.Fatalf("nil view must print nothing: %q", buf.String())
+	}
+}

--- a/ui/box.go
+++ b/ui/box.go
@@ -43,6 +43,12 @@ func BorderColor(s Severity) lipgloss.Color {
 // indent prefix to every line before writing.
 func renderBoxedSection(severity Severity, title string, body string) string {
 	body = strings.TrimRight(body, "\n")
+	// Size the box to the title, not just the body: otherwise a short
+	// body (jarvis info's clear-signed panel, with no hardware-wallet
+	// hint) truncates "Clear Signed · Uniswap (Router)" on the top border.
+	if title != "" {
+		body = padBlockToWidth(body, runewidth.StringWidth(title)+2)
+	}
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(BorderColor(severity)).
@@ -99,6 +105,23 @@ func injectBoxTitle(boxed string, title string, color lipgloss.Color) string {
 		return colored
 	}
 	return colored + "\n" + lines[1]
+}
+
+func padBlockToWidth(body string, minWidth int) string {
+	if minWidth <= 0 {
+		return body
+	}
+	if body == "" {
+		return strings.Repeat(" ", minWidth)
+	}
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		w := runewidth.StringWidth(ansi.Strip(line))
+		if w < minWidth {
+			lines[i] = line + strings.Repeat(" ", minWidth-w)
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func truncateToWidth(s string, maxWidth int) string {

--- a/ui/box_test.go
+++ b/ui/box_test.go
@@ -1,0 +1,23 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBoxedSectionFitsTitleWhenBodyIsShort(t *testing.T) {
+	var buf strings.Builder
+	u := NewTerminalUIWithWriter(&buf, false)
+	u.BoxedSection(SeveritySuccess, "Clear Signed · Uniswap (Uniswap V2 Router)", func(c UI) {
+		c.Info("Swap 1,000 USDC for WETH")
+		c.Info("")
+		c.Info("Source: ERC-7730 registry")
+	})
+	out := buf.String()
+	if !strings.Contains(out, "Clear Signed · Uniswap (Uniswap V2 Router)") {
+		t.Fatalf("title must not be truncated to fit a short body:\n%s", out)
+	}
+	if strings.Contains(out, "hardware wallet") {
+		t.Fatalf("fixture should not include a signing hint:\n%s", out)
+	}
+}

--- a/util/display_tx_test.go
+++ b/util/display_tx_test.go
@@ -558,7 +558,7 @@ func TestInfoLayoutRendersClearSignedBoxAboveCall(t *testing.T) {
 	util.DisplayTxResultWith(u, swapTxResult(), networks.EthereumMainnet, util.LayoutInfo, hashHex,
 		func(d *util.TxDisplay, _ *jarviscommon.TxResult) {
 			d.ClearSign = func(cu ui.UI) {
-				erc7730.Render(cu, &erc7730.ClearSignedView{
+				erc7730.RenderInfo(cu, &erc7730.ClearSignedView{
 					InterpolatedIntent: "Swap 1,000 USDC for WETH",
 					Owner:              "Uniswap",
 					ContractName:       "Uniswap V2 Router",
@@ -583,6 +583,9 @@ func TestInfoLayoutRendersClearSignedBoxAboveCall(t *testing.T) {
 	}
 	if strings.Index(out, "Clear Signed") > strings.Index(out, "Call  swapExactTokensForTokens") {
 		t.Fatalf("clear-signed box must sit above the ABI call:\n%s", out)
+	}
+	if strings.Contains(out, "hardware wallet") {
+		t.Fatalf("info must not tell the operator to compare a hardware wallet screen:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`jarvis info` was still printing "Compare with your hardware wallet screen before approving" inside the ERC-7730 box. That line only makes sense when the operator is about to sign.

`erc7730.Render` (signing card, WalletConnect) keeps the hint. `jarvis info` uses `RenderInfo`, which omits it.

Dropping the long line made a short panel truncate the title (`Clear Signed · Uniswap (Router)` → `Clear Signed · Uniswap`). `BoxedSection` now sizes the box to the title so the full heading still fits.

## Tests

- `Render` includes the hardware-wallet hint; `RenderInfo` does not.
- Info layout still places the panel above the ABI call, and now asserts the hint is absent.
- BoxedSection keeps a long title when the body is short.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

