### PR TITLE
msig: allow any wallet to execute a fully signed Safe tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,10 @@ byte-for-byte compatible apart from the new `transfers`, `net_effect`,
   `jarvis network list` is a table of names, chain IDs and RPC **hosts**
   (never the full URL, so default Infura keys stay off the screen);
   `jarvis msig chains list` uses the same table primitive.
+- Safe `msig execute` can be sent by any local wallet. Safe
+  `execTransaction` does not require the sender to be an owner once the
+  signature threshold is met; `init` and `approve` still do. Classic
+  execute is unchanged (owner-only).
 - Classic `msig info` / `approve` show the inner call in a rounded box
   (Multisig / Tx ID / Status / Signed by); the following EOA
   confirm/revoke/execute card is a quiet heading that collapses the inner

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ of multisig you're talking to.
 |------------|:-------:|:----:|-------|
 | `jarvis msig init`     | yes | yes | Propose a new multisig tx. Safe also accepts a Transaction Builder batch via `--tx-builder-file` / `--tx-builder-json`. |
 | `jarvis msig approve`  | yes | yes | Add your approval. Auto-executes when threshold is met. |
-| `jarvis msig execute`  | yes | yes | Broadcast the on-chain execution. |
+| `jarvis msig execute`  | yes | yes | Broadcast the on-chain execution. Safe: any wallet can pay gas once the threshold is met. |
 | `jarvis msig info`     | yes | yes | Show a specific pending tx with decoded calldata. |
 | `jarvis msig summary`  | yes | yes | List pending txs (Classic: on-chain queue with id / to / sigs / status; Safe: Transaction Service queue). |
 | `jarvis msig gov`      | yes | yes | Show owners / threshold / version / nonce. |
@@ -512,7 +512,7 @@ jarvis msig init 0xSAFE --msig-to 0xTOKEN --msig-value 100 \
 # Other owners load the file, append their signature, write it back
 jarvis msig approve 0xSAFE --from 0xBOB --safe-tx-file ./proposal.json
 
-# Any owner executes from the file once threshold is met
+# Anyone can execute from the file once threshold is met
 jarvis msig execute 0xSAFE --from 0xCAROL --safe-tx-file ./proposal.json
 
 # You can also just inspect a local proposal file

--- a/cmd/msig.go
+++ b/cmd/msig.go
@@ -335,11 +335,12 @@ var executeMsigCmd = &cobra.Command{
 	Short: "Execute a confirmed multisig transaction (Classic execTransaction or Safe execTransaction)",
 	Long: `Broadcast the on-chain execution of a multisig transaction whose
 confirmations meet the threshold. Classic targets call
-executeTransaction(txid); Safe targets call execTransaction(...) with
-the off-chain-collected signatures assembled from the Safe Transaction
-Service.`,
+executeTransaction(txid) from an owner. Safe targets call
+execTransaction(...) with the off-chain-collected signatures assembled
+from the Safe Transaction Service; the executor does not need to be an
+owner.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		return cmdutil.CommonMultisigTxPreprocess(appUI, cmd, args)
+		return cmdutil.CommonMultisigExecutePreprocess(appUI, cmd, args)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		tc, _ := cmdutil.TxContextFrom(cmd)

--- a/cmd/safe.go
+++ b/cmd/safe.go
@@ -62,9 +62,9 @@ var initSafeCmd = &cobra.Command{
 constructed from the target's ABI, sign the EIP-712 safeTxHash with --from
 (or the only owner you have a wallet for), and submit the proposal to the
 Safe Transaction Service. Other owners can later approve via 'jarvis msig
-approve' and any owner can finalise via 'jarvis msig execute'.`,
+approve' and anyone can finalise via 'jarvis msig execute'.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-		if err = cmdutil.CommonSafeTxPreprocess(appUI, cmd, args); err != nil {
+		if err = cmdutil.CommonSafeTxPreprocess(appUI, cmd, args, true); err != nil {
 			return err
 		}
 		if config.MsigValue < 0 {
@@ -271,7 +271,7 @@ over an off-chain signature store. Other owners' off-chain signatures
 		if len(args) < 1 {
 			return fmt.Errorf("usage: jarvis msig approve <safe-or-url> [safeTxHash|nonce]")
 		}
-		return cmdutil.CommonSafeTxPreprocess(appUI, cmd, args)
+		return cmdutil.CommonSafeTxPreprocess(appUI, cmd, args, true)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		tc, _ := cmdutil.TxContextFrom(cmd)
@@ -598,7 +598,9 @@ var executeSafeCmd = &cobra.Command{
 	Short: "Execute a Safe transaction whose signatures meet the threshold",
 	Long: `Fetch a pending Safe transaction, assemble its signatures into the
 format Safe.execTransaction expects, and broadcast the on-chain execution
-from --from (or the single matching owner you have a wallet for).
+from --from (or the only local wallet you have). The executor does not
+need to be a Safe owner: once the signature threshold is met, anyone
+who can pay gas can execute.
 
 The pending tx can be identified by:
 
@@ -612,7 +614,7 @@ The pending tx can be identified by:
 		if len(args) < 1 {
 			return fmt.Errorf("usage: jarvis msig execute <safe-or-url> [safeTxHash|nonce]")
 		}
-		return cmdutil.CommonSafeTxPreprocess(appUI, cmd, args)
+		return cmdutil.CommonSafeTxPreprocess(appUI, cmd, args, false)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		tc, _ := cmdutil.TxContextFrom(cmd)

--- a/cmd/util/owner_pick.go
+++ b/cmd/util/owner_pick.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/tranvictor/jarvis/accounts"
@@ -28,14 +29,20 @@ var (
 	// ErrMultipleLocalOwners means more than one local wallet is an owner
 	// and the policy is OwnerRequireUnique.
 	ErrMultipleLocalOwners = errors.New("multiple local owner wallets")
+	// ErrNoLocalWallet means ~/.jarvis has no wallets at all.
+	ErrNoLocalWallet = errors.New("no local wallet")
+	// ErrMultipleLocalWallets means more than one local wallet exists and
+	// --from was not passed.
+	ErrMultipleLocalWallets = errors.New("multiple local wallets")
 )
 
 type accountLookup func(string) (jtypes.AccDesc, error)
 
 // PickLocalOwner finds local wallets among owners and applies policy.
 // fromFlag is unused for the scan itself: when the user passed --from,
-// callers resolve that account separately (and, on Safe paths, verify
-// it with IsAmongOwners). It is accepted so call sites can pass
+// callers resolve that account separately (and, on Safe init/approve,
+// verify it with IsAmongOwners). Safe execute does not require the
+// executor to be an owner. It is accepted so call sites can pass
 // config.From through without a second helper.
 func PickLocalOwner(owners []string, fromFlag string, policy OwnerPickPolicy) (jtypes.AccDesc, int, error) {
 	return pickLocalOwner(owners, fromFlag, policy, accounts.GetAccount)
@@ -76,4 +83,77 @@ func IsAmongOwners(owners []string, addr string) bool {
 		}
 	}
 	return false
+}
+
+// chooseSafeFrom picks the wallet that will pay for a Safe transaction.
+//
+// requireOwner is true for init/approve. It is false for execute:
+// Safe.execTransaction can be sent by anyone once the signature
+// threshold is met; the executor only pays gas.
+func chooseSafeFrom(
+	fromFlag, safeAddr string,
+	owners []string,
+	requireOwner bool,
+	resolveFrom func(string) (jtypes.AccDesc, error),
+	lookup accountLookup,
+	wallets map[string]jtypes.AccDesc,
+) (jtypes.AccDesc, error) {
+	if fromFlag != "" {
+		fromAcc, err := resolveFrom(fromFlag)
+		if err != nil {
+			return jtypes.AccDesc{}, err
+		}
+		if requireOwner && !IsAmongOwners(owners, fromAcc.Address) {
+			return jtypes.AccDesc{}, fmt.Errorf("%s is not an owner of Safe %s", fromAcc.Address, safeAddr)
+		}
+		return fromAcc, nil
+	}
+
+	fromAcc, _, err := pickLocalOwner(owners, fromFlag, OwnerRequireUnique, lookup)
+	if err == nil {
+		return fromAcc, nil
+	}
+	if errors.Is(err, ErrMultipleLocalOwners) {
+		return jtypes.AccDesc{}, fmt.Errorf(
+			"you have multiple wallets that are owners of this Safe; please specify exactly one with --from",
+		)
+	}
+	if requireOwner {
+		if errors.Is(err, ErrNoLocalOwner) {
+			return jtypes.AccDesc{}, fmt.Errorf(
+				"you don't have any wallet which is an owner of this Safe; please run `jarvis wallet add` first",
+			)
+		}
+		return jtypes.AccDesc{}, err
+	}
+	if !errors.Is(err, ErrNoLocalOwner) {
+		return jtypes.AccDesc{}, err
+	}
+
+	fromAcc, err = pickUniqueLocalWallet(wallets)
+	if errors.Is(err, ErrNoLocalWallet) {
+		return jtypes.AccDesc{}, fmt.Errorf(
+			"no local wallet to pay for execution; please run `jarvis wallet add` or pass --from",
+		)
+	}
+	if errors.Is(err, ErrMultipleLocalWallets) {
+		return jtypes.AccDesc{}, fmt.Errorf(
+			"multiple local wallets; please specify the executor with --from",
+		)
+	}
+	return fromAcc, err
+}
+
+func pickUniqueLocalWallet(all map[string]jtypes.AccDesc) (jtypes.AccDesc, error) {
+	switch len(all) {
+	case 0:
+		return jtypes.AccDesc{}, ErrNoLocalWallet
+	case 1:
+		for _, acc := range all {
+			return acc, nil
+		}
+	default:
+		return jtypes.AccDesc{}, ErrMultipleLocalWallets
+	}
+	return jtypes.AccDesc{}, ErrNoLocalWallet
 }

--- a/cmd/util/owner_pick_test.go
+++ b/cmd/util/owner_pick_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	jtypes "github.com/tranvictor/jarvis/accounts/types"
@@ -76,6 +77,88 @@ func TestPickLocalOwnerSkipsFailedLookups(t *testing.T) {
 	got, n, err := pickLocalOwner([]string{"0xaaa", "0xbbb", "0xccc"}, "", OwnerRequireUnique, lookup)
 	if err != nil || n != 1 || got.Address != "0xBBB" {
 		t.Fatalf("acc=%+v n=%d err=%v", got, n, err)
+	}
+}
+
+func TestChooseSafeFromExecuteAllowsNonOwner(t *testing.T) {
+	alice := jtypes.AccDesc{Address: "0xAAA"}
+	carol := jtypes.AccDesc{Address: "0xCCC"}
+	lookup := testLookup(map[string]jtypes.AccDesc{
+		"0xaaa": alice,
+		"0xccc": carol,
+	})
+	resolve := func(keyword string) (jtypes.AccDesc, error) {
+		return lookup(keyword)
+	}
+	owners := []string{"0xaaa"}
+
+	got, err := chooseSafeFrom("0xccc", "0xsafe", owners, false, resolve, lookup, nil)
+	if err != nil || got.Address != "0xCCC" {
+		t.Fatalf("execute --from non-owner: acc=%+v err=%v", got, err)
+	}
+
+	_, err = chooseSafeFrom("0xccc", "0xsafe", owners, true, resolve, lookup, nil)
+	if err == nil || !strings.Contains(err.Error(), "is not an owner of Safe 0xsafe") {
+		t.Fatalf("approve --from non-owner: err=%v", err)
+	}
+}
+
+func TestChooseSafeFromExecuteFallsBackToUniqueWallet(t *testing.T) {
+	carol := jtypes.AccDesc{Address: "0xCCC"}
+	lookup := testLookup(nil)
+	resolve := func(string) (jtypes.AccDesc, error) {
+		t.Fatal("should not resolve --from")
+		return jtypes.AccDesc{}, nil
+	}
+
+	got, err := chooseSafeFrom("", "0xsafe", []string{"0xaaa"}, false, resolve, lookup, map[string]jtypes.AccDesc{
+		"0xccc": carol,
+	})
+	if err != nil || got.Address != "0xCCC" {
+		t.Fatalf("execute with one non-owner wallet: acc=%+v err=%v", got, err)
+	}
+
+	_, err = chooseSafeFrom("", "0xsafe", []string{"0xaaa"}, false, resolve, lookup, map[string]jtypes.AccDesc{
+		"0xccc": carol,
+		"0xddd": {Address: "0xDDD"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "multiple local wallets") {
+		t.Fatalf("execute with many wallets: err=%v", err)
+	}
+
+	_, err = chooseSafeFrom("", "0xsafe", []string{"0xaaa"}, false, resolve, lookup, nil)
+	if err == nil || !strings.Contains(err.Error(), "no local wallet to pay for execution") {
+		t.Fatalf("execute with no wallets: err=%v", err)
+	}
+}
+
+func TestChooseSafeFromPrefersUniqueOwner(t *testing.T) {
+	alice := jtypes.AccDesc{Address: "0xAAA"}
+	lookup := testLookup(map[string]jtypes.AccDesc{"0xaaa": alice})
+	got, err := chooseSafeFrom("", "0xsafe", []string{"0xaaa"}, false, nil, lookup, map[string]jtypes.AccDesc{
+		"0xaaa": alice,
+		"0xccc": {Address: "0xCCC"},
+	})
+	if err != nil || got.Address != "0xAAA" {
+		t.Fatalf("unique owner should win even when other wallets exist: acc=%+v err=%v", got, err)
+	}
+}
+
+func TestPickUniqueLocalWallet(t *testing.T) {
+	_, err := pickUniqueLocalWallet(nil)
+	if !errors.Is(err, ErrNoLocalWallet) {
+		t.Fatalf("empty: %v", err)
+	}
+	got, err := pickUniqueLocalWallet(map[string]jtypes.AccDesc{"0xccc": {Address: "0xCCC"}})
+	if err != nil || got.Address != "0xCCC" {
+		t.Fatalf("one: acc=%+v err=%v", got, err)
+	}
+	_, err = pickUniqueLocalWallet(map[string]jtypes.AccDesc{
+		"0xccc": {Address: "0xCCC"},
+		"0xddd": {Address: "0xDDD"},
+	})
+	if !errors.Is(err, ErrMultipleLocalWallets) {
+		t.Fatalf("many: %v", err)
 	}
 }
 

--- a/cmd/util/pre_process.go
+++ b/cmd/util/pre_process.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/spf13/cobra"
 
+	"github.com/tranvictor/jarvis/accounts"
 	jtypes "github.com/tranvictor/jarvis/accounts/types"
 	jarviscommon "github.com/tranvictor/jarvis/common"
 	"github.com/tranvictor/jarvis/config"
@@ -298,13 +299,15 @@ func CommonSafeReadPreprocess(u ui.UI, cmd *cobra.Command, args []string) error 
 //  1. Resolves the network and Safe address via the standard preprocess.
 //  2. Builds a SafeContract reader and verifies that the on-chain ABI
 //     matches the Safe shape (so we don't operate on random addresses).
-//  3. Picks the signing wallet — when --from is empty, looks for a single
-//     local wallet that is also an owner of the Safe.
+//  3. Picks the signing wallet. For init/approve, when --from is empty,
+//     looks for a single local wallet that is also an owner of the Safe.
+//     For execute (requireOwner false), any local wallet can pay gas:
+//     Safe.execTransaction does not require the sender to be an owner.
 //  4. Resolves gas / nonce / tx type for any future on-chain transactions
 //     (e.g. execTransaction) so callers can reuse SignAndBroadcast.
 //  5. Wires a SignatureCollector backed by the Safe Transaction Service
 //     for off-chain signature exchange.
-func CommonSafeTxPreprocess(u ui.UI, cmd *cobra.Command, args []string) error {
+func CommonSafeTxPreprocess(u ui.UI, cmd *cobra.Command, args []string, requireOwner bool) error {
 	// Step 0: try to recognise a Safe-app URL / EIP-3770 reference in
 	// args[0] BEFORE the inner preprocess looks at it.
 	var ref *safe.SafeAppRef
@@ -358,33 +361,20 @@ func CommonSafeTxPreprocess(u ui.UI, cmd *cobra.Command, args []string) error {
 	}
 	tc.Safe = safeContract
 
-	var fromAcc jtypes.AccDesc
-	if config.From == "" {
-		fromAcc, _, err = PickLocalOwner(owners, config.From, OwnerRequireUnique)
-		if errors.Is(err, ErrNoLocalOwner) {
-			return fmt.Errorf(
-				"you don't have any wallet which is an owner of this Safe; please run `jarvis wallet add` first",
-			)
-		}
-		if errors.Is(err, ErrMultipleLocalOwners) {
-			return fmt.Errorf(
-				"you have multiple wallets that are owners of this Safe; please specify exactly one with --from",
-			)
-		}
-		if err != nil {
-			return err
-		}
-	} else {
-		fromAcc, _, err = ResolveAccount(tc.Resolver, config.From)
-		if err != nil {
-			return err
-		}
-		if !IsAmongOwners(owners, fromAcc.Address) {
-			return fmt.Errorf(
-				"%s is not an owner of Safe %s",
-				fromAcc.Address, tc.To,
-			)
-		}
+	fromAcc, err := chooseSafeFrom(
+		config.From,
+		tc.To,
+		owners,
+		requireOwner,
+		func(keyword string) (jtypes.AccDesc, error) {
+			acc, _, err := ResolveAccount(tc.Resolver, keyword)
+			return acc, err
+		},
+		accounts.GetAccount,
+		accounts.GetAccounts(),
+	)
+	if err != nil {
+		return err
 	}
 	tc.FromAcc = fromAcc
 	tc.From = fromAcc.Address
@@ -582,6 +572,18 @@ func CommonMultisigReadPreprocess(u ui.UI, cmd *cobra.Command, args []string) er
 // Note: revoke is classic-only; the Run dispatcher is expected to refuse
 // the operation when MultisigType == MultisigSafe with an actionable error.
 func CommonMultisigTxPreprocess(u ui.UI, cmd *cobra.Command, args []string) error {
+	return commonMultisigTxPreprocess(u, cmd, args, true)
+}
+
+// CommonMultisigExecutePreprocess is CommonMultisigTxPreprocess for
+// `jarvis msig execute`. Safe execTransaction can be sent by any local
+// wallet once the threshold is met, so the executor is not required to
+// be an owner. Classic execute still requires an owner.
+func CommonMultisigExecutePreprocess(u ui.UI, cmd *cobra.Command, args []string) error {
+	return commonMultisigTxPreprocess(u, cmd, args, false)
+}
+
+func commonMultisigTxPreprocess(u ui.UI, cmd *cobra.Command, args []string, requireOwner bool) error {
 	ref, err := preResolveMultisigArg(u, cmd, args)
 	if err != nil {
 		return err
@@ -603,7 +605,7 @@ func CommonMultisigTxPreprocess(u ui.UI, cmd *cobra.Command, args []string) erro
 
 	switch typ {
 	case MultisigSafe:
-		if err := CommonSafeTxPreprocess(u, cmd, args); err != nil {
+		if err := CommonSafeTxPreprocess(u, cmd, args, requireOwner); err != nil {
 			return err
 		}
 	case MultisigClassic:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`jarvis msig execute` on a Safe required `--from` to be an owner (or auto-picked a unique local owner). That is wrong: Safe `execTransaction` can be sent by **anyone** once the signature threshold is met. The executor only pays gas.

`msig approve --help` already described `--no-execute` as the way to let a different EOA pay for execution, but execute itself still rejected that EOA.

## Fix

- `init` / `approve` still require an owner.
- `execute` accepts any local wallet:
  - `--from` is used as-is, even if it is not an owner
  - empty `--from` still prefers a unique local owner, then falls back to a unique local wallet, otherwise asks for `--from`
- Classic `execute` is unchanged (on-chain `executeTransaction` is owner-only).

## Tests

`chooseSafeFrom` covers non-owner `--from` on execute (allowed) vs approve (rejected), unique-wallet fallback, and unique-owner preference when other wallets exist.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a076db-61e2-7d46-b1f7-4f006b373023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a076db-61e2-7d46-b1f7-4f006b373023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

