### PR TITLE
msig: stamp [i/n] on every bapprove card, prompt and result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 - One signing card for EOA transactions, Safe proposals/approvals/executions
   and WalletConnect requests: decoded call first, then Sign with / Send to /
   Gas / nonce directly above the prompt.
+- Classic inner txs and Safe approvals/proposals render in a rounded box;
+  the EOA confirm/execute that follows is a quiet heading so the two are
+  not the same visual weight.
 - Derived warnings printed as `!` lines right before the prompt: destination
   not in the address book, native value into a contract, native value attached
   to an ERC-20 call, undecodable calldata, unlimited ERC-20 approval,
@@ -110,9 +113,11 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 ### Batch approvals (`jarvis msig bapprove`)
 
 - Plan printed before the first prompt; each item is a `===== [i/n] … =====`
-  section so it matches the weight of the signing cards inside it. Those cards,
-  their Y/n prompts, and the one-line result all repeat `[i/n]`, so a 50-item
-  transcript stays scannable after the banner has scrolled off.
+  section. The Classic/Safe operation itself is a rounded box
+  (`╭─ [i/n] Classic multisig transaction ─╮`) so it is the thing the eye
+  hits when the next tx appears; the following EOA confirm/execute card is
+  a quiet heading, not a second equals-rule. Cards, Y/n prompts, and the
+  one-line result all repeat `[i/n]`.
 - After a failed item jarvis asks whether to continue; declining records the
   rest as skipped.
 - Unified summary table for Safe and Classic items, totals line, and exit
@@ -140,9 +145,9 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
   `jarvis network list` is a table of names, chain IDs and RPC **hosts**
   (never the full URL, so default Infura keys stay off the screen);
   `jarvis msig chains list` uses the same table primitive.
-- Classic `msig info` / `approve` use the same signing card as Safe (decoded
-  call, Multisig / Tx ID / Status / Signed by) instead of the old bordered
-  box; the following EOA confirm/revoke/execute card collapses the inner
+- Classic `msig info` / `approve` show the inner call in a rounded box
+  (Multisig / Tx ID / Status / Signed by); the following EOA
+  confirm/revoke/execute card is a quiet heading that collapses the inner
   call. Classic `msig summary` lists only the pending queue (id, destination,
   value, sigs, status) rather than every historical tx id. Confirmation and
   execution log scans use the same `Spinner` as other waits instead of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,8 +109,10 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 
 ### Batch approvals (`jarvis msig bapprove`)
 
-- Plan printed before the first prompt; each item runs under a `[i/n]`
-  banner with everything indented; one-line result with a running tally.
+- Plan printed before the first prompt; each item is a `===== [i/n] … =====`
+  section so it matches the weight of the signing cards inside it. Those cards,
+  their Y/n prompts, and the one-line result all repeat `[i/n]`, so a 50-item
+  transcript stays scannable after the banner has scrolled off.
 - After a failed item jarvis asks whether to continue; declining records the
   rest as skipped.
 - Unified summary table for Safe and Classic items, totals line, and exit

--- a/README.md
+++ b/README.md
@@ -268,9 +268,11 @@ Ledger to be plugged in and unlocked.
 ### Batch runs
 
 `jarvis msig bapprove` shows the plan before asking anything, then works
-through the list with one indented block per item. Every signing card, Y/n
-prompt and result line repeats `[i/n]`, so you can search or scroll a
-50-item transcript and still know which transaction you are looking at:
+through the list with one indented block per item. The inner Classic/Safe
+operation is a rounded box so it stands apart from the EOA confirm that
+follows. Every banner, box title, Y/n prompt and result line repeats
+`[i/n]`, so you can search or scroll a 50-item transcript and still know
+which transaction you are looking at:
 
 ```
 =============== Batch approve: 3 transaction(s) ===============
@@ -279,8 +281,9 @@ prompt and result line repeats `[i/n]`, so you can search or scroll a
 3. Classic  mainnet:0xinit…
 
 =============== [1/3] Safe  eth:0xSafe…:0xhash… ===============
-  =============== [1/3] Safe approval ===============
-  ... signing card ...
+  ╭─ [1/3] Safe approval ──────────────────────────────╮
+  │ ... decoded call, warnings ...                     │
+  ╰────────────────────────────────────────────────────╯
   [1/3] Sign approval (off-chain, no gas)? [Y/n]
 ✓ [1/3] approved  safeTxHash 0x…   (1 ok · 2 left)
 
@@ -290,9 +293,12 @@ prompt and result line repeats `[i/n]`, so you can search or scroll a
 Continue with the remaining 1 transaction(s)? [Y/n]
 
 =============== [3/3] Classic  mainnet:0xinit… ===============
-  =============== [3/3] Classic multisig transaction ===============
-  ...
-  =============== [3/3] EOA transaction ===============
+  ╭─ [3/3] Classic multisig transaction ───────────────╮
+  │ Send  1.5 ETH  →  Alice                            │
+  │ ...                                                │
+  ╰────────────────────────────────────────────────────╯
+  [3/3] EOA transaction
+  Call  confirmTransaction  →  Treasury   (Classic transaction shown above)
   [3/3] Sign and broadcast (≈ 0.0017 ETH)? [Y/n]
 ✓ [3/3] approved  confirm tx 0x…   (2 ok · 1 failed)
 

--- a/README.md
+++ b/README.md
@@ -268,8 +268,9 @@ Ledger to be plugged in and unlocked.
 ### Batch runs
 
 `jarvis msig bapprove` shows the plan before asking anything, then works
-through the list with one indented block per item and a one-line result
-that stays in the transcript:
+through the list with one indented block per item. Every signing card, Y/n
+prompt and result line repeats `[i/n]`, so you can search or scroll a
+50-item transcript and still know which transaction you are looking at:
 
 ```
 =============== Batch approve: 3 transaction(s) ===============
@@ -277,18 +278,23 @@ that stays in the transcript:
 2. Safe     bsc:0xSafe…:0xhash…
 3. Classic  mainnet:0xinit…
 
-[1/3] Safe  eth:0xSafe…:0xhash…
-  ... signing card, prompt, spinner ...
-✓ approved  safeTxHash 0x…   (1 ok · 2 left)
+=============== [1/3] Safe  eth:0xSafe…:0xhash… ===============
+  =============== [1/3] Safe approval ===============
+  ... signing card ...
+  [1/3] Sign approval (off-chain, no gas)? [Y/n]
+✓ [1/3] approved  safeTxHash 0x…   (1 ok · 2 left)
 
-[2/3] Safe  bsc:0xSafe…:0xhash…
+=============== [2/3] Safe  bsc:0xSafe…:0xhash… ===============
   ...
-✗ failed  unlock wallet: ledger not connected   (1 ok · 1 failed · 1 left)
+✗ [2/3] failed  unlock wallet: ledger not connected   (1 ok · 1 failed · 1 left)
 Continue with the remaining 1 transaction(s)? [Y/n]
 
-[3/3] Classic  mainnet:0xinit…
+=============== [3/3] Classic  mainnet:0xinit… ===============
+  =============== [3/3] Classic multisig transaction ===============
   ...
-✓ approved  confirm tx 0x…   (2 ok · 1 failed)
+  =============== [3/3] EOA transaction ===============
+  [3/3] Sign and broadcast (≈ 0.0017 ETH)? [Y/n]
+✓ [3/3] approved  confirm tx 0x…   (2 ok · 1 failed)
 
 ===================== Batch summary =====================
 ┌───┬─────────┬─────────┬──────────┬──────────┬───────────────────────┐

--- a/cmd/batch_ui.go
+++ b/cmd/batch_ui.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	cmdutil "github.com/tranvictor/jarvis/cmd/util"
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/ui"
 )
@@ -67,14 +68,11 @@ func printBatchPlan(title string, items []string) {
 	}
 }
 
-// printBatchBanner opens one item: "[2/5] Safe  <ref>".
+// printBatchBanner opens one item as a Section so it matches the weight
+// of the signing cards inside it, and stamps [i/n] on those cards.
 func printBatchBanner(i, total int, kind, label string) {
-	appUI.Info("")
-	appUI.Info("%s %s  %s",
-		appUI.Style(ui.StyledText{Text: fmt.Sprintf("[%d/%d]", i, total), Severity: ui.SeverityCritical}),
-		appUI.Style(ui.StyledText{Text: kind, Severity: ui.SeverityCritical}),
-		label,
-	)
+	cmdutil.SetBatchItem(i, total)
+	appUI.Section(fmt.Sprintf("[%d/%d] %s  %s", i, total, kind, label))
 }
 
 // printBatchItemResult closes one item with a single line whose colour
@@ -83,11 +81,11 @@ func printBatchItemResult(status, detail string, tally batchTally) {
 	var st ui.StyledText
 	switch status {
 	case "approved", "executed", "broadcasted":
-		st = ui.StyledText{Text: "✓ " + status, Severity: ui.SeveritySuccess}
+		st = ui.StyledText{Text: "✓ " + cmdutil.AnnotateBatch(status), Severity: ui.SeveritySuccess}
 	case "skipped":
-		st = ui.StyledText{Text: "⊘ skipped", Severity: ui.SeverityWarn}
+		st = ui.StyledText{Text: "⊘ " + cmdutil.AnnotateBatch("skipped"), Severity: ui.SeverityWarn}
 	default:
-		st = ui.StyledText{Text: "✗ failed", Severity: ui.SeverityError}
+		st = ui.StyledText{Text: "✗ " + cmdutil.AnnotateBatch("failed"), Severity: ui.SeverityError}
 	}
 	line := appUI.Style(st)
 	if detail != "" {
@@ -120,6 +118,7 @@ func resultCell(status string) ui.TableCell {
 
 // printBatchSummaryTable prints the closing table and the totals line.
 func printBatchSummaryTable(rows [][]ui.TableCell, tally batchTally) {
+	cmdutil.ClearBatchItem()
 	appUI.Section("Batch summary")
 	appUI.PrintTable(&ui.Table{
 		Headers: []string{"#", "Kind", "Network", "Target", "Result", "Detail"},

--- a/cmd/batch_ui_test.go
+++ b/cmd/batch_ui_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
+	cmdutil "github.com/tranvictor/jarvis/cmd/util"
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/ui"
 )
@@ -38,6 +40,7 @@ func TestBatchTallyString(t *testing.T) {
 func TestBatchPlanBannerAndResultLines(t *testing.T) {
 	rec := ui.NewRecordingUI()
 	swapAppUI(t, rec)
+	t.Cleanup(cmdutil.ClearBatchItem)
 
 	printBatchPlan("Batch approve", []string{"Safe     eth:0xsafe:0xhash", "Classic  mainnet:0xinit"})
 	tally := batchTally{total: 2}
@@ -45,6 +48,7 @@ func TestBatchPlanBannerAndResultLines(t *testing.T) {
 	withIndentedUI(func() { appUI.Info("inner") })
 	tally.add("approved")
 	printBatchItemResult("approved", "safeTxHash 0xhash", tally)
+	printBatchBanner(2, 2, "Classic", "mainnet:0xinit")
 	tally.add("failed")
 	printBatchItemResult("failed", "sign safeTxHash: rejected", tally)
 
@@ -56,14 +60,88 @@ func TestBatchPlanBannerAndResultLines(t *testing.T) {
 		"Section: Batch approve: 2 transaction(s)",
 		"Info: 1. Safe     eth:0xsafe:0xhash",
 		"Info: 2. Classic  mainnet:0xinit",
-		"Info: ",
-		"Info: [1/2] Safe  eth:0xsafe:0xhash",
+		"Section: [1/2] Safe  eth:0xsafe:0xhash",
 		"Info: inner",
-		"Info: ✓ approved  safeTxHash 0xhash   (1 ok · 1 left)",
-		"Info: ✗ failed  sign safeTxHash: rejected   (1 ok · 1 failed)",
+		"Info: ✓ [1/2] approved  safeTxHash 0xhash   (1 ok · 1 left)",
+		"Section: [2/2] Classic  mainnet:0xinit",
+		"Info: ✗ [2/2] failed  sign safeTxHash: rejected   (1 ok · 1 failed)",
 	}
 	if strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("got:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestBatchBannerStampsSigningCardsAndPrompts(t *testing.T) {
+	rec := ui.NewRecordingUI("y")
+	swapAppUI(t, rec)
+	t.Cleanup(cmdutil.ClearBatchItem)
+
+	tally := batchTally{total: 87, ok: 11}
+	printBatchBanner(12, 87, "Classic", "mainnet:0xinit")
+	withIndentedUI(func() {
+		cmdutil.ShowSigningCard(appUI, &cmdutil.SigningCard{Kind: "Classic multisig transaction"})
+		if !cmdutil.ConfirmSigningCard(appUI, &cmdutil.SigningCard{
+			Kind:   "EOA transaction",
+			Prompt: "Sign and broadcast (≈ 0.0017 ETH)?",
+		}) {
+			t.Fatal("scripted y should confirm")
+		}
+	})
+	tally.add("approved")
+	printBatchItemResult("approved", "confirm tx 0xabc", tally)
+
+	joined := ""
+	for _, e := range rec.Entries() {
+		joined += e.Method + ": " + e.Value + "\n"
+	}
+	for _, w := range []string{
+		"Section: [12/87] Classic  mainnet:0xinit",
+		"Section: [12/87] Classic multisig transaction",
+		"Section: [12/87] EOA transaction",
+		"Confirm: [12/87] Sign and broadcast (≈ 0.0017 ETH)?",
+		"Info: ✓ [12/87] approved  confirm tx 0xabc   (12 ok · 75 left)",
+	} {
+		if !strings.Contains(joined, w) {
+			t.Fatalf("missing %q in:\n%s", w, joined)
+		}
+	}
+}
+
+func TestBatchScanRendersIndexedSections(t *testing.T) {
+	var buf bytes.Buffer
+	term := ui.NewTerminalUIWithWriter(&buf, false)
+	prev := appUI
+	appUI = term
+	t.Cleanup(func() { appUI = prev })
+	t.Cleanup(cmdutil.ClearBatchItem)
+
+	printBatchPlan("Batch approve", []string{"Safe     eth:0xSafe:0xhash", "Classic  mainnet:0xinit"})
+	printBatchBanner(1, 2, "Safe", "eth:0xSafe:0xhash")
+	withIndentedUI(func() {
+		cmdutil.ShowSigningCard(appUI, &cmdutil.SigningCard{Kind: "Safe approval"})
+	})
+	printBatchItemResult("approved", "safeTxHash 0xhash", batchTally{total: 2, ok: 1})
+	printBatchBanner(2, 2, "Classic", "mainnet:0xinit")
+	withIndentedUI(func() {
+		cmdutil.ShowSigningCard(appUI, &cmdutil.SigningCard{Kind: "Classic multisig transaction"})
+		cmdutil.ShowSigningCard(appUI, &cmdutil.SigningCard{Kind: "EOA transaction"})
+	})
+	printBatchItemResult("approved", "confirm tx 0xabc", batchTally{total: 2, ok: 2})
+
+	out := buf.String()
+	for _, w := range []string{
+		"[1/2] Safe  eth:0xSafe:0xhash",
+		"[1/2] Safe approval",
+		"✓ [1/2] approved",
+		"[2/2] Classic  mainnet:0xinit",
+		"[2/2] Classic multisig transaction",
+		"[2/2] EOA transaction",
+		"✓ [2/2] approved",
+		"=====",
+	} {
+		if !strings.Contains(out, w) {
+			t.Fatalf("missing %q in:\n%s", w, out)
+		}
 	}
 }
 
@@ -154,6 +232,7 @@ func TestApproveSafeRefsConfirmOnceReviewsThenSigns(t *testing.T) {
 	signed := fakeSafeRefs(t)
 	rec := ui.NewRecordingUI("y", "")
 	swapAppUI(t, rec)
+	t.Cleanup(cmdutil.ClearBatchItem)
 
 	tally := batchTally{total: 4}
 	results, item, aborted := approveSafeRefsConfirmOnce(safeRefInputs("a", "bad", "reject", "d"), &tally)
@@ -184,7 +263,7 @@ func TestApproveSafeRefsConfirmOnceReviewsThenSigns(t *testing.T) {
 	if confirmAt < 0 {
 		t.Fatalf("single confirm missing:\n%s", joined)
 	}
-	for _, s := range []string{"card for a", "card for reject", "card for d", "fetch pending tx: 404", "✗ failed  fetch pending tx: 404"} {
+	for _, s := range []string{"card for a", "card for reject", "card for d", "fetch pending tx: 404", "✗ [2/4] failed  fetch pending tx: 404"} {
 		at := strings.Index(joined, s)
 		if at < 0 || at > confirmAt {
 			t.Fatalf("%q should appear before the confirm:\n%s", s, joined)
@@ -206,6 +285,7 @@ func TestApproveSafeRefsConfirmOnceDeclineSkipsAll(t *testing.T) {
 	signed := fakeSafeRefs(t)
 	rec := ui.NewRecordingUI("n")
 	swapAppUI(t, rec)
+	t.Cleanup(cmdutil.ClearBatchItem)
 
 	tally := batchTally{total: 2}
 	results, _, aborted := approveSafeRefsConfirmOnce(safeRefInputs("a", "b"), &tally)
@@ -233,6 +313,7 @@ func TestApproveSafeRefsConfirmOnceYesSkipsPrompt(t *testing.T) {
 	signed := fakeSafeRefs(t)
 	rec := ui.NewRecordingUI()
 	swapAppUI(t, rec)
+	t.Cleanup(cmdutil.ClearBatchItem)
 
 	tally := batchTally{total: 1}
 	approveSafeRefsConfirmOnce(safeRefInputs("a"), &tally)

--- a/cmd/batch_ui_test.go
+++ b/cmd/batch_ui_test.go
@@ -81,8 +81,10 @@ func TestBatchBannerStampsSigningCardsAndPrompts(t *testing.T) {
 	withIndentedUI(func() {
 		cmdutil.ShowSigningCard(appUI, &cmdutil.SigningCard{Kind: "Classic multisig transaction"})
 		if !cmdutil.ConfirmSigningCard(appUI, &cmdutil.SigningCard{
-			Kind:   "EOA transaction",
-			Prompt: "Sign and broadcast (≈ 0.0017 ETH)?",
+			Kind:         "EOA transaction",
+			CollapseCall: true,
+			CollapseNote: "(Classic transaction shown above)",
+			Prompt:       "Sign and broadcast (≈ 0.0017 ETH)?",
 		}) {
 			t.Fatal("scripted y should confirm")
 		}
@@ -96,8 +98,8 @@ func TestBatchBannerStampsSigningCardsAndPrompts(t *testing.T) {
 	}
 	for _, w := range []string{
 		"Section: [12/87] Classic  mainnet:0xinit",
-		"Section: [12/87] Classic multisig transaction",
-		"Section: [12/87] EOA transaction",
+		"BoxedSection: [12/87] Classic multisig transaction",
+		"Subsection: [12/87] EOA transaction",
 		"Confirm: [12/87] Sign and broadcast (≈ 0.0017 ETH)?",
 		"Info: ✓ [12/87] approved  confirm tx 0xabc   (12 ok · 75 left)",
 	} {
@@ -124,7 +126,11 @@ func TestBatchScanRendersIndexedSections(t *testing.T) {
 	printBatchBanner(2, 2, "Classic", "mainnet:0xinit")
 	withIndentedUI(func() {
 		cmdutil.ShowSigningCard(appUI, &cmdutil.SigningCard{Kind: "Classic multisig transaction"})
-		cmdutil.ShowSigningCard(appUI, &cmdutil.SigningCard{Kind: "EOA transaction"})
+		cmdutil.ShowSigningCard(appUI, &cmdutil.SigningCard{
+			Kind:         "EOA transaction",
+			CollapseCall: true,
+			CollapseNote: "(Classic transaction shown above)",
+		})
 	})
 	printBatchItemResult("approved", "confirm tx 0xabc", batchTally{total: 2, ok: 2})
 
@@ -132,6 +138,7 @@ func TestBatchScanRendersIndexedSections(t *testing.T) {
 	for _, w := range []string{
 		"[1/2] Safe  eth:0xSafe:0xhash",
 		"[1/2] Safe approval",
+		"╭─",
 		"✓ [1/2] approved",
 		"[2/2] Classic  mainnet:0xinit",
 		"[2/2] Classic multisig transaction",
@@ -142,6 +149,21 @@ func TestBatchScanRendersIndexedSections(t *testing.T) {
 		if !strings.Contains(out, w) {
 			t.Fatalf("missing %q in:\n%s", w, out)
 		}
+	}
+	if strings.Count(out, "╭─") < 2 {
+		t.Fatalf("each multisig op should be a rounded box:\n%s", out)
+	}
+	// The EOA wrapper is a heading, not a second equals-rule competing with the item banner.
+	eoaIdx := strings.Index(out, "[2/2] EOA transaction")
+	if eoaIdx < 0 {
+		t.Fatal("EOA wrapper title missing")
+	}
+	window := out[eoaIdx:]
+	if i := strings.Index(window, "\n"); i > 0 {
+		window = window[:i]
+	}
+	if strings.Contains(window, "=====") || strings.Contains(window, "╭") {
+		t.Fatalf("EOA wrapper must stay a quiet heading, got %q", window)
 	}
 }
 

--- a/cmd/safe_batch.go
+++ b/cmd/safe_batch.go
@@ -391,7 +391,7 @@ func signSafeRef(p *preparedSafeRef, preConfirmed bool) approveSafeRefResult {
 		// and approved+executed outcomes in the summary here because
 		// runSafeApproveOnChain doesn't report that back — the user
 		// can still see what happened in the stream above.
-		if !config.YesToAllPrompt && !appUI.Confirm("Broadcast approveHash on-chain?", true) {
+		if !config.YesToAllPrompt && !appUI.Confirm(cmdutil.AnnotateBatch("Broadcast approveHash on-chain?"), true) {
 			res.status = "skipped"
 			res.reason = "user aborted"
 			return res
@@ -402,7 +402,7 @@ func signSafeRef(p *preparedSafeRef, preConfirmed bool) approveSafeRefResult {
 		return res
 	}
 
-	if !preConfirmed && !config.YesToAllPrompt && !appUI.Confirm("Sign approval (off-chain, no gas)?", true) {
+	if !preConfirmed && !config.YesToAllPrompt && !appUI.Confirm(cmdutil.AnnotateBatch("Sign approval (off-chain, no gas)?"), true) {
 		res.status = "skipped"
 		res.reason = "user aborted"
 		return res
@@ -443,7 +443,7 @@ func signSafeRef(p *preparedSafeRef, preConfirmed bool) approveSafeRefResult {
 		return res
 	}
 
-	if !config.YesToAllPrompt && !appUI.Confirm("Threshold met — broadcast execTransaction now?", true) {
+	if !config.YesToAllPrompt && !appUI.Confirm(cmdutil.AnnotateBatch("Threshold met — broadcast execTransaction now?"), true) {
 		appUI.Info("Skipping execution. Run later with `jarvis msig execute ...`.")
 		return res
 	}

--- a/cmd/util/batch_mark.go
+++ b/cmd/util/batch_mark.go
@@ -1,0 +1,36 @@
+package util
+
+import "fmt"
+
+// batchItemMark is "[i/n]" while `jarvis msig bapprove` is processing one
+// item. Empty outside a batch so a single approve/sign is unchanged.
+var batchItemMark string
+
+// SetBatchItem stamps every signing card, prompt and result line with
+// [i/n] until the next SetBatchItem or ClearBatchItem. That way a
+// 50-item transcript stays scannable: every equals-rule and Y/n prompt
+// names the item you are looking at, not just the banner that scrolled
+// off the top.
+func SetBatchItem(i, total int) {
+	if i < 1 || total < 1 {
+		batchItemMark = ""
+		return
+	}
+	batchItemMark = fmt.Sprintf("[%d/%d]", i, total)
+}
+
+// ClearBatchItem drops the current [i/n] stamp. Call when the batch ends
+// so a later signing card in the same process is not mislabelled.
+func ClearBatchItem() { batchItemMark = "" }
+
+// BatchItemMark returns the current "[i/n]" stamp, or empty outside a batch.
+func BatchItemMark() string { return batchItemMark }
+
+// AnnotateBatch prefixes s with the current [i/n] mark. No-op outside a
+// batch or when s is empty.
+func AnnotateBatch(s string) string {
+	if batchItemMark == "" || s == "" {
+		return s
+	}
+	return batchItemMark + " " + s
+}

--- a/cmd/util/batch_mark_test.go
+++ b/cmd/util/batch_mark_test.go
@@ -1,0 +1,41 @@
+package util
+
+import "testing"
+
+func TestAnnotateBatch(t *testing.T) {
+	t.Cleanup(ClearBatchItem)
+
+	if got := AnnotateBatch("EOA transaction"); got != "EOA transaction" {
+		t.Fatalf("outside a batch: %q", got)
+	}
+	if BatchItemMark() != "" {
+		t.Fatalf("mark should start empty, got %q", BatchItemMark())
+	}
+
+	SetBatchItem(12, 87)
+	if BatchItemMark() != "[12/87]" {
+		t.Fatalf("mark = %q", BatchItemMark())
+	}
+	if got := AnnotateBatch("EOA transaction"); got != "[12/87] EOA transaction" {
+		t.Fatalf("kind: %q", got)
+	}
+	if got := AnnotateBatch("Sign and broadcast (≈ 0.0017 ETH)?"); got != "[12/87] Sign and broadcast (≈ 0.0017 ETH)?" {
+		t.Fatalf("prompt: %q", got)
+	}
+	if got := AnnotateBatch(""); got != "" {
+		t.Fatalf("empty stays empty: %q", got)
+	}
+
+	SetBatchItem(0, 10)
+	if BatchItemMark() != "" {
+		t.Fatalf("invalid index must clear, got %q", BatchItemMark())
+	}
+	SetBatchItem(1, 1)
+	if BatchItemMark() != "[1/1]" {
+		t.Fatalf("single item: %q", BatchItemMark())
+	}
+	ClearBatchItem()
+	if AnnotateBatch("approved") != "approved" {
+		t.Fatalf("cleared mark still annotates")
+	}
+}

--- a/cmd/util/signing_card.go
+++ b/cmd/util/signing_card.go
@@ -90,12 +90,49 @@ type ClassicCardFields struct {
 	Signatures    []ui.StyledText
 }
 
+// isMultisigOp is true for the inner Classic/Safe transaction the operator
+// is reviewing. Those cards are boxed so they stand apart from the EOA
+// confirm/execute wrapper that often follows.
+func isMultisigOp(c *SigningCard) bool {
+	if c == nil {
+		return false
+	}
+	if c.Classic != nil {
+		return true
+	}
+	switch c.Kind {
+	case "Classic multisig transaction", "Safe approval", "Safe proposal", "Safe transaction":
+		return true
+	default:
+		return false
+	}
+}
+
 // ShowSigningCard prints the card. Order is chosen so that what the reader
 // must verify sits directly above the prompt: the call first, then the
 // summary block, then the warnings.
+//
+// Multisig operations (Classic inner tx, Safe approval/proposal) render
+// inside a rounded box so they are the thing the eye hits when a new
+// batch item appears. The following EOA confirm/execute card stays a
+// plain heading — same [i/n] stamp, no second equals-rule or box.
 func ShowSigningCard(u ui.UI, c *SigningCard) {
-	u.Section(AnnotateBatch(c.Kind))
+	title := AnnotateBatch(c.Kind)
+	switch {
+	case isMultisigOp(c):
+		u.BoxedSection(ui.SeverityCritical, title, func(inner ui.UI) {
+			renderSigningCardBody(inner, c)
+		})
+	case c.CollapseCall:
+		u.Subsection(title)
+		renderSigningCardBody(u, c)
+	default:
+		u.Section(title)
+		renderSigningCardBody(u, c)
+	}
+}
 
+func renderSigningCardBody(u ui.UI, c *SigningCard) {
 	if c.ClearSign != nil {
 		c.ClearSign(u)
 	}

--- a/cmd/util/signing_card.go
+++ b/cmd/util/signing_card.go
@@ -94,7 +94,7 @@ type ClassicCardFields struct {
 // must verify sits directly above the prompt: the call first, then the
 // summary block, then the warnings.
 func ShowSigningCard(u ui.UI, c *SigningCard) {
-	u.Section(c.Kind)
+	u.Section(AnnotateBatch(c.Kind))
 
 	if c.ClearSign != nil {
 		c.ClearSign(u)
@@ -237,7 +237,7 @@ func ConfirmSigningCard(u ui.UI, c *SigningCard) bool {
 	if config.YesToAllPrompt {
 		return true
 	}
-	return u.Confirm(c.Prompt, true)
+	return u.Confirm(AnnotateBatch(c.Prompt), true)
 }
 
 // printHexBlock writes hex data wrapped to 32-byte words with the byte count

--- a/cmd/util/signing_card_test.go
+++ b/cmd/util/signing_card_test.go
@@ -447,3 +447,32 @@ func TestSigningCardShowsWalletKind(t *testing.T) {
 		t.Fatalf("wallet kind missing from signer line: %v", rec.Entries())
 	}
 }
+
+func TestShowSigningCardBatchMark(t *testing.T) {
+	t.Cleanup(ClearBatchItem)
+	SetBatchItem(12, 87)
+	rec := ui.NewRecordingUI("y")
+	card := &SigningCard{
+		Kind:   "EOA transaction",
+		Prompt: "Sign and broadcast (≈ 0.0017 ETH)?",
+	}
+	if !ConfirmSigningCard(rec, card) {
+		t.Fatal("scripted y should confirm")
+	}
+	if !rec.HasMessage("[12/87] EOA transaction") {
+		t.Fatalf("section must carry [i/n]: %v", rec.Entries())
+	}
+	if !rec.HasMessage("[12/87] Sign and broadcast (≈ 0.0017 ETH)?") {
+		t.Fatalf("prompt must carry [i/n]: %v", rec.Entries())
+	}
+
+	ClearBatchItem()
+	rec = ui.NewRecordingUI()
+	ShowSigningCard(rec, &SigningCard{Kind: "EOA transaction"})
+	if rec.HasMessage("[12/87] EOA transaction") {
+		t.Fatalf("cleared mark must not leak: %v", rec.Entries())
+	}
+	if !rec.HasMessage("EOA transaction") {
+		t.Fatalf("single-tx card title lost: %v", rec.Entries())
+	}
+}

--- a/cmd/util/signing_card_test.go
+++ b/cmd/util/signing_card_test.go
@@ -21,6 +21,15 @@ func cardAddr(hex, desc string) jarviscommon.Address {
 	return jarviscommon.Address{Address: hex, Desc: desc}
 }
 
+func hasEntry(rec *ui.RecordingUI, method, value string) bool {
+	for _, e := range rec.Entries() {
+		if e.Method == method && e.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
 func addrParam(name, hex, desc string) jarviscommon.ParamResult {
 	a := cardAddr(hex, desc)
 	return jarviscommon.ParamResult{Name: name, Type: "address", Values: []jarviscommon.Value{
@@ -214,6 +223,12 @@ func TestShowSigningCardSafeFieldsAndCollapse(t *testing.T) {
 		Warnings: SigningWarnings(WarningInput{To: cardAddr(cardRouter, "MultiSendCallOnly"), DelegateCall: true, MultiSend: true}),
 	}
 	ShowSigningCard(rec, card)
+	if !hasEntry(rec, "BoxedSection", "Safe approval") {
+		t.Fatalf("Safe approval must be boxed: %v", rec.Entries())
+	}
+	if hasEntry(rec, "Section", "Safe approval") {
+		t.Fatalf("Safe approval must not also use a Section rule: %v", rec.Entries())
+	}
 	for _, w := range []string{
 		"Safe calls: " + cardRouter + " (MultiSendCallOnly)",
 		"Operation: DELEGATECALL (1)",
@@ -236,6 +251,12 @@ func TestShowSigningCardSafeFieldsAndCollapse(t *testing.T) {
 		Safe:         &SafeCardFields{Executes: "0xabc"},
 	}
 	ShowSigningCard(rec, exec)
+	if hasEntry(rec, "Section", "Safe execution") || hasEntry(rec, "BoxedSection", "Safe execution") {
+		t.Fatalf("Safe execution wrapper must be a quiet heading, not a section or box: %v", rec.Entries())
+	}
+	if !hasEntry(rec, "Subsection", "Safe execution") {
+		t.Fatalf("Safe execution wrapper heading missing: %v", rec.Entries())
+	}
 	if !rec.HasMessage("Call  execTransaction  →  " + cardRouter + " (Safe)   (Safe transaction shown above)") {
 		t.Fatalf("collapsed call header missing: %v", rec.Entries())
 	}
@@ -318,6 +339,12 @@ func TestShowSigningCardClassicFields(t *testing.T) {
 			Signatures:    []ui.StyledText{util.StyledAddress(cardAddr(cardMe, "me"))},
 		},
 	})
+	if !hasEntry(rec, "BoxedSection", "Classic multisig transaction") {
+		t.Fatalf("Classic inner tx must be boxed: %v", rec.Entries())
+	}
+	if hasEntry(rec, "Section", "Classic multisig transaction") {
+		t.Fatalf("Classic inner tx must not use a Section rule: %v", rec.Entries())
+	}
 	for _, w := range []string{
 		"Classic multisig transaction",
 		"Send  1000  →  " + cardMe + " (me)",
@@ -351,6 +378,12 @@ func TestShowSigningCardClassicCollapseNote(t *testing.T) {
 	})
 	if !rec.HasMessage("Call  confirmTransaction  →  " + cardMe + " (Treasury)   (Classic transaction shown above)") {
 		t.Fatalf("collapsed Classic note missing: %v", rec.Entries())
+	}
+	if hasEntry(rec, "Section", "EOA transaction") || hasEntry(rec, "BoxedSection", "EOA transaction") {
+		t.Fatalf("EOA confirm wrapper must be a quiet heading: %v", rec.Entries())
+	}
+	if !hasEntry(rec, "Subsection", "EOA transaction") {
+		t.Fatalf("EOA confirm wrapper heading missing: %v", rec.Entries())
 	}
 	if rec.HasMessage("transactionId  42") {
 		t.Fatalf("collapsed call must not print params: %v", rec.Entries())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A 50–100 item `jarvis msig bapprove` run was hard to follow: every signing card used the same section title, and the inner Classic/Safe operation looked identical to the EOA confirm that follows it.

**Landmarks**
- Each item opens as a Section: `===== [12/87] Classic  mainnet:0x… =====`
- The inner Classic/Safe operation is a rounded box, so it is the thing the eye hits when the next tx appears:
  ```
  ╭─ [12/87] Classic multisig transaction ─╮
  │ Send  1.5 ETH  →  Alice                │
  ╰────────────────────────────────────────╯
  ```
- The following EOA confirm/execute is a quiet heading (`[12/87] EOA transaction`), not a second equals-rule or box.
- Y/n prompts and the result line also repeat `[12/87]`. Search the transcript for that stamp to jump between banner, box, prompt, and result.

Single-tx `msig approve` / `send` is unchanged except that Classic/Safe inner cards are boxed there too.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

