### PR TITLE
gas: stop broadcasting type-2 txs with a ~0 Ethereum tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 - One signing card for EOA transactions, Safe proposals/approvals/executions
   and WalletConnect requests: decoded call first, then Sign with / Send to /
   Gas / nonce directly above the prompt.
+- Type-2 gas tip: `eth_maxPriorityFeePerGas` is often ~0 on Ethereum even
+  when max fee looks high. Jarvis now takes the best node oracle, the tip
+  implied by `eth_gasPrice − baseFee`, and a 1 gwei floor (0.01 gwei on
+  cheap L2s), so a high max fee is actually offered to miners. `-s` still
+  overrides.
 - Classic inner txs and Safe approvals/proposals render in a rounded box;
   the EOA confirm/execute that follows is a quiet heading so the two are
   not the same visual weight.

--- a/cmd/common_flags.go
+++ b/cmd/common_flags.go
@@ -23,7 +23,7 @@ func AddCommonFlagsToTransactionalCmds(c *cobra.Command) {
 	c.PersistentFlags().
 		Float64VarP(&config.GasPrice, "gasprice", "p", 0, "Gas price in gwei. 0 = suggested by the network's explorer or nodes. The tx uses gasprice + extraprice")
 	c.PersistentFlags().
-		Float64VarP(&config.TipGas, "tipgas", "s", 0, "tip in gwei, will be use in dynamic fee tx, default value get from node.")
+		Float64VarP(&config.TipGas, "tipgas", "s", 0, "tip in gwei for type-2 txs. 0 = node oracle, raised to the implied market tip and a 1 gwei floor on Ethereum so the tx is not stuck with tip 0")
 	c.PersistentFlags().
 		Float64VarP(&config.ExtraGasPrice, "extraprice", "P", 0, "Extra gas price in gwei. The gas price to be used in the tx is gas price + extra gas price")
 	c.PersistentFlags().

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -924,6 +924,29 @@ func approveClassicRef(cm *walletarmy.WalletManager, a *abi.ABI, r *batchResult)
 		appUI.Warn("Legacy tx — ignoring tip gas parameter.")
 	}
 
+	gasPrice := config.GasPrice
+	if gasPrice == 0 {
+		gasPrice, err = cm.Reader(network).RecommendedGasPrice()
+		if err != nil {
+			appUI.Error("Couldn't get recommended gas price: %s. Skip.", err)
+			r.status, r.reason = "failed", fmt.Sprintf("gas price: %s", err)
+			return
+		}
+	}
+	tipCap := 0.0
+	if txType == types.DynamicFeeTxType {
+		if config.TipGas > 0 {
+			tipCap = config.TipGas
+		} else {
+			tipCap, err = cm.Reader(network).GetSuggestedGasTipCap()
+			if err != nil {
+				appUI.Error("Couldn't estimate recommended gas tip: %s. Skip.", err)
+				r.status, r.reason = "failed", fmt.Sprintf("gas tip: %s", err)
+				return
+			}
+		}
+	}
+
 	var confirmHash string
 	minedTx, err := cm.EnsureTxWithHooks(
 		10,
@@ -934,10 +957,10 @@ func approveClassicRef(cm *walletarmy.WalletManager, a *abi.ABI, r *batchResult)
 		nil,
 		0,
 		2000000,
-		0,
-		0,
-		0,
-		0,
+		gasPrice,
+		config.ExtraGasPrice,
+		tipCap,
+		config.ExtraTipGas,
 		data,
 		network,
 		func(tx *types.Transaction, buildError error) error {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -343,12 +343,26 @@ func sendFromMsig(reader utilreader.Reader, analyzer util.TxAnalyzer, resolver c
 		return
 	}
 
+	tipGas := 0.0
+	if txType == types.LegacyTxType && config.TipGas > 0 {
+		appUI.Warn("Legacy tx: ignoring --tipgas (EIP-1559 tips apply only to type-2 txs).")
+	} else if txType == types.DynamicFeeTxType {
+		tipGas = config.TipGas
+		if tipGas == 0 {
+			tipGas, err = reader.GetSuggestedGasTipCap()
+			if err != nil {
+				appUI.Error("Couldn't estimate recommended gas price: %s", err)
+				return
+			}
+		}
+	}
+
 	sp := sendTxParams{
 		txType:   txType,
 		nonce:    nonce,
 		gasLimit: gasLimit + config.ExtraGasLimit,
 		gasPrice: gasPrice + config.ExtraGasPrice,
-		tipGas:   config.TipGas + config.ExtraTipGas,
+		tipGas:   tipGas + config.ExtraTipGas,
 	}
 	handleMsigSend(sp, fromAcc, msigContractAddr, txdata, reader, analyzer, bc)
 }

--- a/util/reader/gas_tip.go
+++ b/util/reader/gas_tip.go
@@ -1,0 +1,62 @@
+package reader
+
+// EIP-1559 pricing bumps applied after the node oracles.
+const (
+	// gasPriceHeadroom is multiplied onto eth_gasPrice to form maxFeePerGas
+	// so the next blocks can raise base fee without the tx becoming
+	// underpriced.
+	gasPriceHeadroom = 1.5
+
+	// When the oracles collapse to ~0, still offer miners something.
+	// L1-like chains (base fee ≥ 1 gwei) use 1 gwei — the usual wallet
+	// default. Cheap L2s use 0.01 gwei so a quiet Arbitrum tx is not
+	// charged a full Ethereum tip.
+	l1TipFloorGwei      = 1.0
+	l2TipFloorGwei      = 0.01
+	l1BaseFeeCutoffGwei = 1.0
+)
+
+// EffectiveGasTipGwei picks the type-2 priority fee (gwei).
+//
+// nodeTip is the node's eth_maxPriorityFeePerGas (already * tipBump).
+// maxFee is Jarvis's maxFeePerGas (eth_gasPrice * gasPriceHeadroom).
+// baseFee is the latest block base fee.
+//
+// eth_maxPriorityFeePerGas is often ~0 on Ethereum even when maxFee looks
+// generous: miners are paid min(maxFee − baseFee, tip), so a 0 tip sits
+// or is dropped. We take the better of the node tip, the tip implied by
+// eth_gasPrice − baseFee, and a small floor, then clamp to maxFee.
+func EffectiveGasTipGwei(nodeTip, maxFee, baseFee float64) float64 {
+	if nodeTip < 0 {
+		nodeTip = 0
+	}
+	if maxFee < 0 {
+		maxFee = 0
+	}
+	if baseFee < 0 {
+		baseFee = 0
+	}
+
+	gasPrice := maxFee / gasPriceHeadroom
+	marketTip := gasPrice - baseFee
+	if marketTip < 0 {
+		marketTip = 0
+	}
+
+	floor := l2TipFloorGwei
+	if baseFee >= l1BaseFeeCutoffGwei {
+		floor = l1TipFloorGwei
+	}
+
+	tip := nodeTip
+	if marketTip > tip {
+		tip = marketTip
+	}
+	if floor > tip {
+		tip = floor
+	}
+	if maxFee > 0 && tip > maxFee {
+		tip = maxFee
+	}
+	return tip
+}

--- a/util/reader/gas_tip_test.go
+++ b/util/reader/gas_tip_test.go
@@ -1,0 +1,54 @@
+package reader
+
+import "testing"
+
+func TestEffectiveGasTipGwei(t *testing.T) {
+	const eps = 1e-9
+	cases := []struct {
+		name            string
+		node, max, base float64
+		want            float64
+	}{
+		{
+			name: "node oracle at 0, maxFee is only baseFee headroom",
+			// eth_gasPrice = 20, maxFee = 30, baseFee = 20 → market tip 0
+			// L1 floor 1 gwei so we don't broadcast tip 0
+			node: 0, max: 30, base: 20, want: 1,
+		},
+		{
+			name: "implied market tip from eth_gasPrice - baseFee",
+			// eth_gasPrice = 20, maxFee = 30, baseFee = 10 → market 10
+			node: 0, max: 30, base: 10, want: 10,
+		},
+		{
+			name: "node tip higher than implied market",
+			node: 12, max: 30, base: 10, want: 12,
+		},
+		{
+			name: "L2-like tiny base fee uses 0.01 floor not 1 gwei",
+			node: 0, max: 0.045, base: 0.03, want: 0.01,
+		},
+		{
+			name: "L2 implied tip above the floor",
+			// eth_gasPrice = 0.03, maxFee = 0.045, baseFee = 0.01 → 0.02
+			node: 0, max: 0.045, base: 0.01, want: 0.02,
+		},
+		{
+			name: "never exceed maxFee",
+			node: 50, max: 8, base: 20, want: 8,
+		},
+		{
+			name: "maxFee 0 still returns the floor when baseFee looks like L1",
+			node: 0, max: 0, base: 15, want: 1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := EffectiveGasTipGwei(c.node, c.max, c.base)
+			if diff := got - c.want; diff > eps || diff < -eps {
+				t.Fatalf("EffectiveGasTipGwei(%v, %v, %v) = %v, want %v",
+					c.node, c.max, c.base, got, c.want)
+			}
+		})
+	}
+}

--- a/util/reader/reader.go
+++ b/util/reader/reader.go
@@ -697,9 +697,29 @@ type getSuggestedGasResponse struct {
 	Error error
 }
 
-// add 20% tip to miners compared to what returned from the node to improve UX
-// a bit more
+// GetSuggestedGasTipCap returns the type-2 priority fee in gwei.
+//
+// eth_maxPriorityFeePerGas is often ~0 on Ethereum even when maxFee
+// (eth_gasPrice × 1.5) looks high. Miners are paid min(maxFee − baseFee,
+// tip), so a 0 tip sits or is dropped. We take the best node oracle, bump
+// it 20%, then raise it to the implied market tip and a small floor.
 func (er *EthReader) GetSuggestedGasTipCap() (float64, error) {
+	nodeTip, nodeErr := er.nodeSuggestedGasTipCap()
+	maxFee, _ := er.RecommendedGasPrice()
+	baseFee := 0.0
+	if header, err := er.HeaderByNumber(-1); err == nil && header != nil && header.BaseFee != nil {
+		baseFee = jarviscommon.BigToFloat(header.BaseFee, 9)
+	}
+	if nodeErr != nil && maxFee == 0 && baseFee == 0 {
+		return 0, nodeErr
+	}
+	if nodeErr != nil {
+		nodeTip = 0
+	}
+	return EffectiveGasTipGwei(nodeTip, maxFee, baseFee), nil
+}
+
+func (er *EthReader) nodeSuggestedGasTipCap() (float64, error) {
 	resCh := make(chan getSuggestedGasResponse, len(er.nodes))
 	for i := range er.nodes {
 		n := er.nodes[i]
@@ -712,15 +732,30 @@ func (er *EthReader) GetSuggestedGasTipCap() (float64, error) {
 		}()
 	}
 
+	var best *big.Int
 	errs := []error{}
 	for i := 0; i < len(er.nodes); i++ {
 		result := <-resCh
-		if result.Error == nil {
-			return jarviscommon.BigToFloat(result.Gas, 9) * 1.2, result.Error
+		if result.Error != nil || result.Gas == nil {
+			if result.Error != nil {
+				errs = append(errs, result.Error)
+			}
+			continue
 		}
-		errs = append(errs, result.Error)
+		if best == nil || result.Gas.Cmp(best) > 0 {
+			best = result.Gas
+		}
 	}
-	return 0, fmt.Errorf("couldn't read from any nodes: %w", errors.Join(errs...))
+	if best == nil {
+		return 0, fmt.Errorf("couldn't read from any nodes: %w", errors.Join(errs...))
+	}
+	// 20% bump in wei so a 1-wei oracle is not rounded to 0 through gwei float.
+	bumped := new(big.Int).Mul(best, big.NewInt(12))
+	bumped.Div(bumped, big.NewInt(10))
+	if bumped.Sign() == 0 && best.Sign() > 0 {
+		bumped = big.NewInt(1)
+	}
+	return jarviscommon.BigToFloat(bumped, 9), nil
 }
 
 // add 50% to max gas price because the next blocks based price can be increased
@@ -742,7 +777,7 @@ func (er *EthReader) RecommendedGasPrice() (float64, error) {
 	for i := 0; i < len(er.nodes); i++ {
 		result := <-resCh
 		if result.Error == nil {
-			return jarviscommon.BigToFloat(result.Gas, 9) * 1.5, result.Error
+			return jarviscommon.BigToFloat(result.Gas, 9) * gasPriceHeadroom, result.Error
 		}
 		errs = append(errs, result.Error)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
On Ethereum, `eth_maxPriorityFeePerGas` is often ~0 even when max fee (`eth_gasPrice × 1.5`) looks well above market. Miners are paid `min(maxFee − baseFee, tip)`, so those txs sit or get dropped. Operators had to pass `-s` with a large tip.

**What Jarvis did**
- Tip = first successful node’s `eth_maxPriorityFeePerGas × 1.2` (a 1-wei oracle rounded to 0 through gwei float).

**What it does now**
- Best node oracle (max across nodes, 20% bump in wei).
- Implied market tip: `eth_gasPrice − baseFee`.
- Floor: 1 gwei on L1-like chains (base fee ≥ 1 gwei), 0.01 gwei on cheap L2s.
- Clamp so tip never exceeds max fee.
- `-s` / `--tipgas` still overrides.

Also: Classic `bapprove` and `send --from <classic msig>` were passing tip 0 into wallet-army; they now use the same suggestion.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

