### PR TITLE
msig: decode ERC-20/WETH calldata when explorer ABI lookup fails

### DIFF
--- a/cmd/util/classic_msig_card.go
+++ b/cmd/util/classic_msig_card.go
@@ -36,7 +36,7 @@ func decodeClassicCalldata(
 			customABIs[strings.ToLower(to)] = destAbi
 		}
 	}
-	return analyzer.AnalyzeFunctionCallRecursively(util.GetABI, value, to, data, customABIs)
+	return analyzer.AnalyzeFunctionCallRecursively(lookupABI(resolver), value, to, data, customABIs)
 }
 
 func buildClassicMsigCard(

--- a/cmd/util/safe_signing_card.go
+++ b/cmd/util/safe_signing_card.go
@@ -112,17 +112,26 @@ func decodeSafeCalldata(
 		destAbi, err := resolver.ConfigToABI(
 			stx.To.Hex(), config.ForceERC20ABI, config.CustomABI, network,
 		)
-		if err != nil {
-			if len(customABIs) == 0 && !jarviscommon.IsMultiSendCallData(stx.Data) {
-				return nil
+		if err == nil {
+			if _, taken := customABIs[strings.ToLower(stx.To.Hex())]; !taken {
+				customABIs[strings.ToLower(stx.To.Hex())] = destAbi
 			}
-		} else if _, taken := customABIs[strings.ToLower(stx.To.Hex())]; !taken {
-			customABIs[strings.ToLower(stx.To.Hex())] = destAbi
 		}
 	}
+	// Always run the analyzer, even when the explorer ABI lookup failed.
+	// AnalyzeFunctionCallRecursively falls back to the standard ERC-20 ABI
+	// (and MultiSend) so approve/transfer still decode instead of rendering
+	// as raw bytes with a "no ABI" warning.
 	return analyzer.AnalyzeFunctionCallRecursively(
-		util.GetABI, stx.Value, stx.To.Hex(), stx.Data, customABIs,
+		lookupABI(resolver), stx.Value, stx.To.Hex(), stx.Data, customABIs,
 	)
+}
+
+func lookupABI(resolver ABIResolver) jarviscommon.ABIDatabase {
+	if resolver != nil {
+		return resolver.GetABI
+	}
+	return util.GetABI
 }
 
 func safeSignerLine(s safe.OwnerSig, network jarvisnetworks.Network) ui.StyledText {

--- a/cmd/util/safe_signing_card_test.go
+++ b/cmd/util/safe_signing_card_test.go
@@ -1,0 +1,66 @@
+package util
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/config"
+	jarvisnetworks "github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/safe"
+	"github.com/tranvictor/jarvis/txanalyzer"
+	"github.com/tranvictor/jarvis/util/addrbook"
+)
+
+func TestDecodeSafeCalldataFallsBackToERC20WhenExplorerHasNoABI(t *testing.T) {
+	prevForce := config.ForceERC20ABI
+	prevCustom := config.CustomABI
+	config.ForceERC20ABI = false
+	config.CustomABI = ""
+	t.Cleanup(func() {
+		config.ForceERC20ABI = prevForce
+		config.CustomABI = prevCustom
+	})
+
+	network, err := jarvisnetworks.GetNetwork("mainnet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	weth := ethcommon.HexToAddress("0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73")
+	spender := ethcommon.HexToAddress("0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+	data, err := jarviscommon.GetERC20ABI().Pack("approve", spender, big.NewInt(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := txanalyzer.NewGenericAnalyzerWithContext(
+		txanalyzer.NewAnalysisContextWithResolver(nil, network, addrbook.Map{}),
+	)
+	fc := decodeSafeCalldata(
+		&safe.SafeTx{To: weth, Value: big.NewInt(0), Data: data},
+		network,
+		stubResolver{},
+		analyzer,
+		nil,
+	)
+	if fc == nil {
+		t.Fatal("expected analyzer fallback, got nil call")
+	}
+	if fc.Method != "approve" {
+		t.Fatalf("method = %q, want approve", fc.Method)
+	}
+
+	warns := SigningWarnings(WarningInput{
+		To:      jarviscommon.Address{Address: weth.Hex(), Desc: "WETH"},
+		HasData: true,
+		Call:    fc,
+	})
+	for _, w := range warns {
+		if strings.Contains(w, "could not be decoded") {
+			t.Fatalf("ERC-20 fallback must not warn about a missing ABI: %q", w)
+		}
+	}
+}

--- a/txanalyzer/custom_abi_test.go
+++ b/txanalyzer/custom_abi_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
+	jarviscommon "github.com/tranvictor/jarvis/common"
 	jarvisnetworks "github.com/tranvictor/jarvis/networks"
 )
 
@@ -84,7 +85,46 @@ func TestPartialCustomABIKeepsErrorWhenLookupFails(t *testing.T) {
 	if !strings.Contains(fc.Error, "no method with id") {
 		t.Errorf("error = %q, want it to name the unknown selector", fc.Error)
 	}
-	if len(fc.Data) != len(data) {
+	if fc.Data == nil || len(fc.Data) != len(data) {
 		t.Errorf("raw calldata not preserved for the undecodable call")
+	}
+}
+
+func TestAnalyzeFallsBackToERC20WhenExplorerHasNoABI(t *testing.T) {
+	target := "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73"
+	spender := ethcommon.HexToAddress("0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+	data, err := jarviscommon.GetERC20ABI().Pack("approve", spender, big.NewInt(1))
+	if err != nil {
+		t.Fatalf("pack: %s", err)
+	}
+
+	fc := pureAnalyzer().AnalyzeFunctionCallRecursively(
+		noABIFound, big.NewInt(0), target, data, nil,
+	)
+	if fc.Error != "" {
+		t.Fatalf("unexpected error: %s", fc.Error)
+	}
+	if fc.Method != "approve" {
+		t.Fatalf("method = %q, want approve via ERC-20 fallback", fc.Method)
+	}
+}
+
+func TestAnalyzeMethodlessCustomABIFallsBackToERC20(t *testing.T) {
+	target := "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73"
+	spender := ethcommon.HexToAddress("0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+	data, err := jarviscommon.GetERC20ABI().Pack("approve", spender, big.NewInt(1))
+	if err != nil {
+		t.Fatalf("pack: %s", err)
+	}
+	proxy := abiFromJSON(t, `[{"anonymous":false,"inputs":[{"indexed":true,"name":"implementation","type":"address"}],"name":"Upgraded","type":"event"}]`)
+	fc := pureAnalyzer().AnalyzeFunctionCallRecursively(
+		noABIFound, big.NewInt(0), target, data,
+		map[string]*abi.ABI{strings.ToLower(target): proxy},
+	)
+	if fc.Error != "" {
+		t.Fatalf("unexpected error: %s", fc.Error)
+	}
+	if fc.Method != "approve" {
+		t.Fatalf("method = %q, want approve via ERC-20 fallback", fc.Method)
 	}
 }

--- a/util/explorers/etherscan_alike_explorer.go
+++ b/util/explorers/etherscan_alike_explorer.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -107,9 +106,18 @@ func (ee *EtherscanLikeExplorer) RecommendedGasPrice() (float64, error) {
 
 func (ee *EtherscanLikeExplorer) GetABIStringAPIURL(address string) string {
 	return fmt.Sprintf(
-		"%s/api?chainid=%d&module=contract&action=getabi&address=%s&apikey=%s",
-		ee.Domain,
+		"%s?chainid=%d&module=contract&action=getabi&address=%s&apikey=%s",
+		ee.apiEndpoint(),
 		ee.ChainID,
+		address,
+		ee.APIKey,
+	)
+}
+
+func (ee *EtherscanLikeExplorer) getABIStringAPIURLNoChainID(address string) string {
+	return fmt.Sprintf(
+		"%s?module=contract&action=getabi&address=%s&apikey=%s",
+		ee.apiEndpoint(),
 		address,
 		ee.APIKey,
 	)
@@ -142,42 +150,62 @@ func isRateLimited(msg string) bool {
 
 func (ee *EtherscanLikeExplorer) GetABIString(address string) (string, error) {
 	var lastErr error
-	for attempt := 0; attempt < abiFetchAttempts; attempt++ {
-		if attempt > 0 {
-			time.Sleep(abiRetryDelay)
-		}
-		result, retry, err := ee.getABIStringOnce(address)
+	for _, u := range ee.abiURLs(address) {
+		result, err := ee.getABIStringWithRetry(u)
 		if err == nil {
 			return result, nil
 		}
 		lastErr = err
-		if !retry {
-			break
+		if isUnverifiedABI(err) {
+			return "", err
 		}
 	}
 	return "", lastErr
 }
 
-// getABIStringOnce performs one getabi request. retry is true only for
-// transient failures (rate limiting, transport errors).
-func (ee *EtherscanLikeExplorer) getABIStringOnce(address string) (result string, retry bool, err error) {
-	resp, err := http.Get(ee.GetABIStringAPIURL(address))
-	if err != nil {
-		return "", true, fmt.Errorf("%s: %w", ee.label(), redactURLError(err))
+func (ee *EtherscanLikeExplorer) getABIStringWithRetry(u string) (string, error) {
+	var lastErr error
+	for attempt := 0; attempt < abiFetchAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(abiRetryDelay)
+		}
+		result, retry, err := ee.getABIStringOnce(u)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if !retry {
+			return "", err
+		}
 	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	return "", lastErr
+}
+
+// getABIStringOnce performs one ABI request. retry is true only for
+// transient failures (rate limiting, transport errors).
+func (ee *EtherscanLikeExplorer) getABIStringOnce(u string) (result string, retry bool, err error) {
+	status, body, err := ee.get(u)
 	if err != nil {
-		return "", true, fmt.Errorf("%s: reading response: %w", ee.label(), err)
+		return "", true, err
+	}
+	if status == http.StatusTooManyRequests || isRateLimited(string(body)) {
+		return "", true, fmt.Errorf("%s: %s", ee.label(), strings.TrimSpace(string(body)))
+	}
+	if abiStr, ok := parseABIFromBody(body); ok {
+		return abiStr, false, nil
 	}
 	abiresp := abiresponse{}
-	if err := json.Unmarshal(body, &abiresp); err != nil {
-		return "", false, fmt.Errorf("%s: unexpected response: %w", ee.label(), err)
+	if json.Unmarshal(body, &abiresp) == nil && abiresp.Status != "" && abiresp.Status != "1" {
+		msg := abiresp.Result
+		if msg == "" {
+			msg = abiresp.Message
+		}
+		return "", isRateLimited(msg), fmt.Errorf("%s: %s", ee.label(), msg)
 	}
-	if abiresp.Status != "1" {
-		return "", isRateLimited(abiresp.Result), fmt.Errorf("%s: %s", ee.label(), abiresp.Result)
+	if status >= 400 {
+		return "", false, fmt.Errorf("%s: HTTP %d", ee.label(), status)
 	}
-	return abiresp.Result, false, nil
+	return "", false, fmt.Errorf("%s: unexpected response", ee.label())
 }
 
 // redactURLError strips the request URL (and with it the API key) out of
@@ -192,9 +220,18 @@ func redactURLError(err error) error {
 
 func (ee *EtherscanLikeExplorer) getSourceCodeAPIURL(address string) string {
 	return fmt.Sprintf(
-		"%s/api?chainid=%d&module=contract&action=getsourcecode&address=%s&apikey=%s",
-		ee.Domain,
+		"%s?chainid=%d&module=contract&action=getsourcecode&address=%s&apikey=%s",
+		ee.apiEndpoint(),
 		ee.ChainID,
+		address,
+		ee.APIKey,
+	)
+}
+
+func (ee *EtherscanLikeExplorer) getSourceCodeAPIURLNoChainID(address string) string {
+	return fmt.Sprintf(
+		"%s?module=contract&action=getsourcecode&address=%s&apikey=%s",
+		ee.apiEndpoint(),
 		address,
 		ee.APIKey,
 	)
@@ -216,33 +253,50 @@ type sourceCodeResponse struct {
 }
 
 func (ee *EtherscanLikeExplorer) GetContractInfo(address string) (ContractInfo, error) {
-	resp, err := http.Get(ee.getSourceCodeAPIURL(address))
+	for _, u := range ee.contractInfoURLs(address) {
+		for attempt := 0; attempt < abiFetchAttempts; attempt++ {
+			if attempt > 0 {
+				time.Sleep(abiRetryDelay)
+			}
+			info, kind, err := ee.getContractInfoOnce(u)
+			if kind == fetchOK {
+				return info, nil
+			}
+			if kind == fetchUnverified {
+				// Etherscan returns Status="0" / Message="NOTOK" for unverified
+				// contracts. That's not an error from jarvis's POV — we simply
+				// don't have a name to display.
+				return ContractInfo{}, nil
+			}
+			if kind == fetchRetry {
+				_ = err
+				continue
+			}
+			break
+		}
+	}
+	return ContractInfo{}, nil
+}
+
+func (ee *EtherscanLikeExplorer) getContractInfoOnce(u string) (ContractInfo, fetchKind, error) {
+	status, body, err := ee.get(u)
 	if err != nil {
-		return ContractInfo{}, fmt.Errorf("%s: %w", ee.label(), redactURLError(err))
+		return ContractInfo{}, fetchRetry, err
 	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return ContractInfo{}, fmt.Errorf("%s: reading response: %w", ee.label(), err)
+	if status == http.StatusTooManyRequests || isRateLimited(string(body)) {
+		return ContractInfo{}, fetchRetry, fmt.Errorf("%s: rate limited", ee.label())
 	}
-	var sc sourceCodeResponse
-	if err := json.Unmarshal(body, &sc); err != nil {
-		return ContractInfo{}, fmt.Errorf("unmarshal getsourcecode body: %w", err)
+	if info, ok := parseEtherscanContractInfo(body); ok {
+		if info.ok {
+			return info.info, fetchOK, nil
+		}
+		return ContractInfo{}, fetchUnverified, nil
 	}
-	if sc.Status != "1" || len(sc.Result) == 0 {
-		// Etherscan returns Status="0" / Message="NOTOK" for unverified
-		// contracts. That's not an error from jarvis's POV — we simply
-		// don't have a name to display.
-		return ContractInfo{}, nil
+	if info, ok := parseJSONContractInfo(body); ok {
+		return info, fetchOK, nil
 	}
-	r := sc.Result[0]
-	info := ContractInfo{
-		Name:           r.ContractName,
-		Implementation: r.Implementation,
-		IsProxy:        r.Proxy == "1",
-		// ABI is the literal string "Contract source code not verified" when
-		// the source is missing; treat any other value as verified.
-		IsVerified: r.ABI != "" && r.ABI != "Contract source code not verified",
+	if status >= 400 {
+		return ContractInfo{}, fetchMiss, fmt.Errorf("%s: HTTP %d", ee.label(), status)
 	}
-	return info, nil
+	return ContractInfo{}, fetchMiss, fmt.Errorf("%s: unexpected response", ee.label())
 }

--- a/util/explorers/explorer_fallback.go
+++ b/util/explorers/explorer_fallback.go
@@ -1,0 +1,263 @@
+package explorers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// fetchKind classifies one explorer HTTP response so callers can decide
+// whether to retry, stop, or try a different URL shape.
+type fetchKind int
+
+const (
+	fetchOK fetchKind = iota
+	fetchRetry
+	fetchUnverified
+	fetchMiss
+)
+
+func (ee *EtherscanLikeExplorer) trimmedDomain() string {
+	return strings.TrimRight(strings.TrimSpace(ee.Domain), "/")
+}
+
+// apiEndpoint is the Etherscan-style module/action root. Built-in networks
+// store "https://api.etherscan.io/v2" and we append "/api". Custom networks
+// often store the URL the operator copied from the explorer, which already
+// ends in "/api" or "/api/v2" — appending another "/api" 404s.
+func (ee *EtherscanLikeExplorer) apiEndpoint() string {
+	d := ee.trimmedDomain()
+	lower := strings.ToLower(d)
+	if strings.HasSuffix(lower, "/api") ||
+		strings.HasSuffix(lower, "/api/v1") ||
+		strings.HasSuffix(lower, "/api/v2") {
+		return d
+	}
+	return d + "/api"
+}
+
+// origin is the explorer host without a trailing /api or /api/v2, used for
+// JSON REST paths such as Robinscan /api/contracts/:address and Blockscout
+// /api/v2/smart-contracts/:address.
+func (ee *EtherscanLikeExplorer) origin() string {
+	d := ee.trimmedDomain()
+	lower := strings.ToLower(d)
+	for _, suffix := range []string{"/api/v2", "/api/v1", "/api"} {
+		if strings.HasSuffix(lower, suffix) {
+			return d[:len(d)-len(suffix)]
+		}
+	}
+	return d
+}
+
+func (ee *EtherscanLikeExplorer) abiURLs(address string) []string {
+	addr := strings.TrimSpace(address)
+	return []string{
+		ee.GetABIStringAPIURL(addr),
+		ee.getABIStringAPIURLNoChainID(addr),
+		ee.origin() + "/api/contracts/" + addr,
+		ee.origin() + "/api/v2/smart-contracts/" + addr,
+	}
+}
+
+func (ee *EtherscanLikeExplorer) contractInfoURLs(address string) []string {
+	addr := strings.TrimSpace(address)
+	return []string{
+		ee.getSourceCodeAPIURL(addr),
+		ee.getSourceCodeAPIURLNoChainID(addr),
+		ee.origin() + "/api/contracts/" + addr,
+		ee.origin() + "/api/v2/smart-contracts/" + addr,
+	}
+}
+
+func (ee *EtherscanLikeExplorer) get(u string) (int, []byte, error) {
+	resp, err := http.Get(u)
+	if err != nil {
+		return 0, nil, fmt.Errorf("%s: %w", ee.label(), redactURLError(err))
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("%s: reading response: %w", ee.label(), err)
+	}
+	return resp.StatusCode, body, nil
+}
+
+func isUnverifiedABI(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not verified")
+}
+
+func parseABIFromBody(body []byte) (string, bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return "", false
+	}
+	if trimmed[0] == '[' {
+		var arr []json.RawMessage
+		if json.Unmarshal(trimmed, &arr) == nil {
+			return string(trimmed), true
+		}
+		return "", false
+	}
+
+	var etherscan abiresponse
+	if json.Unmarshal(trimmed, &etherscan) == nil && etherscan.Status == "1" {
+		if etherscan.Result != "" && etherscan.Result != "Contract source code not verified" {
+			return etherscan.Result, true
+		}
+		return "", false
+	}
+
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &generic); err != nil {
+		return "", false
+	}
+	raw, ok := generic["abi"]
+	if !ok {
+		return "", false
+	}
+	return abiFieldToString(raw)
+}
+
+func abiFieldToString(raw json.RawMessage) (string, bool) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", false
+	}
+	if raw[0] == '"' {
+		var s string
+		if json.Unmarshal(raw, &s) != nil {
+			return "", false
+		}
+		if s == "" || s == "Contract source code not verified" {
+			return "", false
+		}
+		return s, true
+	}
+	if raw[0] == '[' {
+		return string(raw), true
+	}
+	return "", false
+}
+
+type etherscanContractParse struct {
+	info ContractInfo
+	ok   bool
+}
+
+func parseEtherscanContractInfo(body []byte) (etherscanContractParse, bool) {
+	var sc sourceCodeResponse
+	if json.Unmarshal(body, &sc) != nil {
+		return etherscanContractParse{}, false
+	}
+	if sc.Status != "1" && sc.Status != "0" {
+		return etherscanContractParse{}, false
+	}
+	if sc.Status != "1" || len(sc.Result) == 0 {
+		return etherscanContractParse{ok: false}, true
+	}
+	r := sc.Result[0]
+	return etherscanContractParse{
+		info: ContractInfo{
+			Name:           r.ContractName,
+			Implementation: r.Implementation,
+			IsProxy:        r.Proxy == "1",
+			IsVerified:     r.ABI != "" && r.ABI != "Contract source code not verified",
+		},
+		ok: true,
+	}, true
+}
+
+func parseJSONContractInfo(body []byte) (ContractInfo, bool) {
+	var raw map[string]json.RawMessage
+	if json.Unmarshal(body, &raw) != nil {
+		return ContractInfo{}, false
+	}
+	if _, hasVerified := raw["isVerified"]; !hasVerified {
+		if _, hasSnake := raw["is_verified"]; !hasSnake {
+			if _, hasProxy := raw["is_proxy"]; !hasProxy {
+				if _, hasABI := raw["abi"]; !hasABI {
+					return ContractInfo{}, false
+				}
+			}
+		}
+	}
+
+	info := ContractInfo{
+		Name:           jsonString(raw["name"]),
+		Implementation: parseImplementation(raw["implementation"]),
+		IsVerified:     jsonBool(raw["isVerified"]) || jsonBool(raw["is_verified"]),
+		IsProxy:        jsonBool(raw["is_proxy"]),
+	}
+	if proxyType := jsonString(raw["proxyType"]); proxyType != "" && !strings.EqualFold(proxyType, "null") {
+		info.IsProxy = true
+	}
+	if info.Implementation == "" {
+		info.Implementation = parseImplementationsArray(raw["implementations"])
+	}
+	if info.Implementation != "" {
+		info.IsProxy = true
+	}
+	return info, true
+}
+
+func jsonString(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return strings.TrimSpace(s)
+	}
+	return ""
+}
+
+func jsonBool(raw json.RawMessage) bool {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return false
+	}
+	var b bool
+	if json.Unmarshal(raw, &b) == nil {
+		return b
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s == "1" || strings.EqualFold(s, "true")
+	}
+	return false
+}
+
+func parseImplementation(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	if raw[0] == '"' {
+		return jsonString(raw)
+	}
+	var obj struct {
+		Address string `json:"address"`
+	}
+	if json.Unmarshal(raw, &obj) == nil {
+		return strings.TrimSpace(obj.Address)
+	}
+	return ""
+}
+
+func parseImplementationsArray(raw json.RawMessage) string {
+	var arr []struct {
+		Address string `json:"address"`
+	}
+	if json.Unmarshal(raw, &arr) != nil || len(arr) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(arr[0].Address)
+}

--- a/util/explorers/explorer_fallback_test.go
+++ b/util/explorers/explorer_fallback_test.go
@@ -1,0 +1,130 @@
+package explorers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestApiEndpointDoesNotDoubleAPI(t *testing.T) {
+	ee := NewEtherscanLikeExplorer("https://robinscan.io/api", "", 4663)
+	if got := ee.apiEndpoint(); got != "https://robinscan.io/api" {
+		t.Fatalf("apiEndpoint = %q", got)
+	}
+	if got := ee.origin(); got != "https://robinscan.io" {
+		t.Fatalf("origin = %q", got)
+	}
+	ee = NewEtherscanLikeExplorer("https://api.etherscan.io/v2", "", 1)
+	if got := ee.apiEndpoint(); got != "https://api.etherscan.io/v2/api" {
+		t.Fatalf("etherscan v2 apiEndpoint = %q", got)
+	}
+}
+
+func TestGetABIStringFallsBackToJSONContractEndpoint(t *testing.T) {
+	const addr = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		io.WriteString(w, `{"error":"not found"}`)
+	})
+	mux.HandleFunc("/api/contracts/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(strings.ToLower(r.URL.Path), strings.ToLower(addr)) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{
+			"address":"0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+			"isVerified":true,
+			"name":"TransparentUpgradeableProxy",
+			"proxyType":"eip1967",
+			"implementation":"0xc6b81b429797e0f555440b70cd99e032d7ae947e",
+			"abi":[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"implementation","type":"address"}],"name":"Upgraded","type":"event"}]
+		}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ee := NewEtherscanLikeExplorer(srv.URL, "SECRETKEY", 4663)
+	got, err := ee.GetABIString(addr)
+	if err != nil {
+		t.Fatalf("GetABIString: %v", err)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(got), &arr); err != nil {
+		t.Fatalf("ABI is not JSON: %q %v", got, err)
+	}
+	if len(arr) != 1 || arr[0]["name"] != "Upgraded" {
+		t.Fatalf("unexpected ABI %s", got)
+	}
+
+	info, err := ee.GetContractInfo(addr)
+	if err != nil {
+		t.Fatalf("GetContractInfo: %v", err)
+	}
+	if !info.IsVerified || !info.IsProxy {
+		t.Fatalf("verified proxy: %+v", info)
+	}
+	if !strings.EqualFold(info.Implementation, "0xc6b81b429797e0f555440b70cd99e032d7ae947e") {
+		t.Fatalf("implementation = %q", info.Implementation)
+	}
+	if info.Name != "TransparentUpgradeableProxy" {
+		t.Fatalf("name = %q", info.Name)
+	}
+}
+
+func TestGetABIStringFallsBackToBlockscoutV2(t *testing.T) {
+	const addr = "0x0000000000000000000000000000000000000001"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	mux.HandleFunc("/api/contracts/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	mux.HandleFunc("/api/v2/smart-contracts/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{
+			"name":"WETH",
+			"is_verified":true,
+			"is_proxy":true,
+			"implementations":[{"address":"0x00000000000000000000000000000000000000aa"}],
+			"abi":[{"type":"function","name":"deposit","inputs":[],"outputs":[],"stateMutability":"payable"}]
+		}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ee := NewEtherscanLikeExplorer(srv.URL, "", 1)
+	got, err := ee.GetABIString(addr)
+	if err != nil || !strings.Contains(got, "deposit") {
+		t.Fatalf("GetABIString: %q %v", got, err)
+	}
+	info, err := ee.GetContractInfo(addr)
+	if err != nil {
+		t.Fatalf("GetContractInfo: %v", err)
+	}
+	if !info.IsProxy || !strings.EqualFold(info.Implementation, "0x00000000000000000000000000000000000000aa") {
+		t.Fatalf("info: %+v", info)
+	}
+}
+
+func TestGetContractInfoStillTreatsEtherscanUnverifiedAsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `{"status":"0","message":"NOTOK","result":"Contract source code not verified"}`)
+	}))
+	defer srv.Close()
+
+	ee := NewEtherscanLikeExplorer(srv.URL, "SECRETKEY", 1)
+	info, err := ee.GetContractInfo("0x0000000000000000000000000000000000000001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info != (ContractInfo{}) {
+		t.Fatalf("unverified must be empty, got %+v", info)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`jarvis msig bapprove` warned `calldata could not be decoded (no ABI for 0x0bd7…)` for Robinhood WETH even though the contract is verified on robinscan.io and even a generic ERC-20 ABI should decode `approve`/`transfer`.

**Cause**
- Safe signing cards returned without running the analyzer when `ConfigToABI` failed, so the existing ERC-20 fallback in `AnalyzeFunctionCallRecursively` never ran.
- ABI fetch only used Etherscan v2 (`/api?chainid=&module=contract&action=getabi`). Robinscan serves verified ABIs at `GET /api/contracts/:address`, and WETH is a TransparentUpgradeableProxy whose implementation ABI (deposit/withdraw/approve) lives on that JSON endpoint.

**Fix**
- Always analyze Safe (and Classic) calldata; use the resolver for lookups so a failed explorer fetch still hits the ERC-20 fallback.
- Try additional explorer URL shapes: Etherscan/Blockscout without `chainid`, Robinscan `/api/contracts/:address`, Blockscout `/api/v2/smart-contracts/:address`.
- Read proxy `implementation` from those JSON APIs so `ConfigToABI` can follow the proxy and decode WETH `deposit`/`withdraw`, not only ERC-20 methods.
- Do not append `/api` when the configured explorer URL already ends with `/api` or `/api/v2`.

Verified live against robinscan.io: WETH proxy → impl `0xc6b81b…` (aeWETH) with deposit/withdraw/approve/transfer.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

