### PR TITLE
msig: name the wallet on Send headlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 - Native ETH sends to an EOA and ERC-20 `transfer` / `transferFrom` open as
   `Send  1.5 ETH  →  Alice` / `Send  1,000 USDC  →  Alice` rather than a
   generic Call header. Safe cards label that EOA destination `Recipient`.
+  On a Classic or Safe card the wallet is named on that line:
+  `Send  42,229 MON  from  Treasury  →  Alice`. The card also has a
+  Multisig / Safe row with the full address.
 - Safe cards list the Safe, operation, nonce, `safeTxHash` and collected
   signatures; the EOA card for a Safe execution collapses the inner call
   since it was just shown.

--- a/cmd/safe_display.go
+++ b/cmd/safe_display.go
@@ -56,14 +56,21 @@ func buildSafeSigningCard(
 ) *cmdutil.SigningCard {
 	var resolver cmdutil.ABIResolver
 	var analyzer util.TxAnalyzer
+	safeAddr := ""
 	if tc != nil {
 		resolver = tc.Resolver
 		analyzer = tc.Analyzer
+		if tc.Safe != nil && tc.Safe.Address != "" {
+			safeAddr = tc.Safe.Address
+		} else {
+			safeAddr = tc.To
+		}
 	}
 	return cmdutil.BuildSafeSigningCard(stx, hash, config.Network(), resolver, analyzer, cmdutil.SafeCardOptions{
 		Kind:      opt.kind,
 		Prompt:    opt.prompt,
 		Signer:    opt.signer,
+		SafeAddr:  safeAddr,
 		ExtraABIs: opt.extraABIs,
 		Sigs:      opt.sigs,
 		Threshold: opt.threshold,

--- a/cmd/util/safe_signing_card.go
+++ b/cmd/util/safe_signing_card.go
@@ -20,6 +20,7 @@ type SafeCardOptions struct {
 	Kind      string // "Safe proposal", "Safe approval", "Safe execution", "Safe transaction"
 	Prompt    string
 	Signer    string // EOA that will sign, if any
+	SafeAddr  string // the Safe wallet; shown on the card and as Send ... from
 	ExtraABIs map[string]*abi.ABI
 	Sigs      []safe.OwnerSig
 	Threshold uint64 // 0 = unknown; otherwise "n of m required"
@@ -60,6 +61,9 @@ func BuildSafeSigningCard(
 	}
 	if opt.Signer != "" {
 		card.Signer = util.StyledAddress(util.GetJarvisAddress(opt.Signer, network))
+	}
+	if opt.SafeAddr != "" {
+		card.Safe.Address = util.StyledAddress(util.GetJarvisAddress(opt.SafeAddr, network))
 	}
 	if stx.Value != nil && stx.Value.Sign() > 0 {
 		card.Value = jarviscommon.BigToFloatString(stx.Value, network.GetNativeTokenDecimal()) +

--- a/cmd/util/signing_card.go
+++ b/cmd/util/signing_card.go
@@ -61,9 +61,12 @@ type SigningCard struct {
 
 // SafeCardFields are the SafeTx parameters that have no EOA equivalent.
 type SafeCardFields struct {
-	Operation      string // "CALL" or "DELEGATECALL"
-	DelegateCall   bool
-	MultiSend      bool
+	Operation    string // "CALL" or "DELEGATECALL"
+	DelegateCall bool
+	MultiSend    bool
+	// Address is the Safe itself. Shown as the "Safe" row and used as the
+	// payer on Send headlines (ERC-20 transfer / native value).
+	Address        ui.StyledText
 	SafeNonce      string
 	SafeTxHash     string
 	SafeTxGas      string
@@ -108,6 +111,19 @@ func isMultisigOp(c *SigningCard) bool {
 	}
 }
 
+func signingCardPayer(c *SigningCard) ui.StyledText {
+	if c == nil {
+		return ui.StyledText{}
+	}
+	if c.Classic != nil && c.Classic.Multisig.Text != "" {
+		return c.Classic.Multisig
+	}
+	if c.Safe != nil && c.Safe.Address.Text != "" {
+		return c.Safe.Address
+	}
+	return ui.StyledText{}
+}
+
 // ShowSigningCard prints the card. Order is chosen so that what the reader
 // must verify sits directly above the prompt: the call first, then the
 // summary block, then the warnings.
@@ -135,6 +151,10 @@ func ShowSigningCard(u ui.UI, c *SigningCard) {
 func renderSigningCardBody(u ui.UI, c *SigningCard) {
 	if c.ClearSign != nil {
 		c.ClearSign(u)
+	}
+
+	if from := signingCardPayer(c); from.Text != "" {
+		util.AnnotatePaymentFrom(c.Call, from)
 	}
 
 	body := c.ClearSign != nil || c.Call != nil || c.RawData != ""
@@ -195,6 +215,9 @@ func renderSigningCardBody(u ui.UI, c *SigningCard) {
 		rows = append(rows, [2]ui.TableCell{label("Nonce"), ui.TC(c.Nonce)})
 	}
 	if s := c.Safe; s != nil {
+		if s.Address.Text != "" {
+			rows = append(rows, [2]ui.TableCell{label("Safe"), ui.TCS(s.Address.Text, s.Address.Severity)})
+		}
 		op := ui.TC(s.Operation)
 		if s.DelegateCall {
 			op = ui.TCS(s.Operation, ui.SeverityWarn)

--- a/cmd/util/signing_card_test.go
+++ b/cmd/util/signing_card_test.go
@@ -347,7 +347,7 @@ func TestShowSigningCardClassicFields(t *testing.T) {
 	}
 	for _, w := range []string{
 		"Classic multisig transaction",
-		"Send  1000  →  " + cardMe + " (me)",
+		"Send  1000  from  " + cardMe + " (Treasury)  →  " + cardMe + " (me)",
 		"Calls: " + cardUSDC + " (USDC)",
 		"Multisig: " + cardMe + " (Treasury)",
 		"Tx ID: #42",
@@ -422,11 +422,15 @@ func TestShowSigningCardNativeSendToEOA(t *testing.T) {
 		Value:   "1.5 ETH",
 		Call:    util.NewFunctionCallDisplay(fc, nil),
 		Safe: &SafeCardFields{
+			Address:   util.StyledAddress(cardAddr(cardRouter, "Treasury Safe")),
 			Operation: "CALL (0)", SafeNonce: "3", SafeTxHash: "0xabc",
 		},
 	})
-	if !rec.HasMessage("Send  1.5 ETH  →  " + cardMe + " (Alice)") {
+	if !rec.HasMessage("Send  1.5 ETH  from  " + cardRouter + " (Treasury Safe)  →  " + cardMe + " (Alice)") {
 		t.Fatalf("native send headline missing: %v", rec.Entries())
+	}
+	if !rec.HasMessage("Safe: " + cardRouter + " (Treasury Safe)") {
+		t.Fatalf("Safe address missing: %v", rec.Entries())
 	}
 	if !rec.HasMessage("Recipient: " + cardMe + " (Alice)") {
 		t.Fatalf("EOA send should label the destination Recipient: %v", rec.Entries())
@@ -457,10 +461,16 @@ func TestShowSigningCardERC20TransferHeadline(t *testing.T) {
 		Kind: "Safe approval",
 		To:   util.StyledAddress(cardAddr(cardUSDC, "USDC")),
 		Call: util.NewFunctionCallDisplay(fc, nil),
-		Safe: &SafeCardFields{Operation: "CALL (0)", SafeNonce: "4", SafeTxHash: "0xabc"},
+		Safe: &SafeCardFields{
+			Address:   util.StyledAddress(cardAddr(cardMe, "Treasury")),
+			Operation: "CALL (0)", SafeNonce: "4", SafeTxHash: "0xabc",
+		},
 	})
-	if !rec.HasMessage("Send  1,000 USDC  →  " + alice.Address + " (Alice)") {
+	if !rec.HasMessage("Send  1,000 USDC  from  " + cardMe + " (Treasury)  →  " + alice.Address + " (Alice)") {
 		t.Fatalf("erc20 send headline missing: %v", rec.Entries())
+	}
+	if !rec.HasMessage("Safe: " + cardMe + " (Treasury)") {
+		t.Fatalf("Safe address missing: %v", rec.Entries())
 	}
 	if !rec.HasMessage("Safe calls: " + cardUSDC + " (USDC)") {
 		t.Fatalf("token destination should stay on Safe calls: %v", rec.Entries())

--- a/util/display_tx.go
+++ b/util/display_tx.go
@@ -392,11 +392,10 @@ func (p txPrinter) paymentTitle(d *FunctionCallDisplay) string {
 	if d == nil || d.Payment == nil {
 		return ""
 	}
-	line := "Send  " + d.Payment.Amount + "  →  " + p.text(d.Payment.To)
 	if d.Payment.From.Text != "" {
-		line += "   from " + p.text(d.Payment.From)
+		return "Send  " + d.Payment.Amount + "  from  " + p.text(d.Payment.From) + "  →  " + p.text(d.Payment.To)
 	}
-	return line
+	return "Send  " + d.Payment.Amount + "  →  " + p.text(d.Payment.To)
 }
 
 func (p txPrinter) printCallBody(u ui.UI, d *FunctionCallDisplay) {

--- a/util/payment.go
+++ b/util/payment.go
@@ -15,7 +15,7 @@ import (
 type PaymentReading struct {
 	Amount string
 	To     ui.StyledText
-	From   ui.StyledText // transferFrom only
+	From   ui.StyledText // transferFrom, or the Safe/Classic wallet on a signing card
 }
 
 func nativePayment(to jarviscommon.Address, value *big.Int, network networks.Network) *PaymentReading {
@@ -110,6 +110,21 @@ func paymentTokenSymbol(v jarviscommon.Value, dest jarviscommon.Address) string 
 		return d
 	}
 	return ""
+}
+
+// AnnotatePaymentFrom fills Payment.From on a send that has no from yet
+// (native value or ERC-20 transfer). transferFrom already names the token
+// holder, so those are left alone. Inner MultiSend entries are walked too.
+func AnnotatePaymentFrom(d *FunctionCallDisplay, from ui.StyledText) {
+	if d == nil || from.Text == "" {
+		return
+	}
+	if d.Payment != nil && d.Payment.From.Text == "" {
+		d.Payment.From = from
+	}
+	for _, inner := range d.InnerCalls {
+		AnnotatePaymentFrom(inner, from)
+	}
 }
 
 func namedAddress(fc *jarviscommon.FunctionCall, names ...string) *jarviscommon.Address {

--- a/util/payment_test.go
+++ b/util/payment_test.go
@@ -66,6 +66,12 @@ func TestTokenPaymentTransferFrom(t *testing.T) {
 	if p == nil || p.Amount != "5 USDC" || p.From.Text == "" {
 		t.Fatalf("%+v", p)
 	}
+
+	rec := ui.NewRecordingUI()
+	PrintFunctionCall(rec, NewFunctionCallDisplay(fc, networks.EthereumMainnet))
+	if !rec.HasMessage("Send  5 USDC  from  " + from.Address + " (Router)  →  " + to.Address + " (Alice)") {
+		t.Fatalf("transferFrom headline: %v", rec.Entries())
+	}
 }
 
 func TestNativeInnerCallRendersAsSend(t *testing.T) {
@@ -85,5 +91,38 @@ func TestNativeInnerCallRendersAsSend(t *testing.T) {
 	}
 	if rec.HasMessage("<undecoded>") {
 		t.Fatalf("native send must not look undecoded: %v", rec.Entries())
+	}
+}
+
+func TestAnnotatePaymentFromFillsTransferNotTransferFrom(t *testing.T) {
+	msig := ui.StyledText{Text: "0x1111111111111111111111111111111111111111 (Treasury)"}
+	to := jarviscommon.Address{Address: "0x9642b23Ed1E01Df1092B92641051881a322F5D4E", Desc: "Alice"}
+	holder := jarviscommon.Address{Address: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D", Desc: "Router"}
+	transfer := NewFunctionCallDisplay(&jarviscommon.FunctionCall{
+		Destination: jarviscommon.Address{Address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", Desc: "USDC token"},
+		Method:      "transfer",
+		Params: []jarviscommon.ParamResult{
+			{Name: "_to", Type: "address", Values: []jarviscommon.Value{{Kind: jarviscommon.DisplayAddress, Address: &to}}},
+			{Name: "_value", Type: "uint256", Values: []jarviscommon.Value{{Raw: "1000000", Kind: jarviscommon.DisplayToken, Token: &jarviscommon.TokenHint{Decimal: 6, Symbol: "USDC"}}}},
+		},
+	}, networks.EthereumMainnet)
+	AnnotatePaymentFrom(transfer, msig)
+	if transfer.Payment == nil || transfer.Payment.From.Text != msig.Text {
+		t.Fatalf("transfer From = %+v", transfer.Payment)
+	}
+
+	fromCall := NewFunctionCallDisplay(&jarviscommon.FunctionCall{
+		Destination: jarviscommon.Address{Address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", Desc: "USDC", Decimal: 6},
+		Method:      "transferFrom",
+		Params: []jarviscommon.ParamResult{
+			{Name: "from", Type: "address", Values: []jarviscommon.Value{{Kind: jarviscommon.DisplayAddress, Address: &holder}}},
+			{Name: "to", Type: "address", Values: []jarviscommon.Value{{Kind: jarviscommon.DisplayAddress, Address: &to}}},
+			{Name: "amount", Type: "uint256", Values: []jarviscommon.Value{{Raw: "1000000"}}},
+		},
+	}, networks.EthereumMainnet)
+	wantFrom := fromCall.Payment.From.Text
+	AnnotatePaymentFrom(fromCall, msig)
+	if fromCall.Payment.From.Text != wantFrom {
+		t.Fatalf("transferFrom From overwritten: %q", fromCall.Payment.From.Text)
 	}
 }

--- a/walletconnect/gateways/safe.go
+++ b/walletconnect/gateways/safe.go
@@ -215,6 +215,7 @@ func (g *SafeGateway) promptSafeConfirm(stx *safe.SafeTx, hash [32]byte) error {
 			Kind:      "Safe proposal",
 			Prompt:    "Sign this Safe proposal and submit to the transaction service?",
 			Signer:    g.owner.Address,
+			SafeAddr:  g.addr.Hex(),
 			Threshold: threshold,
 		})
 		if !cmdutil.ConfirmSigningCard(fullUI, card) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Classic `msig bapprove` ERC-20 transfers opened as:

```
Send  42,229 MON  →  0xa458… (defillama to receive revshare)
```

The payer (the Classic wallet) was only a muted Multisig row below, easy to miss next to the Send line.

**Change**

- `Send  42,229 MON  from  Treasury  →  defillama…` when the card is a Classic or Safe op.
- Classic still has the Multisig row; Safe cards now also have a Safe row with the wallet address/name.
- ERC-20 `transferFrom` still uses the token-holder `from`, not the wallet.

Native ETH sends to an EOA use the same `from` slot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

