### PR TITLE
msig: present ETH and ERC-20 sends as Send lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,12 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
   and WalletConnect requests: decoded call first, then Sign with / Send to /
   Gas / nonce directly above the prompt.
 - Derived warnings printed as `!` lines right before the prompt: destination
-  not in the address book, native value into a contract, undecodable
-  calldata, unlimited ERC-20 approval, `setApprovalForAll`, approval to an
-  unknown spender, Safe `DELEGATECALL`.
+  not in the address book, native value into a contract, native value attached
+  to an ERC-20 call, undecodable calldata, unlimited ERC-20 approval,
+  `setApprovalForAll`, approval to an unknown spender, Safe `DELEGATECALL`.
+- Native ETH sends to an EOA and ERC-20 `transfer` / `transferFrom` open as
+  `Send  1.5 ETH  →  Alice` / `Send  1,000 USDC  →  Alice` rather than a
+  generic Call header. Safe cards label that EOA destination `Recipient`.
 - Safe cards list the Safe, operation, nonce, `safeTxHash` and collected
   signatures; the EOA card for a Safe execution collapses the inner call
   since it was just shown.

--- a/README.md
+++ b/README.md
@@ -221,8 +221,36 @@ Sign and broadcast (≈ 0.00170246 ETH)? [y/N]
 >
 ```
 
+```
+================ Safe approval =================
+
+Send  1.5 ETH  →  0x9642b23Ed1E01Df1092B92641051881a322F5D4E (Alice)
+
+Sign with    0x9642b23Ed1E01Df1092B92641051881a322F5D4E (me)   ledger   mainnet
+Recipient    0x9642b23Ed1E01Df1092B92641051881a322F5D4E (Alice)
+Value        1.5 ETH
+Operation    CALL (0)
+Safe nonce   17
+safeTxHash   0xabc…
+
+Sign this Safe approval (off-chain, no gas)? [y/N]
+>
+```
+
+An ERC-20 transfer uses the same `Send  amount  →  recipient` line (the
+token contract stays on `Safe calls` / `Send to`). Attaching native value
+to an ERC-20 `transfer` / `approve` / similar call adds:
+
+```
+! attaches 1.5 ETH to an ERC-20 transfer on USDC; the native value goes to the token contract, not the recipient
+```
+
+WETH `deposit` is payable on purpose, so it keeps the ordinary
+`sends 1.5 ETH into a contract` warning instead.
+
 Warnings are emitted for: a destination that is not in your address book,
-native value sent into a contract, calldata jarvis could not decode,
+native value sent into a contract, native value attached to an ERC-20 call,
+calldata jarvis could not decode,
 unlimited ERC-20 approvals, `setApprovalForAll`, approvals to unknown
 spenders, and Safe `DELEGATECALL` operations. Safe cards add the Safe
 address, operation, nonce, `safeTxHash` and the list of collected

--- a/cmd/util/classic_msig_card.go
+++ b/cmd/util/classic_msig_card.go
@@ -82,14 +82,27 @@ func buildClassicMsigCard(
 		HasData:        len(data) > 0,
 		Call:           fc,
 	}
+	if isContract, err := util.IsContract(to, network); err == nil {
+		warn.ToIsContract = isContract
+	}
+	if isERC20, err := util.IsERC20(to, network); err == nil && isERC20 {
+		warn.ToIsERC20 = true
+		util.GetERC20Symbol(to, network)
+		util.GetERC20Decimal(to, network)
+	}
 	if len(data) > 0 {
-		if isContract, err := util.IsContract(to, network); err == nil {
-			warn.ToIsContract = isContract
-		}
 		if fc != nil && fc.Method != "" {
 			card.Call = util.NewFunctionCallDisplay(fc, network)
 		} else {
 			card.RawData = "0x" + ethcommon.Bytes2Hex(data)
+		}
+	} else if value != nil && value.Sign() > 0 {
+		card.Call = util.NewFunctionCallDisplay(&jarviscommon.FunctionCall{
+			Destination: toJarvis,
+			Value:       value,
+		}, network)
+		if !warn.ToIsContract {
+			card.ToLabel = "Recipient"
 		}
 	}
 	card.Warnings = SigningWarnings(warn)

--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -283,7 +283,8 @@ func buildEOASigningCard(
 	}
 
 	toHex := tx.To().Hex()
-	if isERC20, _ := util.IsERC20(toHex, network); isERC20 {
+	isERC20, _ := util.IsERC20(toHex, network)
+	if isERC20 {
 		// Warm the caches so the analyzer below annotates token amounts.
 		util.GetERC20Symbol(toHex, network)
 		util.GetERC20Decimal(toHex, network)
@@ -296,7 +297,7 @@ func buildEOASigningCard(
 		return nil, err
 	}
 	warn := WarningInput{
-		To: to, ToIsContract: isContract, Value: tx.Value(), NativeSymbol: symbol,
+		To: to, ToIsContract: isContract, ToIsERC20: isERC20, Value: tx.Value(), NativeSymbol: symbol,
 		NativeDecimals: network.GetNativeTokenDecimal(),
 		HasData:        len(tx.Data()) > 0, SignerBalance: balance, MaxCost: maxCost,
 	}
@@ -318,6 +319,10 @@ func buildEOASigningCard(
 		}
 	} else if len(tx.Data()) > 0 {
 		card.RawData = "0x" + ethcommon.Bytes2Hex(tx.Data())
+	} else if tx.Value().Sign() > 0 {
+		card.Call = util.NewFunctionCallDisplay(&jarviscommon.FunctionCall{
+			Destination: to, Value: tx.Value(),
+		}, network)
 	}
 
 	if note != nil && note.ExecutesSafeTxHash != "" {

--- a/cmd/util/safe_signing_card.go
+++ b/cmd/util/safe_signing_card.go
@@ -78,16 +78,29 @@ func BuildSafeSigningCard(
 		DelegateCall:   stx.Operation == safe.OpDelegateCall,
 		MultiSend:      isMultiSend,
 	}
+	if isContract, err := util.IsContract(stx.To.Hex(), network); err == nil {
+		warn.ToIsContract = isContract
+	}
+	if isERC20, err := util.IsERC20(stx.To.Hex(), network); err == nil && isERC20 {
+		warn.ToIsERC20 = true
+		util.GetERC20Symbol(stx.To.Hex(), network)
+		util.GetERC20Decimal(stx.To.Hex(), network)
+	}
 	if len(stx.Data) > 0 {
-		if isContract, err := util.IsContract(stx.To.Hex(), network); err == nil {
-			warn.ToIsContract = isContract
-		}
 		fc := decodeSafeCalldata(stx, network, resolver, analyzer, opt.ExtraABIs)
 		if fc != nil {
 			warn.Call = fc
 			card.Call = util.NewFunctionCallDisplay(fc, network)
 		} else {
 			card.RawData = "0x" + ethcommon.Bytes2Hex(stx.Data)
+		}
+	} else if stx.Value != nil && stx.Value.Sign() > 0 {
+		card.Call = util.NewFunctionCallDisplay(&jarviscommon.FunctionCall{
+			Destination: toJarvis,
+			Value:       stx.Value,
+		}, network)
+		if !warn.ToIsContract {
+			card.ToLabel = "Recipient"
 		}
 	}
 	card.Warnings = SigningWarnings(warn)

--- a/cmd/util/signing_card.go
+++ b/cmd/util/signing_card.go
@@ -27,6 +27,9 @@ type SigningCard struct {
 	// expected rather than a surprise.
 	Wallet string
 	To     ui.StyledText // empty Text for contract creation; see CreateAddress
+	// ToLabel overrides the destination row name ("Send to", "Safe calls",
+	// "Calls"). Native ETH sends to an EOA use "Recipient".
+	ToLabel string
 	// CreateAddress is the predicted address when the tx deploys a contract.
 	CreateAddress string
 	Value         string // "1.5 ETH"; empty hides the row
@@ -133,6 +136,8 @@ func ShowSigningCard(u ui.UI, c *SigningCard) {
 	} else if c.To.Text != "" {
 		toLabel := "Send to"
 		switch {
+		case c.ToLabel != "":
+			toLabel = c.ToLabel
 		case c.Safe != nil:
 			toLabel = "Safe calls"
 		case c.Classic != nil:
@@ -265,8 +270,10 @@ type WarningInput struct {
 	NativeDecimals uint64
 	HasData        bool
 	Call           *jarviscommon.FunctionCall
-	DelegateCall   bool
-	MultiSend      bool
+	// ToIsERC20 is true when the destination is an ERC-20 token contract.
+	ToIsERC20    bool
+	DelegateCall bool
+	MultiSend    bool
 	// SignerBalance and MaxCost enable the insufficient-funds warning; either
 	// nil skips it. MaxCost is value + gasLimit × max fee.
 	SignerBalance *big.Int
@@ -302,7 +309,9 @@ func SigningWarnings(in WarningInput) []string {
 	if in.To.Address != "" && !jarviscommon.IsKnownAddress(in.To) {
 		out = append(out, fmt.Sprintf("%s is not in your address book", in.To.Address))
 	}
-	if in.Value != nil && in.Value.Sign() > 0 && in.ToIsContract {
+	if w := erc20NativeValueWarnings(in.Call, in.To, in.ToIsERC20, in.Value, in.NativeSymbol, in.nativeDecimals()); len(w) > 0 {
+		out = append(out, w...)
+	} else if in.Value != nil && in.Value.Sign() > 0 && in.ToIsContract {
 		out = append(out, fmt.Sprintf("sends %s %s into a contract",
 			in.nativeAmount(in.Value), in.NativeSymbol))
 	}
@@ -375,6 +384,81 @@ func approvalWarnings(fc *jarviscommon.FunctionCall) []string {
 func isMaxUint(raw string) bool {
 	_, ok := jarviscommon.MaxUintLabel(raw)
 	return ok
+}
+
+func erc20NativeValueWarnings(
+	fc *jarviscommon.FunctionCall,
+	dest jarviscommon.Address,
+	destIsERC20 bool,
+	value *big.Int,
+	symbol string,
+	decimals uint64,
+) []string {
+	var out []string
+	if w := oneERC20NativeValueWarning(fc, dest, destIsERC20, value, symbol, decimals); w != "" {
+		out = append(out, w)
+	}
+	if fc == nil {
+		return out
+	}
+	for _, inner := range fc.DecodedFunctionCalls {
+		out = append(out, erc20NativeValueWarnings(
+			inner, inner.Destination, isERC20Write(inner.Method), inner.Value, symbol, decimals,
+		)...)
+	}
+	return out
+}
+
+func oneERC20NativeValueWarning(
+	fc *jarviscommon.FunctionCall,
+	dest jarviscommon.Address,
+	destIsERC20 bool,
+	value *big.Int,
+	symbol string,
+	decimals uint64,
+) string {
+	if value == nil || value.Sign() <= 0 {
+		return ""
+	}
+	method := ""
+	if fc != nil {
+		method = fc.Method
+	}
+	if isPayableTokenMethod(method) {
+		return ""
+	}
+	if !destIsERC20 && !isERC20Write(method) {
+		return ""
+	}
+	token := dest.Address
+	if jarviscommon.IsKnownAddress(dest) {
+		if label := strings.TrimSpace(strings.TrimSuffix(dest.Desc, " token")); label != "" {
+			token = label
+		}
+	}
+	amount := jarviscommon.CompactAmount(jarviscommon.BigToFloatString(value, decimals))
+	what := "call"
+	if method != "" {
+		what = method
+	}
+	return fmt.Sprintf("attaches %s %s to an ERC-20 %s on %s; the native value goes to the token contract, not the recipient",
+		amount, symbol, what, token)
+}
+
+func isERC20Write(method string) bool {
+	switch method {
+	case "transfer", "transferFrom", "approve", "increaseAllowance", "decreaseAllowance", "permit":
+		return true
+	}
+	return false
+}
+
+func isPayableTokenMethod(method string) bool {
+	switch method {
+	case "deposit", "depositTo":
+		return true
+	}
+	return false
 }
 
 // FormatGasLine renders the fee parameters of a tx in one line, cost first:

--- a/cmd/util/signing_card_test.go
+++ b/cmd/util/signing_card_test.go
@@ -67,6 +67,29 @@ func TestSigningWarningsCoverTheRiskyCases(t *testing.T) {
 			want: []string{"sends 1.5 ETH into a contract"},
 		},
 		{
+			name: "erc20 call with native value",
+			in: WarningInput{
+				To: cardAddr(cardUSDC, "USDC"), ToIsContract: true, ToIsERC20: true,
+				Value: big.NewInt(1500000000000000000), NativeSymbol: "ETH",
+				Call: &jarviscommon.FunctionCall{
+					Destination: cardAddr(cardUSDC, "USDC"), Method: "transfer",
+					Params: []jarviscommon.ParamResult{addrParam("to", cardMe, "me"), uintParam("amount", "1000")},
+				},
+			},
+			want: []string{"attaches 1.5 ETH to an ERC-20 transfer on USDC"},
+		},
+		{
+			name: "weth deposit keeps the generic contract-value warning",
+			in: WarningInput{
+				To: cardAddr(cardUSDC, "WETH"), ToIsContract: true, ToIsERC20: true,
+				Value: big.NewInt(1500000000000000000), NativeSymbol: "ETH",
+				Call: &jarviscommon.FunctionCall{
+					Destination: cardAddr(cardUSDC, "WETH"), Method: "deposit",
+				},
+			},
+			want: []string{"sends 1.5 ETH into a contract"},
+		},
+		{
 			name: "delegatecall multisend",
 			in:   WarningInput{To: cardAddr(cardRouter, "MultiSendCallOnly"), DelegateCall: true, MultiSend: true},
 			want: []string{"DELEGATECALL into MultiSend"},
@@ -297,6 +320,7 @@ func TestShowSigningCardClassicFields(t *testing.T) {
 	})
 	for _, w := range []string{
 		"Classic multisig transaction",
+		"Send  1000  →  " + cardMe + " (me)",
 		"Calls: " + cardUSDC + " (USDC)",
 		"Multisig: " + cardMe + " (Treasury)",
 		"Tx ID: #42",
@@ -348,6 +372,65 @@ func TestShowSigningCardClassicProposalOmitsTxID(t *testing.T) {
 	}
 	if !rec.HasMessage("Classic multisig transaction") || !rec.HasMessage("Multisig: "+cardMe+" (Treasury)") {
 		t.Fatalf("proposal card missing: %v", rec.Entries())
+	}
+}
+
+func TestShowSigningCardNativeSendToEOA(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	fc := &jarviscommon.FunctionCall{
+		Destination: cardAddr(cardMe, "Alice"),
+		Value:       big.NewInt(1_500_000_000_000_000_000),
+	}
+	ShowSigningCard(rec, &SigningCard{
+		Kind:    "Safe approval",
+		Network: "mainnet",
+		To:      util.StyledAddress(cardAddr(cardMe, "Alice")),
+		ToLabel: "Recipient",
+		Value:   "1.5 ETH",
+		Call:    util.NewFunctionCallDisplay(fc, nil),
+		Safe: &SafeCardFields{
+			Operation: "CALL (0)", SafeNonce: "3", SafeTxHash: "0xabc",
+		},
+	})
+	if !rec.HasMessage("Send  1.5 ETH  →  " + cardMe + " (Alice)") {
+		t.Fatalf("native send headline missing: %v", rec.Entries())
+	}
+	if !rec.HasMessage("Recipient: " + cardMe + " (Alice)") {
+		t.Fatalf("EOA send should label the destination Recipient: %v", rec.Entries())
+	}
+	if rec.HasMessage("Safe calls:") {
+		t.Fatalf("EOA send must not look like a contract call: %v", rec.Entries())
+	}
+	if rec.HasMessage("<undecoded>") {
+		t.Fatalf("native send must not look undecoded: %v", rec.Entries())
+	}
+}
+
+func TestShowSigningCardERC20TransferHeadline(t *testing.T) {
+	rec := ui.NewRecordingUI()
+	alice := cardAddr(cardMe, "Alice")
+	amount := jarviscommon.Value{
+		Raw: "1000000000", Kind: jarviscommon.DisplayToken,
+		Token: &jarviscommon.TokenHint{Decimal: 6, Symbol: "USDC"},
+	}
+	fc := &jarviscommon.FunctionCall{
+		Destination: cardAddr(cardUSDC, "USDC token"), Method: "transfer",
+		Params: []jarviscommon.ParamResult{
+			addrParam("_to", cardMe, "Alice"),
+			{Name: "_value", Type: "uint256", Values: []jarviscommon.Value{amount}},
+		},
+	}
+	ShowSigningCard(rec, &SigningCard{
+		Kind: "Safe approval",
+		To:   util.StyledAddress(cardAddr(cardUSDC, "USDC")),
+		Call: util.NewFunctionCallDisplay(fc, nil),
+		Safe: &SafeCardFields{Operation: "CALL (0)", SafeNonce: "4", SafeTxHash: "0xabc"},
+	})
+	if !rec.HasMessage("Send  1,000 USDC  →  " + alice.Address + " (Alice)") {
+		t.Fatalf("erc20 send headline missing: %v", rec.Entries())
+	}
+	if !rec.HasMessage("Safe calls: " + cardUSDC + " (USDC)") {
+		t.Fatalf("token destination should stay on Safe calls: %v", rec.Entries())
 	}
 }
 

--- a/util/display.go
+++ b/util/display.go
@@ -109,6 +109,11 @@ func buildFunctionCallDisplay(fc *jarviscommon.FunctionCall, nested bool, networ
 	for _, inner := range fc.DecodedFunctionCalls {
 		d.InnerCalls = append(d.InnerCalls, buildFunctionCallDisplay(inner, true, network))
 	}
+	if p := tokenPayment(fc); p != nil {
+		d.Payment = p
+	} else if fc.Method == "" && len(fc.Data) == 0 {
+		d.Payment = nativePayment(fc.Destination, fc.Value, network)
+	}
 	return d
 }
 

--- a/util/display_model.go
+++ b/util/display_model.go
@@ -50,6 +50,10 @@ type FunctionCallDisplay struct {
 	Data       string                 `json:"data,omitempty"`
 	InnerCalls []*FunctionCallDisplay `json:"inner_calls,omitempty"`
 	Error      string                 `json:"error,omitempty"`
+	// Payment is set for a native send or ERC-20 transfer so the call can
+	// render as "Send 1.5 ETH → Alice" instead of a generic Call header.
+	// Omitted from JSON to keep --json-output stable.
+	Payment *PaymentReading `json:"-"`
 }
 
 // TxLayout selects how much of a TxDisplay is rendered and how densely.

--- a/util/display_tx.go
+++ b/util/display_tx.go
@@ -374,16 +374,33 @@ func (p txPrinter) printNetEffect(rows []NetEffectDisplay) {
 // printCall renders the top-level call and its inner calls as an indented
 // tree instead of bordered tables.
 func (p txPrinter) printCall(d *FunctionCallDisplay) {
-	if d.Method == "" {
-		p.u.Subsection("Call  <undecoded>  →  " + p.text(d.Destination))
-	} else {
-		p.u.Subsection("Call  " + d.Method + "  →  " + p.text(d.Destination))
-	}
+	p.u.Subsection(p.callTitle(d))
 	p.printCallBody(p.u.Indent(), d)
 }
 
+func (p txPrinter) callTitle(d *FunctionCallDisplay) string {
+	if line := p.paymentTitle(d); line != "" {
+		return line
+	}
+	if d.Method == "" {
+		return "Call  <undecoded>  →  " + p.text(d.Destination)
+	}
+	return "Call  " + d.Method + "  →  " + p.text(d.Destination)
+}
+
+func (p txPrinter) paymentTitle(d *FunctionCallDisplay) string {
+	if d == nil || d.Payment == nil {
+		return ""
+	}
+	line := "Send  " + d.Payment.Amount + "  →  " + p.text(d.Payment.To)
+	if d.Payment.From.Text != "" {
+		line += "   from " + p.text(d.Payment.From)
+	}
+	return line
+}
+
 func (p txPrinter) printCallBody(u ui.UI, d *FunctionCallDisplay) {
-	if d.Value != "" {
+	if d.Value != "" && d.Payment == nil {
 		u.Info("%s %s", p.muted("value"), d.Value)
 	}
 	if d.Error != "" {
@@ -403,11 +420,15 @@ func (p txPrinter) printCallBody(u ui.UI, d *FunctionCallDisplay) {
 		u.Info("%s", line)
 	}
 	for _, inner := range d.InnerCalls {
-		method := inner.Method
-		if method == "" {
-			method = "<undecoded>"
+		if line := p.paymentTitle(inner); line != "" {
+			u.Info("↳ %s", line)
+		} else {
+			method := inner.Method
+			if method == "" {
+				method = "<undecoded>"
+			}
+			u.Info("↳ %s  →  %s", p.bold(method), p.text(inner.Destination))
 		}
-		u.Info("↳ %s  →  %s", p.bold(method), p.text(inner.Destination))
 		p.printCallBody(u.Indent(), inner)
 	}
 }

--- a/util/payment.go
+++ b/util/payment.go
@@ -1,0 +1,172 @@
+package util
+
+import (
+	"math/big"
+	"strings"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/ui"
+)
+
+// PaymentReading is the one-line form of a native send or an ERC-20
+// transfer/transferFrom. Signing cards and the Call tree use it so "the Safe
+// is sending 1.5 ETH to Alice" reads as a send, not as a contract call.
+type PaymentReading struct {
+	Amount string
+	To     ui.StyledText
+	From   ui.StyledText // transferFrom only
+}
+
+func nativePayment(to jarviscommon.Address, value *big.Int, network networks.Network) *PaymentReading {
+	if value == nil || value.Sign() <= 0 {
+		return nil
+	}
+	dec, sym := uint64(18), "ETH"
+	if network != nil {
+		dec = network.GetNativeTokenDecimal()
+		sym = network.GetNativeTokenSymbol()
+	}
+	amount := jarviscommon.CompactAmount(jarviscommon.BigToFloatString(value, dec)) + " " + sym
+	return &PaymentReading{Amount: amount, To: StyledAddress(to)}
+}
+
+func tokenPayment(fc *jarviscommon.FunctionCall) *PaymentReading {
+	if fc == nil {
+		return nil
+	}
+	switch fc.Method {
+	case "transfer":
+		to := namedAddress(fc, "to", "dst", "recipient")
+		amount := namedValue(fc, "value", "amount", "wad")
+		if to == nil {
+			to = addressAt(fc, 0)
+		}
+		if amount == nil {
+			amount = valueAt(fc, 1)
+		}
+		if to == nil || amount == nil {
+			return nil
+		}
+		return &PaymentReading{
+			Amount: paymentAmountText(*amount, fc.Destination),
+			To:     styledParamAddress(*to),
+		}
+	case "transferFrom":
+		from := namedAddress(fc, "from", "src")
+		to := namedAddress(fc, "to", "dst", "recipient")
+		amount := namedValue(fc, "value", "amount", "wad")
+		if from == nil {
+			from = addressAt(fc, 0)
+		}
+		if to == nil {
+			to = addressAt(fc, 1)
+		}
+		if amount == nil {
+			amount = valueAt(fc, 2)
+		}
+		if to == nil || amount == nil {
+			return nil
+		}
+		p := &PaymentReading{
+			Amount: paymentAmountText(*amount, fc.Destination),
+			To:     styledParamAddress(*to),
+		}
+		if from != nil {
+			p.From = styledParamAddress(*from)
+		}
+		return p
+	default:
+		return nil
+	}
+}
+
+func paymentAmountText(v jarviscommon.Value, dest jarviscommon.Address) string {
+	symbol := paymentTokenSymbol(v, dest)
+	decimals := uint64(0)
+	if v.Token != nil {
+		decimals = v.Token.Decimal
+	} else if dest.Decimal > 0 {
+		decimals = uint64(dest.Decimal)
+	}
+	if decimals > 0 {
+		human := jarviscommon.CompactAmount(jarviscommon.BigToFloatString(jarviscommon.StringToBig(v.Raw), decimals))
+		if symbol != "" {
+			return human + " " + symbol
+		}
+		return human
+	}
+	return jarviscommon.ReadableNumber(v.Raw)
+}
+
+func paymentTokenSymbol(v jarviscommon.Value, dest jarviscommon.Address) string {
+	if v.Token != nil && v.Token.Symbol != "" {
+		return v.Token.Symbol
+	}
+	d := strings.TrimSpace(dest.Desc)
+	d = strings.TrimSuffix(d, " token")
+	d = strings.TrimSpace(d)
+	if d != "" && d != "unknown" {
+		return d
+	}
+	return ""
+}
+
+func namedAddress(fc *jarviscommon.FunctionCall, names ...string) *jarviscommon.Address {
+	if p := namedParam(fc, names...); p != nil {
+		return paramAddress(p)
+	}
+	return nil
+}
+
+func namedValue(fc *jarviscommon.FunctionCall, names ...string) *jarviscommon.Value {
+	if p := namedParam(fc, names...); p != nil {
+		return paramScalar(p)
+	}
+	return nil
+}
+
+func namedParam(fc *jarviscommon.FunctionCall, names ...string) *jarviscommon.ParamResult {
+	want := map[string]bool{}
+	for _, n := range names {
+		want[canonicalParamName(n)] = true
+	}
+	for i := range fc.Params {
+		if want[canonicalParamName(fc.Params[i].Name)] {
+			return &fc.Params[i]
+		}
+	}
+	return nil
+}
+
+func canonicalParamName(name string) string {
+	return strings.ToLower(strings.TrimPrefix(strings.TrimSpace(name), "_"))
+}
+
+func addressAt(fc *jarviscommon.FunctionCall, i int) *jarviscommon.Address {
+	if i < 0 || i >= len(fc.Params) {
+		return nil
+	}
+	return paramAddress(&fc.Params[i])
+}
+
+func valueAt(fc *jarviscommon.FunctionCall, i int) *jarviscommon.Value {
+	if i < 0 || i >= len(fc.Params) {
+		return nil
+	}
+	return paramScalar(&fc.Params[i])
+}
+
+func paramAddress(p *jarviscommon.ParamResult) *jarviscommon.Address {
+	if p == nil || len(p.Values) != 1 || p.Values[0].Address == nil {
+		return nil
+	}
+	return p.Values[0].Address
+}
+
+func paramScalar(p *jarviscommon.ParamResult) *jarviscommon.Value {
+	if p == nil || len(p.Values) != 1 {
+		return nil
+	}
+	return &p.Values[0]
+}

--- a/util/payment_test.go
+++ b/util/payment_test.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"math/big"
+	"testing"
+
+	jarviscommon "github.com/tranvictor/jarvis/common"
+	"github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/ui"
+)
+
+func TestNativePaymentHeadline(t *testing.T) {
+	to := jarviscommon.Address{Address: "0x9642b23Ed1E01Df1092B92641051881a322F5D4E", Desc: "Alice"}
+	p := nativePayment(to, big.NewInt(1_500_000_000_000_000_000), networks.EthereumMainnet)
+	if p == nil || p.Amount != "1.5 ETH" {
+		t.Fatalf("amount = %+v", p)
+	}
+	if p.To.Text != jarviscommon.PlainAddress(to) {
+		t.Fatalf("to = %q", p.To.Text)
+	}
+}
+
+func TestTokenPaymentTransfer(t *testing.T) {
+	to := jarviscommon.Address{Address: "0x9642b23Ed1E01Df1092B92641051881a322F5D4E", Desc: "Alice"}
+	amount := jarviscommon.Value{
+		Raw:   "1000000000",
+		Kind:  jarviscommon.DisplayToken,
+		Token: &jarviscommon.TokenHint{Decimal: 6, Symbol: "USDC"},
+	}
+	fc := &jarviscommon.FunctionCall{
+		Destination: jarviscommon.Address{Address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", Desc: "USDC token"},
+		Method:      "transfer",
+		Params: []jarviscommon.ParamResult{
+			{Name: "_to", Type: "address", Values: []jarviscommon.Value{{Raw: to.Address, Kind: jarviscommon.DisplayAddress, Address: &to}}},
+			{Name: "_value", Type: "uint256", Values: []jarviscommon.Value{amount}},
+		},
+	}
+	p := tokenPayment(fc)
+	if p == nil || p.Amount != "1,000 USDC" {
+		t.Fatalf("amount = %+v", p)
+	}
+	if p.To.Text != jarviscommon.PlainAddress(to) {
+		t.Fatalf("to = %q", p.To.Text)
+	}
+
+	rec := ui.NewRecordingUI()
+	PrintFunctionCall(rec, NewFunctionCallDisplay(fc, networks.EthereumMainnet))
+	if !rec.HasMessage("Send  1,000 USDC  →  " + to.Address + " (Alice)") {
+		t.Fatalf("missing send headline: %v", rec.Entries())
+	}
+}
+
+func TestTokenPaymentTransferFrom(t *testing.T) {
+	from := jarviscommon.Address{Address: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D", Desc: "Router"}
+	to := jarviscommon.Address{Address: "0x9642b23Ed1E01Df1092B92641051881a322F5D4E", Desc: "Alice"}
+	fc := &jarviscommon.FunctionCall{
+		Destination: jarviscommon.Address{Address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", Desc: "USDC", Decimal: 6},
+		Method:      "transferFrom",
+		Params: []jarviscommon.ParamResult{
+			{Name: "from", Type: "address", Values: []jarviscommon.Value{{Kind: jarviscommon.DisplayAddress, Address: &from}}},
+			{Name: "to", Type: "address", Values: []jarviscommon.Value{{Kind: jarviscommon.DisplayAddress, Address: &to}}},
+			{Name: "amount", Type: "uint256", Values: []jarviscommon.Value{{Raw: "5000000", Kind: jarviscommon.DisplayInteger}}},
+		},
+	}
+	p := tokenPayment(fc)
+	if p == nil || p.Amount != "5 USDC" || p.From.Text == "" {
+		t.Fatalf("%+v", p)
+	}
+}
+
+func TestNativeInnerCallRendersAsSend(t *testing.T) {
+	alice := jarviscommon.Address{Address: "0x9642b23Ed1E01Df1092B92641051881a322F5D4E", Desc: "Alice"}
+	outer := &jarviscommon.FunctionCall{
+		Destination: jarviscommon.Address{Address: "0x40A2aCCbd92BCA938b02010E17A5b8929b67764f", Desc: "MultiSendCallOnly"},
+		Method:      "multiSend",
+		DecodedFunctionCalls: []*jarviscommon.FunctionCall{{
+			Destination: alice,
+			Value:       big.NewInt(1_500_000_000_000_000_000),
+		}},
+	}
+	rec := ui.NewRecordingUI()
+	PrintFunctionCall(rec, NewFunctionCallDisplay(outer, networks.EthereumMainnet))
+	if !rec.HasMessage("Send  1.5 ETH  →  " + alice.Address + " (Alice)") {
+		t.Fatalf("inner ETH send: %v", rec.Entries())
+	}
+	if rec.HasMessage("<undecoded>") {
+		t.Fatalf("native send must not look undecoded: %v", rec.Entries())
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`jarvis msig approve` treated a native ETH send and an ERC-20 transfer like any other contract call: `Safe calls` pointed at the recipient (or the token), and the action was easy to miss.

**Presentation**
- ETH to an EOA: `Send  1.5 ETH  →  Alice`, destination row labelled `Recipient`.
- ERC-20 `transfer` / `transferFrom`: `Send  1,000 USDC  →  Alice` (token contract stays on `Safe calls` / `Send to`).
- The same Send line is used inside MultiSend batches, so an inner native transfer is no longer `<undecoded>`.

**Warning**
- Attaching native value to an ERC-20 write (`transfer`, `approve`, …) now warns that the ETH goes to the token contract, not the token recipient.
- WETH `deposit` / `depositTo` keep the existing `sends X ETH into a contract` warning; those methods are payable on purpose.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

