### PR TITLE
info: never resolve the zero address to an address-book name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 - `--degen` expands collapsed values, shows full addresses and switches the
   parameter list back to a bordered table.
 - Addresses are name-first (`me (0x9642…5D4E)`); unknown ones are bare
-  short hex, the zero address is labelled. Only an *unknown call target* is
+  short hex, the zero address is labelled `(zero address)` even if the
+  address book has a name for it. Only an *unknown call target* is
   highlighted in yellow. Each tx ends with a one-line footer (status,
   method, hash) so the outcome is visible even after a long event list.
 - **Net effect** block (per-address net token change) when a tx has four or

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Events (3)
   token events from unverified contracts. `--json-output` still includes
   a `transfers` array.
 - Unknown addresses are shown as bare short hex; `(zero address)` marks
-  mints and burns. Integers get thousands separators and token amounts are
+  mints, burns and empty approve-targets, and is never replaced by an
+  address-book name. Integers get thousands separators and token amounts are
   rounded to four decimals (four significant digits below 1). `--degen` and
   `--json-output` keep every digit.
 - Arrays longer than a few items and long `bytes` blobs are collapsed;

--- a/common/printer.go
+++ b/common/printer.go
@@ -177,6 +177,12 @@ func PlainAddress(addr Address) string {
 	if addr.Address == "" {
 		return ""
 	}
+	// address(0) is a sentinel (mint/burn/"none"), never a person. A
+	// malformed addresses.json key can otherwise bind a name to it because
+	// go-ethereum HexToAddress maps invalid hex to the zero address.
+	if IsZeroAddress(addr.Address) {
+		return addr.Address + " (zero address)"
+	}
 	if addr.Decimal != 0 {
 		return fmt.Sprintf("%s (%s - %d)", addr.Address, addr.Desc, addr.Decimal)
 	}
@@ -239,6 +245,9 @@ func IsZeroAddress(hex string) bool {
 func VerboseAddress(addr Address) string {
 	if addr.Address == "" {
 		return ""
+	}
+	if IsZeroAddress(addr.Address) {
+		return fmt.Sprintf("%s (%s)", addr.Address, NameWithColor("zero address"))
 	}
 	if addr.Decimal != 0 {
 		return fmt.Sprintf(

--- a/common/printer_test.go
+++ b/common/printer_test.go
@@ -35,6 +35,7 @@ func TestNameFirst(t *testing.T) {
 		{unknown, false, "0x9642…5D4E"},
 		{blank, true, "0x9642b23Ed1E01Df1092B92641051881a322F5D4E"},
 		{Address{Address: "0x0000000000000000000000000000000000000000"}, false, "0x0000…0000 (zero address)"},
+		{Address{Address: "0x0000000000000000000000000000000000000000", Desc: "Quang Le"}, false, "0x0000…0000 (zero address)"},
 		{Address{}, false, ""},
 	}
 	for _, c := range cases {
@@ -60,6 +61,10 @@ func TestPlainAddressOmitsUnknown(t *testing.T) {
 	}
 	if got := PlainAddress(Address{Address: hex, Desc: "me"}); got != hex+" (me)" {
 		t.Fatalf("known desc dropped: %q", got)
+	}
+	zero := "0x0000000000000000000000000000000000000000"
+	if got := PlainAddress(Address{Address: zero, Desc: "Quang Le"}); got != zero+" (zero address)" {
+		t.Fatalf("zero address must ignore address-book names, got %q", got)
 	}
 }
 

--- a/db/address_database_test.go
+++ b/db/address_database_test.go
@@ -1,6 +1,10 @@
 package db
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
 
 // TestGetAddressMatches_ExactAddressNeverFallsBackToFuzzy reproduces a real
 // bug report: a registered address whose *label* happens to mention another
@@ -94,5 +98,21 @@ func TestGetAddressMatches_FreeTextStillFuzzyMatches(t *testing.T) {
 	results, _ := getAddressMatches("foobar", source, exact)
 	if len(results) != 1 || results[0].Address != addr {
 		t.Fatalf("expected label search to still fuzzy-match, got %+v", results)
+	}
+}
+
+func TestRegisterIgnoresInvalidKeysAndZeroAddress(t *testing.T) {
+	d := &DefaultAddressDatabase{Data: map[common.Address]string{}}
+	d.Register("Quang Le", "should not bind")
+	d.Register("", "empty")
+	d.Register("0x0", "short")
+	d.Register("0x0000000000000000000000000000000000000000", "Quang Le")
+	if _, ok := d.Data[common.Address{}]; ok {
+		t.Fatalf("zero address must not carry an address-book name: %+v", d.Data)
+	}
+	const me = "0x9642b23Ed1E01Df1092B92641051881a322F5D4E"
+	d.Register(me, "me")
+	if d.Data[common.HexToAddress(me)] != "me" {
+		t.Fatal("valid addresses must still register")
 	}
 }

--- a/db/default_address_database.go
+++ b/db/default_address_database.go
@@ -9,6 +9,8 @@ import (
 	"path"
 
 	"github.com/ethereum/go-ethereum/common"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
 )
 
 type DefaultAddressDatabase struct {
@@ -16,7 +18,17 @@ type DefaultAddressDatabase struct {
 }
 
 func (self *DefaultAddressDatabase) Register(addr string, name string) {
-	self.Data[common.HexToAddress(addr)] = name
+	// HexToAddress maps invalid or truncated hex (and any non-hex string)
+	// onto address(0). A reversed or typo'd addresses.json entry would
+	// otherwise attach someone's name to the zero address.
+	if !jarviscommon.LooksLikeAddress(addr) {
+		return
+	}
+	a := common.HexToAddress(addr)
+	if a == (common.Address{}) {
+		return
+	}
+	self.Data[a] = name
 }
 
 func registerTokens(db *DefaultAddressDatabase) error {

--- a/util/addrbook/default.go
+++ b/util/addrbook/default.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
 	jarviscommon "github.com/tranvictor/jarvis/common"
 	db "github.com/tranvictor/jarvis/db"
 	jarvisnetworks "github.com/tranvictor/jarvis/networks"
@@ -36,6 +38,15 @@ func NewDefault(network jarvisnetworks.Network) AddressResolver {
 // Resolve looks up addr in the local address databases and enriches the result
 // with ERC20 decimal metadata when available from the on-disk cache.
 func (r Default) Resolve(addr string) jarviscommon.Address {
+	// address(0) is a mint/burn/"none" sentinel, never a named EOA. Skip
+	// the address book, ERC-20 cache and explorer-name cache: a bad
+	// addresses.json key (go-ethereum HexToAddress maps garbage to zero)
+	// or a leftover cache entry would otherwise print as a person.
+	if jarviscommon.IsZeroAddress(addr) ||
+		(jarviscommon.LooksLikeAddress(addr) && ethcommon.HexToAddress(addr) == (ethcommon.Address{})) {
+		return jarviscommon.Address{Address: ethcommon.HexToAddress("0x0").Hex(), Desc: "zero address"}
+	}
+
 	// ERC20 enrichment — cache-only, no network call.
 	// Caches are pre-populated by AnalysisContext.ERC20InfoFor during tx
 	// analysis, by util.IsERC20, or by util.GetERC20Symbol/GetERC20Decimal.

--- a/util/addrbook/default_test.go
+++ b/util/addrbook/default_test.go
@@ -1,0 +1,19 @@
+package addrbook
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tranvictor/jarvis/networks"
+)
+
+func TestResolveZeroAddressIgnoresAddressBook(t *testing.T) {
+	r := NewDefault(networks.EthereumMainnet)
+	got := r.Resolve("0x0000000000000000000000000000000000000000")
+	if got.Desc != "zero address" {
+		t.Fatalf("zero address desc = %q, want %q", got.Desc, "zero address")
+	}
+	if !strings.EqualFold(got.Address, "0x0000000000000000000000000000000000000000") {
+		t.Fatalf("zero address hex = %q", got.Address)
+	}
+}

--- a/util/display_tx_internal_test.go
+++ b/util/display_tx_internal_test.go
@@ -8,8 +8,9 @@ func TestCompactAddressText(t *testing.T) {
 	const hash = "0x3f9a1c2b4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e1c2"
 
 	cases := map[string]string{
-		a:                                 a[:6] + "…5D4E",
-		a + " (me)":                       "me (0x9642…5D4E)",
+		a:           a[:6] + "…5D4E",
+		a + " (me)": "me (0x9642…5D4E)",
+		"0x0000000000000000000000000000000000000000 (Quang Le)": "0x0000…0000 (zero address)",
 		a + " (USDC - 6)":                 "USDC (0x9642…5D4E)",
 		a + " (unknown)":                  "0x9642…5D4E",
 		"from " + a + " to " + b:          "from 0x9642…5D4E to 0x7a25…488D",

--- a/util/display_tx_test.go
+++ b/util/display_tx_test.go
@@ -248,6 +248,24 @@ func TestPlainTransferIsHeadlineOnly(t *testing.T) {
 	}
 }
 
+func TestZeroAddressNeverShowsAddressBookName(t *testing.T) {
+	r := swapTxResult()
+	zero := "0x0000000000000000000000000000000000000000"
+	r.FunctionCall.Params = []jarviscommon.ParamResult{
+		scalar("approveTarget", "address", addrValue(zero, "Quang Le")),
+	}
+	r.Logs = nil
+	for _, layout := range []util.TxLayout{util.LayoutInfo, util.LayoutInfoFull} {
+		out := render(t, r, layout, "")
+		if strings.Contains(out, "Quang Le") {
+			t.Fatalf("zero address must not show an address-book name in layout %v:\n%s", layout, out)
+		}
+		if !strings.Contains(out, "zero address") {
+			t.Fatalf("zero address must be labelled in layout %v:\n%s", layout, out)
+		}
+	}
+}
+
 func TestUnlimitedApprovalIsFlagged(t *testing.T) {
 	r := swapTxResult()
 	r.FunctionCall = nil

--- a/util/util.go
+++ b/util/util.go
@@ -541,7 +541,7 @@ func (r *EnrichedResolver) Resolve(addr string) jarviscommon.Address {
 // silently leaves the cache untouched in those cases so callers can use it as
 // a "best-effort enrichment" hook without worrying about latency or failure.
 func PrefetchContractName(addr string, network networks.Network) {
-	if addr == "" {
+	if addr == "" || jarviscommon.IsZeroAddress(addr) {
 		return
 	}
 	addrLower := strings.ToLower(addr)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`approveTarget  0x000…000 (Quang Le)` was the zero address picking up an address-book name.

`common.HexToAddress` maps invalid `~/addresses.json` keys (a name, a truncated hex, an empty string) onto `address(0)`. Loading the book then bound that name to the sentinel.

- Invalid and zero keys are no longer registered.
- Resolve/print always label `0x000…000` as `(zero address)`, ignoring any book or explorer cache entry.

The Call tree will now show `0x0000…0000 (zero address)` instead of a person.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

