### PR TITLE
rpc: treat schemeless node URLs as HTTPS, not Unix sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
 
 ### Signing screen
 
+- RPC URLs without a scheme (`rpc.example.com/path`) are treated as HTTPS,
+  not as a Unix socket. go-ethereum's `rpc.Dial` used to try IPC for any
+  URL missing `://`, which printed a stdlib
+  `Couldn't connect to: … dial unix … no such file or directory` on
+  `msig approve` even when another node succeeded. Localhost stays HTTP;
+  `*.ipc` and absolute paths stay IPC. Failed extra nodes are skipped
+  quietly instead of logging through the stdlib logger.
 - One signing card for EOA transactions, Safe proposals/approvals/executions
   and WalletConnect requests: decoded call first, then Sign with / Send to /
   Gas / nonce directly above the prompt.

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	jarviscommon "github.com/tranvictor/jarvis/common"
 	"github.com/tranvictor/jarvis/networks"
 	"github.com/tranvictor/jarvis/ui"
 	"github.com/tranvictor/jarvis/util"
@@ -322,7 +323,7 @@ var nodeAddCmd = &cobra.Command{
 	Short: "Add a custom RPC node for a network",
 	Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
-		networkArg, name, nodeURL := args[0], args[1], args[2]
+		networkArg, name, nodeURL := args[0], args[1], jarviscommon.CanonicalRPCURL(args[2])
 		networkName := canonicalNodeNetworkName(networkArg)
 		if _, err := networks.GetNetwork(networkArg); err != nil {
 			appUI.Warn("Network %q is not in the built-in list, but adding the node anyway.", networkArg)
@@ -562,6 +563,7 @@ var nodeImportCmd = &cobra.Command{
 			}
 			added := 0
 			for name, nodeURL := range e.Nodes {
+				nodeURL = jarviscommon.CanonicalRPCURL(nodeURL)
 				if _, exists := cfg.Nodes[name]; !exists {
 					cfg.Nodes[name] = nodeURL
 					added++

--- a/common/rpc_url.go
+++ b/common/rpc_url.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"net"
+	"path/filepath"
+	"strings"
+)
+
+// CanonicalRPCURL makes a node URL safe for go-ethereum's rpc.Dial.
+// Dial treats any string without a URI scheme as a Unix IPC path, so a
+// stored host like rpc.example.com/path is tried as a socket and fails with
+// "dial unix … no such file or directory". Public hosts get https://;
+// loopback hosts get http://; real IPC paths are left alone.
+func CanonicalRPCURL(raw string) string {
+	u := strings.TrimSpace(raw)
+	if u == "" || strings.Contains(u, "://") || isRPCIPCPath(u) {
+		return u
+	}
+	if isRPCLoopbackHost(rpcURLHost(u)) {
+		return "http://" + u
+	}
+	return "https://" + u
+}
+
+func isRPCIPCPath(u string) bool {
+	if strings.HasSuffix(strings.ToLower(u), ".ipc") {
+		return true
+	}
+	if filepath.IsAbs(u) || strings.HasPrefix(u, "./") || strings.HasPrefix(u, "../") {
+		return true
+	}
+	if len(u) >= 3 && u[1] == ':' && (u[2] == '\\' || u[2] == '/') {
+		return true
+	}
+	return strings.HasPrefix(u, `\\.\pipe\`) || strings.HasPrefix(u, `//./pipe/`)
+}
+
+func rpcURLHost(u string) string {
+	host := u
+	if i := strings.Index(u, "/"); i >= 0 {
+		host = u[:i]
+	}
+	if strings.HasPrefix(host, "[") {
+		if j := strings.Index(host, "]"); j >= 0 {
+			return host[1:j]
+		}
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
+func isRPCLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/common/rpc_url_test.go
+++ b/common/rpc_url_test.go
@@ -1,0 +1,32 @@
+package common
+
+import "testing"
+
+func TestCanonicalRPCURL(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"  rpc-mainnet.monadinfra.com/rpc/KEY  ", "https://rpc-mainnet.monadinfra.com/rpc/KEY"},
+		{"rpc.example.com", "https://rpc.example.com"},
+		{"rpc.example.com:443/path", "https://rpc.example.com:443/path"},
+		{"https://rpc.example.com/path", "https://rpc.example.com/path"},
+		{"http://rpc.example.com", "http://rpc.example.com"},
+		{"wss://rpc.example.com/ws", "wss://rpc.example.com/ws"},
+		{"localhost:8545", "http://localhost:8545"},
+		{"LOCALHOST/rpc", "http://LOCALHOST/rpc"},
+		{"127.0.0.1:8545", "http://127.0.0.1:8545"},
+		{"[::1]:8545", "http://[::1]:8545"},
+		{"/var/run/geth.ipc", "/var/run/geth.ipc"},
+		{"./geth.ipc", "./geth.ipc"},
+		{"geth.ipc", "geth.ipc"},
+		{`\\.\pipe\geth.ipc`, `\\.\pipe\geth.ipc`},
+		{`C:\geth\geth.ipc`, `C:\geth\geth.ipc`},
+	}
+	for _, c := range cases {
+		got := CanonicalRPCURL(c.in)
+		if got != c.want {
+			t.Errorf("CanonicalRPCURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/util/broadcaster/broadcaster.go
+++ b/util/broadcaster/broadcaster.go
@@ -3,7 +3,6 @@ package broadcaster
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -134,13 +133,13 @@ func NewGenericBroadcaster(nodes map[string]string) *Broadcaster {
 	clients := map[string]*rpc.Client{}
 	urls := make(map[string]string, len(nodes))
 	for name, c := range nodes {
+		c = common.CanonicalRPCURL(c)
 		urls[name] = c
 		client, err := rpc.Dial(c)
 		if err != nil {
-			log.Printf("Couldn't connect to: %s - %v", c, err)
-		} else {
-			clients[name] = client
+			continue
 		}
+		clients[name] = client
 	}
 	return &Broadcaster{
 		clients: clients,

--- a/util/nodes.go
+++ b/util/nodes.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	jarviscommon "github.com/tranvictor/jarvis/common"
 	jarvisnetworks "github.com/tranvictor/jarvis/networks"
 	"github.com/tranvictor/jarvis/util/reader"
 )
@@ -81,11 +82,11 @@ func SaveNodeConfig(networkName string, cfg NodeConfig) error {
 }
 
 func normalizeRPCURL(u string) string {
-	return strings.TrimRight(strings.TrimSpace(u), "/")
+	return strings.TrimRight(jarviscommon.CanonicalRPCURL(strings.TrimSpace(u)), "/")
 }
 
 // FindNodeNameByURL returns the configured name whose RPC URL matches url
-// (trailing slashes and surrounding space ignored).
+// (trailing slashes, surrounding space and a missing http(s) scheme ignored).
 func FindNodeNameByURL(nodes map[string]string, url string) (string, bool) {
 	want := normalizeRPCURL(url)
 	if want == "" {
@@ -140,19 +141,19 @@ func GetNodes(network jarvisnetworks.Network) (map[string]string, error) {
 
 	nodes := make(map[string]string, len(cfg.Nodes))
 	for k, v := range cfg.Nodes {
-		nodes[k] = v
+		nodes[k] = jarviscommon.CanonicalRPCURL(v)
 	}
 	if cfg.UseDefaults {
 		for k, v := range network.GetDefaultNodes() {
 			if _, exists := nodes[k]; !exists {
-				nodes[k] = v
+				nodes[k] = jarviscommon.CanonicalRPCURL(v)
 			}
 		}
 	}
 
 	// Env-var override is always applied on top.
 	if envNode := strings.TrimSpace(os.Getenv(network.GetNodeVariableName())); envNode != "" {
-		nodes["custom-node"] = envNode
+		nodes["custom-node"] = jarviscommon.CanonicalRPCURL(envNode)
 	}
 
 	return nodes, nil

--- a/util/nodes_test.go
+++ b/util/nodes_test.go
@@ -6,6 +6,7 @@ func TestFindNodeNameByURL(t *testing.T) {
 	nodes := map[string]string{
 		"mainnet-kyber": "https://ethereum-rpc.kyberswap.com/",
 		"own":           "https://my.example/rpc",
+		"infra":         "rpc-mainnet.monadinfra.com/rpc/KEY",
 	}
 	name, ok := FindNodeNameByURL(nodes, "https://ethereum-rpc.kyberswap.com")
 	if !ok || name != "mainnet-kyber" {
@@ -13,5 +14,13 @@ func TestFindNodeNameByURL(t *testing.T) {
 	}
 	if _, ok := FindNodeNameByURL(nodes, "https://other.example"); ok {
 		t.Fatal("expected no match")
+	}
+	name, ok = FindNodeNameByURL(nodes, "https://rpc-mainnet.monadinfra.com/rpc/KEY")
+	if !ok || name != "infra" {
+		t.Fatalf("schemeless stored URL: got (%q, %v), want infra", name, ok)
+	}
+	name, ok = FindNodeNameByURL(map[string]string{"infra": "https://rpc-mainnet.monadinfra.com/rpc/KEY"}, "rpc-mainnet.monadinfra.com/rpc/KEY")
+	if !ok || name != "infra" {
+		t.Fatalf("schemeless lookup: got (%q, %v), want infra", name, ok)
 	}
 }

--- a/util/reader/one_node_reader.go
+++ b/util/reader/one_node_reader.go
@@ -32,7 +32,7 @@ type OneNodeReader struct {
 func NewOneNodeReader(name, url string) *OneNodeReader {
 	return &OneNodeReader{
 		nodeName:   name,
-		nodeURL:    url,
+		nodeURL:    jarviscommon.CanonicalRPCURL(url),
 		client:     nil,
 		ethClient:  nil,
 		gethClient: nil,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`jarvis msig approve` printed a stdlib line even when the approve itself succeeded:

```
Couldn't connect to: rpc-mainnet.monadinfra.com/rpc/KEY - dial unix …: no such file or directory
```

go-ethereum `rpc.Dial` treats any URL **without a scheme** as a Unix IPC socket. Classic approve builds the broadcaster while constructing the signing card (`FillSigningTxParams` → `EthBroadcaster`), so every configured node is dialled up front. A scheme-less extra node logged through `log.Printf` and looked like a real failure.

## Fix

- `CanonicalRPCURL` prefixes public hosts with `https://`, loopback with `http://`, and leaves real IPC paths (`*.ipc`, absolute paths) alone.
- Applied in `GetNodes`, at dial sites (broadcaster + reader), and when adding/importing nodes so new configs store a scheme.
- Failed extra nodes are skipped quietly instead of using the stdlib logger.
- `FindNodeNameByURL` treats `host` and `https://host` as the same node.

Existing `~/.jarvis/nodes/*.json` is not rewritten; URLs are canonicalized at read/dial time.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

