### PR TITLE
msig: decode Classic confirmTransaction on the EOA signing card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
   not in the address book, native value into a contract, native value attached
   to an ERC-20 call, undecodable calldata, unlimited ERC-20 approval,
   `setApprovalForAll`, approval to an unknown spender, Safe `DELEGATECALL`.
+- Classic `msig approve` / revoke / execute EOA cards decode `confirmTransaction`
+  (and the other built-in Classic methods) even when the explorer ABI is
+  missing or is a methodless proxy. The following signing card used to dump
+  raw bytes for the wallet you were already operating on.
 - Native ETH sends to an EOA and ERC-20 `transfer` / `transferFrom` open as
   `Send  1.5 ETH  →  Alice` / `Send  1,000 USDC  →  Alice` rather than a
   generic Call header. Safe cards label that EOA destination `Recipient`.

--- a/cmd/util/prompt_util.go
+++ b/cmd/util/prompt_util.go
@@ -303,22 +303,20 @@ func buildEOASigningCard(
 	}
 
 	var fc *jarviscommon.FunctionCall
-	if isContract && len(tx.Data()) > 0 {
+	if len(tx.Data()) > 0 {
+		// Decode even when eth_getCode didn't flag a contract: Classic msig
+		// approve is confirmTransaction to the wallet, and a failed code
+		// lookup used to dump the raw 36 bytes instead of the built-in ABI.
 		fc = analyzer.AnalyzeFunctionCallRecursively(util.GetABI, tx.Value(), toHex, tx.Data(), customABIs)
 		warn.Call = fc
-		if fc != nil {
+		if fc != nil && (fc.Method != "" || isContract) {
 			card.Call = util.NewFunctionCallDisplay(fc, network)
+			if fc.Method != "" {
+				card.ClearSign = func(cu ui.UI) { renderContractClearSign(cu, tx, fc, network, customABIs) }
+			}
+		} else {
+			card.RawData = "0x" + ethcommon.Bytes2Hex(tx.Data())
 		}
-		// ERC-7730 clear-signing layer: when a descriptor matches the
-		// destination contract, the curated view is rendered above the raw
-		// ABI decode so the operator can scan the intent at a glance and
-		// still cross-check against the full breakdown. Failures fall through
-		// silently — we never make the review worse than today.
-		if fc != nil && fc.Method != "" {
-			card.ClearSign = func(cu ui.UI) { renderContractClearSign(cu, tx, fc, network, customABIs) }
-		}
-	} else if len(tx.Data()) > 0 {
-		card.RawData = "0x" + ethcommon.Bytes2Hex(tx.Data())
 	} else if tx.Value().Sign() > 0 {
 		card.Call = util.NewFunctionCallDisplay(&jarviscommon.FunctionCall{
 			Destination: to, Value: tx.Value(),

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -28,14 +28,22 @@ import (
 )
 
 // classicMsigABI returns the ABI for packing Gnosis Classic multisig calls.
-// It prefers the verified explorer ABI when available and falls back to the
-// built-in classic ABI when the contract is unverified — same as bapprove.
+// It prefers the verified explorer ABI when that ABI actually describes the
+// Classic methods (confirmTransaction, …) and falls back to the built-in
+// ABI when the contract is unverified or is a methodless proxy.
 func classicMsigABI(resolver ABIResolver, addr string, network jarvisnetworks.Network) *abi.ABI {
-	a, err := resolver.GetABI(addr, network)
-	if err == nil {
-		return a
+	fallback := util.GetGnosisMsigABI()
+	if resolver == nil {
+		return fallback
 	}
-	return util.GetGnosisMsigABI()
+	a, err := resolver.GetABI(addr, network)
+	if err != nil || a == nil {
+		return fallback
+	}
+	if _, ok := a.Methods["confirmTransaction"]; !ok {
+		return fallback
+	}
+	return a
 }
 
 // PostProcessFunc is a callback called with the decoded function call after
@@ -175,7 +183,10 @@ func HandleApproveOrRevokeOrExecuteMsig(
 	}
 
 	SetClassicSigningNote()
-	if broadcasted, err := SignAndBroadcast(u, tc.FromAcc, tx, nil, reader, analyzer, a, bc); err != nil && !broadcasted && !errors.Is(err, ErrUserCancelled) {
+	customABIs := map[string]*abi.ABI{
+		strings.ToLower(tc.To): a,
+	}
+	if broadcasted, err := SignAndBroadcast(u, tc.FromAcc, tx, customABIs, reader, analyzer, a, bc); err != nil && !broadcasted && !errors.Is(err, ErrUserCancelled) {
 		u.Error("Failed to proceed after signing the tx: %s. Aborted.", err)
 	}
 }

--- a/txanalyzer/analyzer.go
+++ b/txanalyzer/analyzer.go
@@ -298,6 +298,12 @@ func (self *TxAnalyzer) analyzeFunctionCallRecursively(
 	if IsMultiSendCallData(data) && !abiHasSelector(a, data[:4]) {
 		a = GetMultiSendABI()
 	}
+	// Classic Gnosis wallets are often unverified proxies. Jarvis already
+	// packed confirmTransaction with the built-in ABI; without this the
+	// following EOA signing card would render as raw bytes.
+	if util.IsGnosisMsigCallData(data) && !abiHasSelector(a, data[:4]) {
+		a = util.GetGnosisMsigABI()
+	}
 
 	// Look up ERC20 context for the destination so that integer params
 	// (token amounts) can be annotated with decimal and symbol.

--- a/txanalyzer/custom_abi_test.go
+++ b/txanalyzer/custom_abi_test.go
@@ -10,6 +10,7 @@ import (
 
 	jarviscommon "github.com/tranvictor/jarvis/common"
 	jarvisnetworks "github.com/tranvictor/jarvis/networks"
+	"github.com/tranvictor/jarvis/util"
 )
 
 func abiFromJSON(t *testing.T, json string) *abi.ABI {
@@ -126,5 +127,41 @@ func TestAnalyzeMethodlessCustomABIFallsBackToERC20(t *testing.T) {
 	}
 	if fc.Method != "approve" {
 		t.Fatalf("method = %q, want approve via ERC-20 fallback", fc.Method)
+	}
+}
+
+func TestAnalyzeFallsBackToGnosisMsigABIWhenExplorerHasNoABI(t *testing.T) {
+	msig := "0x48B8419B2Bc0fB63Ee96e3a370e30B200cC2e672"
+	data, err := util.GetGnosisMsigABI().Pack("confirmTransaction", big.NewInt(6))
+	if err != nil {
+		t.Fatalf("pack: %s", err)
+	}
+	fc := pureAnalyzer().AnalyzeFunctionCallRecursively(
+		noABIFound, big.NewInt(0), msig, data, nil,
+	)
+	if fc.Error != "" {
+		t.Fatalf("unexpected error: %s", fc.Error)
+	}
+	if fc.Method != "confirmTransaction" {
+		t.Fatalf("method = %q, want confirmTransaction via Classic ABI fallback", fc.Method)
+	}
+	if len(fc.Params) != 1 || fc.Params[0].Values[0].Raw != "6" {
+		t.Fatalf("transactionId not decoded: %+v", fc.Params)
+	}
+}
+
+func TestAnalyzeFallsBackToGnosisMsigABIWhenProxyABIHasNoMethods(t *testing.T) {
+	msig := "0x48B8419B2Bc0fB63Ee96e3a370e30B200cC2e672"
+	data, err := util.GetGnosisMsigABI().Pack("confirmTransaction", big.NewInt(6))
+	if err != nil {
+		t.Fatalf("pack: %s", err)
+	}
+	proxy := abiFromJSON(t, `[{"inputs":[{"name":"_singleton","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"stateMutability":"payable","type":"fallback"}]`)
+	fc := pureAnalyzer().AnalyzeFunctionCallRecursively(
+		noABIFound, big.NewInt(0), msig, data,
+		map[string]*abi.ABI{strings.ToLower(msig): proxy},
+	)
+	if fc.Method != "confirmTransaction" {
+		t.Fatalf("method = %q, want confirmTransaction, err %q", fc.Method, fc.Error)
 	}
 }

--- a/util/gnosis_msig_test.go
+++ b/util/gnosis_msig_test.go
@@ -77,3 +77,29 @@ func TestGnosisMsigTxIDFromCalldataConfirm(t *testing.T) {
 		t.Fatal("expected nil for unknown selector")
 	}
 }
+
+func TestIsGnosisMsigCallData(t *testing.T) {
+	data, err := GetGnosisMsigABI().Pack("confirmTransaction", big.NewInt(6))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !IsGnosisMsigCallData(data) {
+		t.Fatal("confirmTransaction should match the built-in Classic ABI")
+	}
+	submit, err := GetGnosisMsigABI().Pack("executeTransaction", big.NewInt(6))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !IsGnosisMsigCallData(submit) {
+		t.Fatal("executeTransaction should match")
+	}
+	if !IsGnosisMsigCallData(data[:4]) {
+		t.Fatal("the 4-byte selector alone should match")
+	}
+	if IsGnosisMsigCallData([]byte{0x01, 0x02, 0x03, 0x04}) {
+		t.Fatal("unknown selector must not match")
+	}
+	if IsGnosisMsigCallData(nil) {
+		t.Fatal("empty data must not match")
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -946,6 +946,18 @@ func GnosisMsigTxIDFromCalldata(data []byte) *big.Int {
 	return nil
 }
 
+// IsGnosisMsigCallData reports whether data's selector is a method on the
+// built-in Classic Gnosis multisig ABI (confirmTransaction, submitTransaction,
+// executeTransaction, …). Used so the analyzer can decode those calls when
+// the explorer ABI is missing or is a methodless proxy.
+func IsGnosisMsigCallData(data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+	_, err := GetGnosisMsigABI().MethodById(data[:4])
+	return err == nil
+}
+
 func GetABI(addr string, network networks.Network) (*abi.ABI, error) {
 	abiStr, err := GetABIString(addr, network)
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The inner Classic transaction card decoded fine. The following **EOA transaction** card for `confirmTransaction(uint256)` (`0xc01a8c84`, tx id 6) dumped raw bytes and warned `no ABI for <the same msig>`.

**Cause**
- `jarvis msig approve` packed that call with the built-in Classic ABI, then passed `nil` customABIs into `SignAndBroadcast`.
- The EOA card looked the destination up on the explorer. Classic wallets are often methodless proxies, so lookup failed and the ERC-20 fallback could not match `confirmTransaction`.
- If `eth_getCode` did not flag a contract, analysis was skipped entirely and the 36 bytes were shown raw.

**Fix**
- Pass the ABI that just packed the call into the EOA signing card.
- Use the built-in Classic ABI when the explorer ABI has no `confirmTransaction`.
- Analyzer well-known fallback (same idea as MultiSend): if the selector is a Classic method, decode with `GetGnosisMsigABI()`.
- Always attempt calldata decode on the EOA card when there is data, so a missed `IsContract` check cannot hide `confirmTransaction`.

The EOA card should now collapse to `Call  confirmTransaction  →  <msig>   (Classic transaction shown above)` instead of raw bytes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

