### PR TITLE
info: drop the Transfers list; Events already has every movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 
 - Headline line: status glyph, method, destination; a muted second line
   carries from / value / gas / nonce / block.
-- New **Transfers** section derived from `Transfer` and `Approval` logs, with
-  `UNLIMITED` marking max-uint approvals.
 - Function call shown as an indented tree; arrays longer than a few items and
   long `bytes` values collapse. Events are one line each.
 - `--degen` expands collapsed values, shows full addresses and switches the
@@ -23,7 +21,8 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
   highlighted in yellow. Each tx ends with a one-line footer (status,
   method, hash) so the outcome is visible even after a long event list.
 - **Net effect** block (per-address net token change) when a tx has four or
-  more transfers; the transfer list is capped at eight in the compact view.
+  more token movements. The per-hop Transfers list is not printed; Events
+  already has every movement. `--json-output` still includes `transfers`.
 - Integers carry thousands separators (`1,000,000,000`); token amounts are
   rounded to four decimals in compact views. `--degen`/JSON keep full
   precision.
@@ -37,10 +36,6 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 - Overloaded methods show their Solidity name (`execute`, not `execute0`).
 - The `Network:` header and the bare hash echo are gone; the network sits on
   the details line.
-- Transfer rows are laid out in columns (`amount   from  →  to`) so arrows
-  and destinations line up; approvals read `from  approves  spender` with
-  `UNLIMITED <token>` in the amount column, deposits/withdrawals name the
-  mechanism in place of the missing party.
 - Time-named integer parameters (`deadline`, `expiry`, `validUntil`,
   `unlockTime`, …) holding a plausible unix time show the date and how far
   away it is: `2026-09-07 03:30:00 UTC, in 30 min`. The compact view shows
@@ -100,7 +95,7 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 - Broadcasting prints `✓ broadcast` followed by a live status line
   (not in mempool → in mempool → mined / reverted / dropped) with elapsed
   time; off-TTY each state is printed once.
-- After mining, the post-sign view shows the headline, Transfers and Events
+- After mining, the post-sign view shows the headline, Net effect and Events
   (gas used / limit in the details line) instead of the full `info` dump.
 - Waiting for a Ledger uses the same status line with a countdown.
 

--- a/README.md
+++ b/README.md
@@ -148,10 +148,6 @@ this and always carries full, untruncated values.
 ✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)
          mainnet   from me (0x9642…5D4E)   value 0 ETH   gas 0.00213000 ETH   nonce 412   block 19234567
 
-Transfers
-  1,000 USDC    me (0x9642…5D4E)              →  USDC/WETH pair (0x0d4a…1852)
-  0.3121 WETH   USDC/WETH pair (0x0d4a…1852)  →  me (0x9642…5D4E)
-
 Call  swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)
   amountIn      1,000,000,000  uint256
   amountOutMin  311,200,000,000,000,000  uint256
@@ -171,18 +167,15 @@ Events (3)
 
 - The headline is status + what was called + where. The muted second line
   holds the numbers you rarely need (network, gas, nonce, block).
-- **Transfers** is derived from the `Transfer` / `Approval` / `Deposit` /
-  `Withdrawal` logs so asset movement is visible without reading the
-  events. Rows are columns (`amount   from  →  to`); approvals read
-  `from  approves  spender` with `UNLIMITED <token>` in the amount column.
-  Standard token events decode even when the emitting contract is
-  unverified.
 - Time-named parameters (`deadline`, `expiry`, `validUntil`, …) show the
   date and distance instead of raw seconds; `-x` keeps both.
-- With four or more transfers a **Net effect** block comes first: one line
-  per address with its net change per token, sender first, so a swap that
-  hops through three pools still reads as "−1,000 USDC, +0.3121 WETH". The
-  transfer list is capped at eight lines in the compact view.
+- With four or more token movements a **Net effect** block comes first: one
+  line per address with its net change per token, sender first, so a swap
+  that hops through three pools still reads as "−1,000 USDC, +0.3121 WETH".
+  The per-hop list is not printed; **Events** at the bottom has every
+  `Transfer` / `Approval` / `Deposit` / `Withdrawal`, including standard
+  token events from unverified contracts. `--json-output` still includes
+  a `transfers` array.
 - Unknown addresses are shown as bare short hex; `(zero address)` marks
   mints and burns. Integers get thousands separators and token amounts are
   rounded to four decimals (four significant digits below 1). `--degen` and
@@ -239,7 +232,7 @@ progress and the list of confirmers; approving then collapses the inner
 
 After signing, a live status line replaces the silent wait
 (`⠋ in mempool, waiting to be mined…  0:12`), and once mined jarvis prints
-the same headline + Transfers + Events view as `info` so you can see what
+the same headline + Net effect + Events view as `info` so you can see what
 actually happened. The same status line is used while jarvis waits for a
 Ledger to be plugged in and unlocked.
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -129,7 +129,7 @@ type UI interface {
 	Section(title string)
 
 	// Subsection writes a bold heading preceded by a blank line, with no
-	// rule. Use it for the blocks inside a Section (e.g. "Transfers",
+	// rule. Use it for the blocks inside a Section (e.g. "Net effect",
 	// "Events (4)") so they stand out without adding visual weight.
 	Subsection(title string)
 

--- a/util/display.go
+++ b/util/display.go
@@ -168,8 +168,9 @@ func buildTxDisplay(result *jarviscommon.TxResult, network networks.Network) *Tx
 	return d
 }
 
-// buildTransfers derives asset movements from the well-known token events so
-// the reader gets "what moved" without scanning the event table.
+// buildTransfers derives asset movements from the well-known token events.
+// The terminal no longer lists them hop-by-hop (Events already does); they
+// still feed Net effect and --json-output.
 func buildTransfers(logs []jarviscommon.LogResult) []TransferDisplay {
 	var out []TransferDisplay
 	for _, l := range logs {
@@ -221,7 +222,7 @@ func buildTransfers(logs []jarviscommon.LogResult) []TransferDisplay {
 }
 
 // netEffectMinTransfers is the transfer count from which a per-address net
-// summary is worth printing; below it the list itself is the summary.
+// summary is worth printing; below it the event list itself is the summary.
 const netEffectMinTransfers = 4
 
 // netEffectMaxRows caps the summary so it stays a summary.

--- a/util/display_model.go
+++ b/util/display_model.go
@@ -57,7 +57,7 @@ type FunctionCallDisplay struct {
 type TxLayout int
 
 const (
-	// LayoutInfo is the default for `jarvis info`: headline, transfers,
+	// LayoutInfo is the default for `jarvis info`: headline, net effect,
 	// collapsed call, one line per event, shortened addresses.
 	LayoutInfo TxLayout = iota
 	// LayoutInfoFull is `jarvis info -x`: nothing collapsed, gas card, full
@@ -65,8 +65,8 @@ const (
 	LayoutInfoFull
 	// LayoutPostSign is shown right after a tx the user just signed was
 	// mined: the call was already confirmed on the signing screen, so only
-	// status, gas, transfers and events are printed (the call reappears only
-	// when the tx reverted).
+	// status, gas, net effect and events are printed (the call reappears
+	// only when the tx reverted).
 	LayoutPostSign
 )
 
@@ -109,9 +109,11 @@ type TxDisplay struct {
 
 	TxType       string               `json:"tx_type"`
 	FunctionCall *FunctionCallDisplay `json:"function_call,omitempty"`
-	Transfers    []TransferDisplay    `json:"transfers,omitempty"`
+	// Transfers is kept for --json-output; the terminal no longer prints a
+	// per-hop list (Events at the bottom already has every movement).
+	Transfers []TransferDisplay `json:"transfers,omitempty"`
 	// NetEffect summarises Transfers per address; only computed when there
-	// are enough transfers for the list alone to be hard to read.
+	// are enough transfers for the event list alone to be hard to read.
 	NetEffect []NetEffectDisplay `json:"net_effect,omitempty"`
 	Logs      []LogDisplay       `json:"logs,omitempty"`
 	// RevertReason is the decoded revert payload of a reverted tx, when the

--- a/util/display_tx.go
+++ b/util/display_tx.go
@@ -206,7 +206,7 @@ func (p txPrinter) headline(d *TxDisplay, network networks.Network) string {
 }
 
 // printTxDisplay renders d according to layout. The order is by importance:
-// what happened (headline), what moved (transfers), the ERC-7730 clear-signed
+// what happened (headline), what moved (net effect), the ERC-7730 clear-signed
 // reading when a descriptor matched, what was called, what was emitted, and
 // the headline again so the last line on screen is the summary.
 func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network, layout TxLayout) {
@@ -237,17 +237,13 @@ func printTxDisplay(u ui.UI, d *TxDisplay, network networks.Network, layout TxLa
 		p.printNetEffect(d.NetEffect)
 		printed = true
 	}
-	if len(d.Transfers) > 0 {
-		p.printTransfers(d.Transfers)
-		printed = true
-	}
 	emptyCall := d.FunctionCall != nil && d.FunctionCall.Method == "" &&
 		(d.FunctionCall.Data == "" || d.FunctionCall.Data == "0x") && len(d.FunctionCall.InnerCalls) == 0
 	showCall := d.FunctionCall != nil && !emptyCall && (layout != LayoutPostSign || d.Status == "reverted")
 	// Post-sign already showed the panel on the signing card. Info layouts
 	// print it above the ABI call so the operator gets the same reading
 	// without signing. Leading Info("") matches Subsection spacing; a
-	// no-op callback then looks the same as today's transfers → call gap.
+	// no-op callback then looks the same as today's net-effect → call gap.
 	if layout != LayoutPostSign && d.ClearSign != nil {
 		u.Info("")
 		d.ClearSign(u)
@@ -337,10 +333,6 @@ func (p txPrinter) printCard(d *TxDisplay, network networks.Network) {
 	p.u.KeyValueCells(rows)
 }
 
-// maxCompactTransfers caps the Transfers list in compact layouts. Past this
-// the Net effect block carries the meaning; -x still lists everything.
-const maxCompactTransfers = 8
-
 // printNetEffect renders the per-address summary: one line per address, its
 // token deltas coloured by sign.
 func (p txPrinter) printNetEffect(rows []NetEffectDisplay) {
@@ -376,81 +368,6 @@ func (p txPrinter) printNetEffect(rows []NetEffectDisplay) {
 			deltas[i] = p.u.Style(ui.StyledText{Text: text, Severity: sev})
 		}
 		p.u.Indent().Info("%s%s   %s", p.text(r.Address), pad, strings.Join(deltas, "   "))
-	}
-}
-
-func (p txPrinter) printTransfers(ts []TransferDisplay) {
-	title := "Transfers"
-	hidden := 0
-	if p.compact && len(ts) > maxCompactTransfers {
-		title = fmt.Sprintf("Transfers (%d)", len(ts))
-		hidden = len(ts) - maxCompactTransfers
-		ts = ts[:maxCompactTransfers]
-	}
-	p.u.Subsection(title)
-	amountWidth := 0
-	amountText := func(t TransferDisplay) string {
-		if p.compact && !strings.HasPrefix(t.Amount, "#") {
-			return jarviscommon.CompactAmount(t.Amount)
-		}
-		return t.Amount
-	}
-	plain := func(t TransferDisplay) string {
-		if t.Unlimited {
-			return "UNLIMITED " + p.plainText(t.Token)
-		}
-		return amountText(t) + " " + p.plainText(t.Token)
-	}
-	// Every row is "amount   from  verb  to" with each column padded to the
-	// widest entry so the arrows and destinations line up. Deposits and
-	// withdrawals name the mechanism in place of the missing party; approvals
-	// swap the arrow for a verb, and an unlimited allowance is flagged in the
-	// amount column where the eye already is.
-	type cell struct{ plain, styled string }
-	fromCell := func(t TransferDisplay) cell {
-		if t.Kind == "deposit" {
-			return cell{"deposit", p.muted("deposit")}
-		}
-		return cell{p.plainText(t.From), p.text(t.From)}
-	}
-	toCell := func(t TransferDisplay) cell {
-		if t.Kind == "withdrawal" {
-			return cell{"withdrawal", p.muted("withdrawal")}
-		}
-		return cell{p.plainText(t.To), p.text(t.To)}
-	}
-	verbCell := func(t TransferDisplay) cell {
-		if t.Kind == "approval" {
-			return cell{"approves", "approves"}
-		}
-		return cell{"→", "→"}
-	}
-	fromWidth, verbWidth := 0, 0
-	for _, t := range ts {
-		if w := ui.VisibleWidth(plain(t)); w > amountWidth {
-			amountWidth = w
-		}
-		if w := ui.VisibleWidth(fromCell(t).plain); w > fromWidth {
-			fromWidth = w
-		}
-		if w := ui.VisibleWidth(verbCell(t).plain); w > verbWidth {
-			verbWidth = w
-		}
-	}
-	for _, t := range ts {
-		amount := amountText(t) + " " + p.text(t.Token)
-		if t.Unlimited {
-			amount = p.u.Style(ui.StyledText{Text: plain(t), Severity: ui.SeverityWarn})
-		}
-		from, verb, to := fromCell(t), verbCell(t), toCell(t)
-		p.u.Indent().Info("%s%s   %s%s  %s%s  %s",
-			amount, strings.Repeat(" ", amountWidth-ui.VisibleWidth(plain(t))),
-			from.styled, strings.Repeat(" ", fromWidth-ui.VisibleWidth(from.plain)),
-			verb.styled, strings.Repeat(" ", verbWidth-ui.VisibleWidth(verb.plain)),
-			to.styled)
-	}
-	if hidden > 0 {
-		p.u.Indent().Info("%s", p.muted(fmt.Sprintf("… %d more (-x lists all)", hidden)))
 	}
 }
 

--- a/util/display_tx_test.go
+++ b/util/display_tx_test.go
@@ -112,9 +112,6 @@ func TestInfoLayoutOrdersByImportance(t *testing.T) {
 	want := []string{
 		"✓ done   swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)",
 		"         mainnet   from me (0x9642…5D4E)   value 0 ETH   gas 0.00213000 ETH   nonce 412   block 19234567",
-		"Transfers",
-		"  1,000 USDC    me (0x9642…5D4E)              →  USDC/WETH pair (0x0d4a…1852)",
-		"  0.3121 WETH   USDC/WETH pair (0x0d4a…1852)  →  me (0x9642…5D4E)",
 		"Call  swapExactTokensForTokens  →  Uniswap V2 Router (0x7a25…488D)",
 		"  amountIn      1,000,000,000  uint256",
 		"  path          [2 items]  address[]",
@@ -136,6 +133,9 @@ func TestInfoLayoutOrdersByImportance(t *testing.T) {
 			t.Fatalf("%q appears out of order in output:\n%s", w, out)
 		}
 		pos = idx
+	}
+	if strings.Contains(out, "\nTransfers\n") {
+		t.Fatalf("compact layout must not print a Transfers list:\n%s", out)
 	}
 	if strings.Contains(out, "│") || strings.Contains(out, "╭") {
 		t.Fatalf("compact layout must not draw table borders:\n%s", out)
@@ -214,8 +214,11 @@ func TestRevertedHeadlineAndPostSignLayout(t *testing.T) {
 	if strings.Contains(post, "Call  ") {
 		t.Fatalf("successful post-sign layout must not repeat the call:\n%s", post)
 	}
-	if !strings.Contains(post, "Transfers") || !strings.Contains(post, "Events (3)") {
-		t.Fatalf("post-sign layout should keep transfers and events:\n%s", post)
+	if strings.Contains(post, "\nTransfers\n") {
+		t.Fatalf("post-sign layout must not print a Transfers list:\n%s", post)
+	}
+	if !strings.Contains(post, "Events (3)") {
+		t.Fatalf("post-sign layout should keep events:\n%s", post)
 	}
 	if strings.Count(post, "✓ done") != 1 {
 		t.Fatalf("post-sign layout should not repeat the headline as footer:\n%s", post)
@@ -265,8 +268,8 @@ func TestUnlimitedApprovalIsFlagged(t *testing.T) {
 	if len(d.Transfers) != 1 || d.Transfers[0].Kind != "approval" || !d.Transfers[0].Unlimited {
 		t.Fatalf("expected one unlimited approval, got %+v", d.Transfers)
 	}
-	if !rec.HasMessage("UNLIMITED USDC") || !rec.HasMessage("approves") {
-		t.Fatalf("expected UNLIMITED marker, got %v", rec.Entries())
+	if !rec.HasMessage("Approval") || !rec.HasMessage("spender") {
+		t.Fatalf("expected the Approval event, got %v", rec.Entries())
 	}
 }
 
@@ -401,9 +404,19 @@ func TestTransfersUseTopicPositionsForDaiStyleNames(t *testing.T) {
 		},
 		Data: []jarviscommon.ParamResult{scalar("wad", "uint256", tokenValue("5000000000000000000", "WETH", 18))},
 	}}
-	out := render(t, r, util.LayoutInfo, hashHex)
-	if !strings.Contains(out, "5 WETH   me (0x9642…5D4E)  approves  Uniswap V2 Router (0x7a25…488D)") {
-		t.Fatalf("dai-style approval parties missing:\n%s", out)
+	rec := ui.NewRecordingUI()
+	d := util.DisplayTxResult(rec, r, networks.EthereumMainnet, util.LayoutInfo, hashHex)
+	if len(d.Transfers) != 1 || d.Transfers[0].Kind != "approval" {
+		t.Fatalf("expected one approval transfer, got %+v", d.Transfers)
+	}
+	if !strings.Contains(d.Transfers[0].From.Text, meHex) || !strings.Contains(d.Transfers[0].To.Text, routerHex) {
+		t.Fatalf("dai-style src/guy topics should fill from/to: %+v", d.Transfers[0])
+	}
+	if rec.HasMessage("Transfers") {
+		t.Fatal("must not print a Transfers subsection")
+	}
+	if !rec.HasMessage("Approval") || !rec.HasMessage("guy") {
+		t.Fatalf("events should still show the dai-style approval, got %v", rec.Entries())
 	}
 }
 
@@ -422,43 +435,6 @@ func TestTimestampParamsShowTheDate(t *testing.T) {
 	echo := util.ParamValueLines(ui.NewRecordingUI(), util.NewParamDisplay(scalar("deadline", "uint256", intValue("1725600000"))))
 	if len(echo) != 1 || !strings.HasPrefix(echo[0], "2024-09-06 05:20:00 UTC, ") || !strings.HasSuffix(echo[0], " ago") {
 		t.Fatalf("echo should be the date with a relative hint, got %q", echo)
-	}
-}
-
-func TestTransferRowsAlignAcrossKinds(t *testing.T) {
-	me := addr(meHex, "me")
-	router := addr(routerHex, "Uniswap V2 Router")
-	pair := addr(pairHex, "USDC/WETH pair")
-	weth := addr(wethHex, "WETH token")
-	r := swapTxResult()
-	r.FunctionCall = nil
-	r.Logs = []jarviscommon.LogResult{
-		transferLog(usdcHex, "USDC", 6, me, router, "1000000000"),
-		{Name: "Approval", Address: weth,
-			Topics: []jarviscommon.TopicResult{
-				{Name: "owner", Value: addrValue(me.Address, me.Desc)},
-				{Name: "spender", Value: addrValue(router.Address, router.Desc)},
-			},
-			Data: []jarviscommon.ParamResult{scalar("value", "uint256", tokenValue(
-				"115792089237316195423570985008687907853269984665640564039457584007913129639935", "WETH", 18))}},
-		{Name: "Deposit", Address: weth,
-			Topics: []jarviscommon.TopicResult{{Name: "dst", Value: addrValue(router.Address, router.Desc)}},
-			Data:   []jarviscommon.ParamResult{scalar("wad", "uint256", tokenValue("5000000000000000000", "WETH", 18))}},
-		{Name: "Withdrawal", Address: weth,
-			Topics: []jarviscommon.TopicResult{{Name: "src", Value: addrValue(pair.Address, pair.Desc)}},
-			Data:   []jarviscommon.ParamResult{scalar("wad", "uint256", tokenValue("1234500000000000000", "WETH", 18))}},
-	}
-	out := render(t, r, util.LayoutInfo, hashHex)
-	want := []string{
-		"  1,000 USDC       me (0x9642…5D4E)              →         Uniswap V2 Router (0x7a25…488D)",
-		"  UNLIMITED WETH   me (0x9642…5D4E)              approves  Uniswap V2 Router (0x7a25…488D)",
-		"  5 WETH           deposit                       →         Uniswap V2 Router (0x7a25…488D)",
-		"  1.2345 WETH      USDC/WETH pair (0x0d4a…1852)  →         withdrawal",
-	}
-	for _, w := range want {
-		if !strings.Contains(out, w) {
-			t.Fatalf("missing aligned row %q in:\n%s", w, out)
-		}
 	}
 }
 
@@ -497,36 +473,14 @@ func TestNetEffectSummarisesManyTransfers(t *testing.T) {
 	if !strings.Contains(out, "Net effect\n  me (0x9642…5D4E)               -1,000 USDC   +0.3121 WETH\n") {
 		t.Fatalf("net effect block:\n%s", out)
 	}
-	if strings.Index(out, "Net effect") > strings.Index(out, "Transfers") {
-		t.Fatalf("net effect should precede the transfer list:\n%s", out)
+	if strings.Contains(out, "\nTransfers\n") {
+		t.Fatalf("net effect txs must not also print a Transfers list:\n%s", out)
 	}
 
 	r.Logs = r.Logs[:3]
 	d = util.DisplayTxResult(ui.NewRecordingUI(), r, networks.EthereumMainnet, util.LayoutInfo, hashHex)
 	if d.NetEffect != nil {
 		t.Fatalf("three transfers need no summary: %+v", d.NetEffect)
-	}
-}
-
-func TestCompactTransfersAreCapped(t *testing.T) {
-	me := addr(meHex, "me")
-	pair := addr(pairHex, "USDC/WETH pair")
-	r := swapTxResult()
-	r.FunctionCall = nil
-	r.Logs = nil
-	for i := 0; i < 11; i++ {
-		r.Logs = append(r.Logs, transferLog(usdcHex, "USDC", 6, me, pair, "1000000"))
-	}
-	out := render(t, r, util.LayoutInfo, hashHex)
-	if !strings.Contains(out, "Transfers (11)") || strings.Count(out, "1 USDC   me") != 8 {
-		t.Fatalf("compact layout should list 8 of 11 transfers:\n%s", out)
-	}
-	if !strings.Contains(out, "… 3 more (-x lists all)") {
-		t.Fatalf("hidden count missing:\n%s", out)
-	}
-	full := render(t, r, util.LayoutInfoFull, hashHex)
-	if strings.Count(full, "1 USDC   ") != 11 || strings.Contains(full, "more (-x") {
-		t.Fatalf("full layout must list every transfer:\n%s", full)
 	}
 }
 
@@ -546,9 +500,8 @@ func TestInfoLayoutPrintsClearSignBeforeCall(t *testing.T) {
 	if cs < 0 || call < 0 || cs > call {
 		t.Fatalf("clear-sign panel must sit above the ABI call:\n%s", out)
 	}
-	transfers := strings.Index(out, "Transfers")
-	if transfers < 0 || transfers > cs {
-		t.Fatalf("clear-sign panel must sit after transfers:\n%s", out)
+	if strings.Contains(out, "\nTransfers\n") {
+		t.Fatalf("info must not print a Transfers list:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`jarvis info` no longer prints the per-hop **Transfers** list after Net effect. That section repeated what **Events** already shows at the bottom.

**Net effect** still appears when there are four or more token movements. `--json-output` still includes a `transfers` array.

Post-sign output follows the same rule: headline, Net effect (when present), Events.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

