### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "jarvis",
+  "install": "go build ./... && make jarvis"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent environment (`.cursor/environment.json`) so future agents get a working `jarvis` development environment out of the box.

`jarvis` is a Go CLI (Go 1.25.7). Cursor's default base image already ships Go, so no custom Dockerfile is needed. The project has no long-running services, so only an `install` step is required (no `start`/`terminals`).

```json
{
  "name": "jarvis",
  "install": "go build ./... && make jarvis"
}
```

- `go build ./...` compiles every package (validation).
- `make jarvis` produces the `jarvis` binary via the repository's canonical build target.

## Validation

| Check | Result |
| --- | --- |
| `go build ./...` + `make jarvis` (local) | Passed |
| Install idempotence | Passed twice (~1.5s cached on rerun) |
| Clean-pod draft environment build (fresh checkout, default image) | SUCCEEDED — install exit code 0 |
| `./jarvis version` | `jarvis v0.3.0-2-g1d184e7` |
| `./jarvis network list` | Lists all supported chains |
| `contract read` WETH `totalSupply` on mainnet | Live value returned (RPC + explorer ABI lookup work) |
| `go test ./...` | All packages pass except `util/account/usb` |

The `util/account/usb` package fails only because `libusb` cannot initialize without USB hardware in a headless container (Ledger/Trezor device enumeration) — an environment limitation, not a code issue.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc7f050f-7150-4cee-b141-bec186d38288?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc7f050f-7150-4cee-b141-bec186d38288&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

